### PR TITLE
feat: add metric/imperial unit system support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PROJECT_SOURCES
     src/core/dive_data.cpp
     src/core/log_parser.cpp
     src/core/config.cpp
+    src/core/units.cpp
     src/ui/main_window.cpp
     src/ui/timeline.cpp
     src/generators/overlay_gen.cpp
@@ -50,6 +51,7 @@ set(PROJECT_HEADERS
     include/core/dive_data.h
     include/core/log_parser.h
     include/core/config.h
+    include/core/units.h
     include/ui/main_window.h
     include/ui/timeline.h
     include/generators/overlay_gen.h

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -6,6 +6,7 @@
 #include <QString>
 #include <QFont>
 #include <QColor>
+#include "include/core/units.h"
 
 class Config : public QObject
 {
@@ -24,6 +25,7 @@ class Config : public QObject
     Q_PROPERTY(bool showNDL READ showNDL WRITE setShowNDL NOTIFY showNDLChanged)
     Q_PROPERTY(bool showPressure READ showPressure WRITE setShowPressure NOTIFY showPressureChanged)
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
+    Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
     // Export settings
     Q_PROPERTY(double frameRate READ frameRate WRITE setFrameRate NOTIFY frameRateChanged)
@@ -63,6 +65,9 @@ public:
     bool showTime() const;
     void setShowTime(bool show);
     
+    Units::UnitSystem unitSystem() const;
+    void setUnitSystem(Units::UnitSystem system);
+    
     // Export settings
     double frameRate() const;
     void setFrameRate(double fps);
@@ -81,6 +86,7 @@ signals:
     void showNDLChanged();
     void showPressureChanged();
     void showTimeChanged();
+    void unitSystemChanged();
     void frameRateChanged();
     
 private:
@@ -104,6 +110,7 @@ private:
     bool m_showNDL;
     bool m_showPressure;
     bool m_showTime;
+    Units::UnitSystem m_unitSystem;
     double m_frameRate;
     
     // Load configuration from disk

--- a/include/core/units.h
+++ b/include/core/units.h
@@ -1,0 +1,48 @@
+#ifndef UNITS_H
+#define UNITS_H
+
+#include <QObject>
+#include <QString>
+
+class Units : public QObject
+{
+    Q_OBJECT
+    
+public:
+    enum class UnitSystem {
+        Metric,
+        Imperial
+    };
+    Q_ENUM(UnitSystem)
+    
+    explicit Units(QObject *parent = nullptr);
+    
+    // Depth conversions
+    static double metersToFeet(double meters);
+    static double feetToMeters(double feet);
+    
+    // Temperature conversions  
+    static double celsiusToFahrenheit(double celsius);
+    static double fahrenheitToCelsius(double fahrenheit);
+    
+    // Pressure conversions
+    static double barToPsi(double bar);
+    static double psiToBar(double psi);
+    
+    // Format values with appropriate units and precision
+    static QString formatDepth(double depthMeters, UnitSystem system);
+    static QString formatTemperature(double tempCelsius, UnitSystem system);
+    static QString formatPressure(double pressureBar, UnitSystem system);
+    
+    // Get unit labels
+    static QString depthUnit(UnitSystem system);
+    static QString temperatureUnit(UnitSystem system);
+    static QString pressureUnit(UnitSystem system);
+    
+    // Convert and format in one step
+    static QString formatDepthValue(double depthMeters, UnitSystem system);
+    static QString formatTemperatureValue(double tempCelsius, UnitSystem system);
+    static QString formatPressureValue(double pressureBar, UnitSystem system);
+};
+
+#endif // UNITS_H

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -7,6 +7,8 @@
 #include <QFont>
 #include <QColor>
 #include "include/core/dive_data.h"
+#include "include/core/config.h"
+#include "include/core/units.h"
 
 class OverlayGenerator : public QObject
 {

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -23,6 +23,7 @@ Config::Config(QObject *parent)
     , m_showNDL(true)
     , m_showPressure(true)
     , m_showTime(true)
+    , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
 {
     // Load settings from disk
@@ -170,6 +171,19 @@ double Config::frameRate() const
     return m_frameRate;
 }
 
+Units::UnitSystem Config::unitSystem() const
+{
+    return m_unitSystem;
+}
+
+void Config::setUnitSystem(Units::UnitSystem system)
+{
+    if (m_unitSystem != system) {
+        m_unitSystem = system;
+        emit unitSystemChanged();
+    }
+}
+
 void Config::setFrameRate(double fps)
 {
     if (m_frameRate != fps) {
@@ -212,6 +226,10 @@ void Config::loadConfig()
     m_showPressure = m_settings.value("overlay/showPressure", true).toBool();
     m_showTime = m_settings.value("overlay/showTime", true).toBool();
     
+    // Load unit system
+    int unitSystemValue = m_settings.value("overlay/unitSystem", static_cast<int>(Units::UnitSystem::Metric)).toInt();
+    m_unitSystem = static_cast<Units::UnitSystem>(unitSystemValue);
+    
     // Load export settings
     m_frameRate = m_settings.value("export/frameRate", 10.0).toDouble();
 }
@@ -242,6 +260,9 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showNDL", m_showNDL);
     m_settings.setValue("overlay/showPressure", m_showPressure);
     m_settings.setValue("overlay/showTime", m_showTime);
+    
+    // Save unit system
+    m_settings.setValue("overlay/unitSystem", static_cast<int>(m_unitSystem));
     
     // Save export settings
     m_settings.setValue("export/frameRate", m_frameRate);

--- a/src/core/units.cpp
+++ b/src/core/units.cpp
@@ -1,0 +1,97 @@
+#include "include/core/units.h"
+#include <QLocale>
+
+Units::Units(QObject *parent)
+    : QObject(parent)
+{
+}
+
+double Units::metersToFeet(double meters)
+{
+    return meters * 3.28084;
+}
+
+double Units::feetToMeters(double feet)
+{
+    return feet / 3.28084;
+}
+
+double Units::celsiusToFahrenheit(double celsius)
+{
+    return (celsius * 9.0 / 5.0) + 32.0;
+}
+
+double Units::fahrenheitToCelsius(double fahrenheit)
+{
+    return (fahrenheit - 32.0) * 5.0 / 9.0;
+}
+
+double Units::barToPsi(double bar)
+{
+    return bar * 14.5038;
+}
+
+double Units::psiToBar(double psi)
+{
+    return psi / 14.5038;
+}
+
+QString Units::formatDepth(double depthMeters, UnitSystem system)
+{
+    if (system == UnitSystem::Imperial) {
+        double feet = metersToFeet(depthMeters);
+        return QString::number(feet, 'f', 1);
+    } else {
+        return QString::number(depthMeters, 'f', 1);
+    }
+}
+
+QString Units::formatTemperature(double tempCelsius, UnitSystem system)
+{
+    if (system == UnitSystem::Imperial) {
+        double fahrenheit = celsiusToFahrenheit(tempCelsius);
+        return QString::number(fahrenheit, 'f', 1);
+    } else {
+        return QString::number(tempCelsius, 'f', 1);
+    }
+}
+
+QString Units::formatPressure(double pressureBar, UnitSystem system)
+{
+    if (system == UnitSystem::Imperial) {
+        double psi = barToPsi(pressureBar);
+        return QString::number(psi, 'f', 0);
+    } else {
+        return QString::number(pressureBar, 'f', 0);
+    }
+}
+
+QString Units::depthUnit(UnitSystem system)
+{
+    return (system == UnitSystem::Imperial) ? "ft" : "m";
+}
+
+QString Units::temperatureUnit(UnitSystem system)
+{
+    return (system == UnitSystem::Imperial) ? "°F" : "°C";
+}
+
+QString Units::pressureUnit(UnitSystem system)
+{
+    return (system == UnitSystem::Imperial) ? "psi" : "bar";
+}
+
+QString Units::formatDepthValue(double depthMeters, UnitSystem system)
+{
+    return formatDepth(depthMeters, system) + " " + depthUnit(system);
+}
+
+QString Units::formatTemperatureValue(double tempCelsius, UnitSystem system)
+{
+    return formatTemperature(tempCelsius, system) + temperatureUnit(system);
+}
+
+QString Units::formatPressureValue(double pressureBar, UnitSystem system)
+{
+    return formatPressure(pressureBar, system) + " " + pressureUnit(system);
+}

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -321,7 +321,8 @@ QImage OverlayGenerator::generatePreview(DiveData* dive)
 }
 
 void OverlayGenerator::drawDepth(QPainter &painter, double depth, const QRect &rect) {
-    QString depthStr = QString::number(depth, 'f', 1) + " m";
+    Units::UnitSystem unitSystem = Config::instance()->unitSystem();
+    QString depthStr = Units::formatDepthValue(depth, unitSystem);
     
     painter.save();
     
@@ -345,7 +346,8 @@ void OverlayGenerator::drawDepth(QPainter &painter, double depth, const QRect &r
 }
 
 void OverlayGenerator::drawTemperature(QPainter &painter, double temp, const QRect &rect) {
-    QString tempStr = QString::number(temp, 'f', 1) + " °C";
+    Units::UnitSystem unitSystem = Config::instance()->unitSystem();
+    QString tempStr = Units::formatTemperatureValue(temp, unitSystem);
     
     painter.save();
     
@@ -444,7 +446,8 @@ void OverlayGenerator::drawPressure(QPainter &painter, double pressure, const QR
     valueFont.setBold(true);
     painter.setFont(valueFont);
     
-    QString pressureStr = QString::number(qRound(pressure)) + " bar";
+    Units::UnitSystem unitSystem = Config::instance()->unitSystem();
+    QString pressureStr = Units::formatPressureValue(pressure, unitSystem);
     
     // Position value - adjust for multi-tank
     QRect valueRect;
@@ -544,7 +547,9 @@ void OverlayGenerator::drawTTS(QPainter &painter, double tts, const QRect &rect,
     
     QString decoText = tr("DECO");
     if (ceiling > 0.0) {
-        decoText += QString(" (%1m)").arg(ceiling, 0, 'f', 1);
+        Units::UnitSystem unitSystem = Config::instance()->unitSystem();
+        QString ceilingStr = Units::formatDepthValue(ceiling, unitSystem);
+        decoText += QString(" (%1)").arg(ceilingStr);
     }
     
     // Position DECO text in the bottom of the rect

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,8 @@
 #include "include/export/image_export.h"
 #include "include/export/video_export.h"
 #include "include/generators/overlay_image_provider.h"
+#include "include/core/config.h"
+#include "include/core/units.h"
 
 // Global image provider
 OverlayImageProvider* g_imageProvider = nullptr;
@@ -36,6 +38,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<OverlayGenerator>("Unabara.Generators", 1, 0, "OverlayGenerator");
     qmlRegisterType<ImageExporter>("Unabara.Export", 1, 0, "ImageExporter");
     qmlRegisterType<VideoExporter>("Unabara.Export", 1, 0, "VideoExporter");
+    qmlRegisterUncreatableMetaObject(Units::staticMetaObject, "Unabara.Core", 1, 0, "Units", "Units is a utility class");
     
     // Create the QML engine
     QQmlApplicationEngine engine;
@@ -72,6 +75,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("mainWindow", &mainWindow);
     engine.rootContext()->setContextProperty("logParser", &logParser);
     engine.rootContext()->setContextProperty("overlayGenerator", overlayGenerator);
+    engine.rootContext()->setContextProperty("config", Config::instance());
 
     // Expose version to QML
     engine.rootContext()->setContextProperty("appVersion", UNABARA_VERSION_STR);

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -5,6 +5,7 @@ import QtQuick.Dialogs
 import Unabara.UI 1.0
 import Unabara.Generators 1.0
 import Unabara.Export 1.0
+import Unabara.Core 1.0
 import QtMultimedia
 
 ApplicationWindow {
@@ -322,6 +323,13 @@ ApplicationWindow {
                         function onTemplateChanged() { previewImage.updatePreview() }
                         function onFontChanged() { previewImage.updatePreview() }
                         function onTextColorChanged() { previewImage.updatePreview() }
+                    }
+                    
+                    // Monitor changes to config properties
+                    Connections {
+                        target: config
+                        
+                        function onUnitSystemChanged() { previewImage.updatePreview() }
                     }
                     
                     // Add status changes monitoring
@@ -858,7 +866,7 @@ ApplicationWindow {
         modal: true
         standardButtons: Dialog.Ok | Dialog.Cancel
         width: 400
-        height: 300
+        height: 400
 
         // Ensure settings are applied when dialog is accepted
         onAccepted: {
@@ -938,6 +946,39 @@ ApplicationWindow {
                         onCheckedChanged: {
                             overlayGenerator.showPressure = checked
                             previewImage.updatePreview()
+                        }
+                    }
+                }
+            }
+            
+            GroupBox {
+                title: qsTr("Units")
+                Layout.fillWidth: true
+                
+                ColumnLayout {
+                    anchors.fill: parent
+                    
+                    RadioButton {
+                        id: metricUnitsRadio
+                        text: qsTr("Metric (m, °C, bar)")
+                        checked: config.unitSystem === Units.Metric
+                        onCheckedChanged: {
+                            if (checked) {
+                                config.unitSystem = Units.Metric
+                                previewImage.updatePreview()
+                            }
+                        }
+                    }
+                    
+                    RadioButton {
+                        id: imperialUnitsRadio
+                        text: qsTr("Imperial (ft, °F, psi)")
+                        checked: config.unitSystem === Units.Imperial
+                        onCheckedChanged: {
+                            if (checked) {
+                                config.unitSystem = Units.Imperial
+                                previewImage.updatePreview()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION

  - Add Units utility class with conversion functions for depth (m/ft), temperature (°C/°F), and pressure (bar/psi)
  - Extend Config class with unitSystem property and persistent storage
  - Update OverlayGenerator to use converted values based on user preference
  - Add Units settings group to Settings dialog with metric/imperial toggle
  - Expose Config and Units enum to QML for UI integration
  - Maintain data integrity by keeping internal data in metric while converting for display
  - Add real-time preview updates when switching between unit systems

  Fixes display of telemetry data in both measurement systems while preserving Subsurface's metric data format.
