### PR TITLE
fix: Add more custom search paths for the ffmpeg binaries

### DIFF
--- a/include/export/video_export.h
+++ b/include/export/video_export.h
@@ -107,6 +107,8 @@ private:
     bool encodeFramesToVideo(const QString &outputPath);
     
     // Helper methods
+    static QString ffmpegCommandName();
+    static QStringList listFfmpegPossiblePaths();
     QString findFFmpegPath();
     QString generateFFmpegCommand(const QString &inputPattern, 
                                  const QString &outputFile);

--- a/src/export/video_export.cpp
+++ b/src/export/video_export.cpp
@@ -106,8 +106,8 @@ QStringList VideoExporter::listFfmpegPossiblePaths()
 {
 #ifdef Q_OS_WIN
     return {
-        "C:/Program Files/ffmpeg/bin/ffmpeg.exe",
-        "C:/Program Files (x86)/ffmpeg/bin/ffmpeg.exe"
+        "C:/Program Files/ffmpeg/bin/",
+        "C:/Program Files (x86)/ffmpeg/bin/"
     };
 #endif
 #ifdef Q_OS_APPLE


### PR DESCRIPTION
Add search paths used by homebrew and manual builds on linux/mac.

I have added new helper functions to keep the main logic compact. The new helpers are made static but purely a matter of taste, I'm not  a fan of having member methods that don't really require an instance or touch the state, definitely open to changing this if you prefer.