### PR TITLE
feat: add CCR (Closed-Circuit Rebreather) support with PO2 telemetry

### DIFF
--- a/include/core/config.h
+++ b/include/core/config.h
@@ -27,6 +27,12 @@ class Config : public QObject
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
     Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
+    // CCR settings
+    Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
+    Q_PROPERTY(bool showPO2Cell2 READ showPO2Cell2 WRITE setShowPO2Cell2 NOTIFY showPO2Cell2Changed)
+    Q_PROPERTY(bool showPO2Cell3 READ showPO2Cell3 WRITE setShowPO2Cell3 NOTIFY showPO2Cell3Changed)
+    Q_PROPERTY(bool showCompositePO2 READ showCompositePO2 WRITE setShowCompositePO2 NOTIFY showCompositePO2Changed)
+    
     // Export settings
     Q_PROPERTY(double frameRate READ frameRate WRITE setFrameRate NOTIFY frameRateChanged)
     
@@ -68,6 +74,19 @@ public:
     Units::UnitSystem unitSystem() const;
     void setUnitSystem(Units::UnitSystem system);
     
+    // CCR settings
+    bool showPO2Cell1() const;
+    void setShowPO2Cell1(bool show);
+    
+    bool showPO2Cell2() const;
+    void setShowPO2Cell2(bool show);
+    
+    bool showPO2Cell3() const;
+    void setShowPO2Cell3(bool show);
+    
+    bool showCompositePO2() const;
+    void setShowCompositePO2(bool show);
+    
     // Export settings
     double frameRate() const;
     void setFrameRate(double fps);
@@ -88,6 +107,12 @@ signals:
     void showTimeChanged();
     void unitSystemChanged();
     void frameRateChanged();
+    
+    // CCR signals
+    void showPO2Cell1Changed();
+    void showPO2Cell2Changed();
+    void showPO2Cell3Changed();
+    void showCompositePO2Changed();
     
 private:
     explicit Config(QObject *parent = nullptr);
@@ -112,6 +137,12 @@ private:
     bool m_showTime;
     Units::UnitSystem m_unitSystem;
     double m_frameRate;
+    
+    // CCR settings
+    bool m_showPO2Cell1;
+    bool m_showPO2Cell2;
+    bool m_showPO2Cell3;
+    bool m_showCompositePO2;
     
     // Load configuration from disk
     void loadConfig();

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -18,6 +18,7 @@ struct DiveDataPoint {
     double ceiling;             // Decompression ceiling in meters
     double o2percent;           // O2 percentage
     double tts;                 // Time To Surface in minutes
+    QVector<double> po2Sensors; // PO2 sensor values in bar (for CCR dives)
     
     // Constructor with default values
     DiveDataPoint(double time = 0.0, double d = 0.0, double temp = 0.0, 
@@ -43,6 +44,29 @@ struct DiveDataPoint {
     // Get the number of tanks with pressure data
     Q_INVOKABLE int tankCount() const {
         return pressures.size();
+    }
+    
+    // PO2 sensor access methods
+    Q_INVOKABLE double getPO2Sensor(int sensorIndex) const {
+        return (sensorIndex >= 0 && sensorIndex < po2Sensors.size()) ? po2Sensors[sensorIndex] : 0.0;
+    }
+    
+    void addPO2Sensor(double po2Value, int sensorIndex) {
+        // Resize the vector if necessary
+        if (sensorIndex >= po2Sensors.size()) {
+            po2Sensors.resize(sensorIndex + 1, 0.0);
+        }
+        po2Sensors[sensorIndex] = po2Value;
+    }
+    
+    Q_INVOKABLE int po2SensorCount() const {
+        return po2Sensors.size();
+    }
+    
+    // Get the composite PO2 (last sensor)
+    Q_INVOKABLE double getCompositePO2() const {
+        if (po2Sensors.isEmpty()) return 0.0;
+        return po2Sensors.last();
     }
 };
 

--- a/include/core/log_parser.h
+++ b/include/core/log_parser.h
@@ -44,7 +44,7 @@ private:
     // Helper functions for XML parsing
     DiveData* parseDiveElement(QXmlStreamReader &xml);
     void parseDiveComputerElement(QXmlStreamReader &xml, DiveData* dive, int &sampleCount);
-    void parseSampleElement(QXmlStreamReader &xml, DiveData* dive, double &lastTemperature, double &lastNDL, double &lastTTS, QMap<int, double> &lastPressures);
+    void parseSampleElement(QXmlStreamReader &xml, DiveData* dive, double &lastTemperature, double &lastNDL, double &lastTTS, QMap<int, double> &lastPressures, QMap<int, double> &lastPO2Sensors);
     void parseCylinderElement(QXmlStreamReader &xml, DiveData* dive);
     void parseDiveSites(QXmlStreamReader &xml);
     bool isCylinderActiveAtTime(int cylinderIndex, double timestamp) const;

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -23,6 +23,12 @@ class OverlayGenerator : public QObject
     Q_PROPERTY(bool showPressure READ showPressure WRITE setShowPressure NOTIFY showPressureChanged)
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
     
+    // CCR properties
+    Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
+    Q_PROPERTY(bool showPO2Cell2 READ showPO2Cell2 WRITE setShowPO2Cell2 NOTIFY showPO2Cell2Changed)
+    Q_PROPERTY(bool showPO2Cell3 READ showPO2Cell3 WRITE setShowPO2Cell3 NOTIFY showPO2Cell3Changed)
+    Q_PROPERTY(bool showCompositePO2 READ showCompositePO2 WRITE setShowCompositePO2 NOTIFY showCompositePO2Changed)
+    
 public:
     explicit OverlayGenerator(QObject *parent = nullptr);
     
@@ -36,6 +42,12 @@ public:
     bool showPressure() const { return m_showPressure; }
     bool showTime() const { return m_showTime; }
     
+    // CCR getters
+    bool showPO2Cell1() const { return m_showPO2Cell1; }
+    bool showPO2Cell2() const { return m_showPO2Cell2; }
+    bool showPO2Cell3() const { return m_showPO2Cell3; }
+    bool showCompositePO2() const { return m_showCompositePO2; }
+    
     // Setters
     void setTemplatePath(const QString &path);
     void setFont(const QFont &font);
@@ -45,6 +57,12 @@ public:
     void setShowNDL(bool show);
     void setShowPressure(bool show);
     void setShowTime(bool show);
+    
+    // CCR setters
+    void setShowPO2Cell1(bool show);
+    void setShowPO2Cell2(bool show);
+    void setShowPO2Cell3(bool show);
+    void setShowCompositePO2(bool show);
     
     // Generate overlay for a specific time point
     Q_INVOKABLE QImage generateOverlay(DiveData* dive, double timePoint);
@@ -62,6 +80,12 @@ signals:
     void showPressureChanged();
     void showTimeChanged();
     
+    // CCR signals
+    void showPO2Cell1Changed();
+    void showPO2Cell2Changed();
+    void showPO2Cell3Changed();
+    void showCompositePO2Changed();
+    
 private:
     QString m_templatePath;
     QFont m_font;
@@ -71,6 +95,12 @@ private:
     bool m_showNDL;
     bool m_showPressure;
     bool m_showTime;
+    
+    // CCR settings
+    bool m_showPO2Cell1;
+    bool m_showPO2Cell2;
+    bool m_showPO2Cell3;
+    bool m_showCompositePO2;
     
     // Helper methods for drawing
     void drawDepth(QPainter &painter, double depth, const QRect &rect);
@@ -82,6 +112,10 @@ private:
     void drawDataItem(QPainter &painter, const QString &label, const QString &value, const QRect &rect, bool centerAlign);
     // Helper method to draw section headers with consistent positioning
     void drawSectionHeader(QPainter &painter, const QString &label, const QRect &rect);
+    
+    // CCR drawing methods
+    void drawPO2Cell(QPainter &painter, double po2Value, const QRect &rect, int cellNumber);
+    void drawCompositePO2(QPainter &painter, double po2Value, const QRect &rect);
 };
 
 #endif // OVERLAY_GEN_H

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -25,6 +25,10 @@ Config::Config(QObject *parent)
     , m_showTime(true)
     , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
+    , m_showPO2Cell1(false)
+    , m_showPO2Cell2(false)
+    , m_showPO2Cell3(false)
+    , m_showCompositePO2(false)
 {
     // Load settings from disk
     loadConfig();
@@ -192,6 +196,59 @@ void Config::setFrameRate(double fps)
     }
 }
 
+// CCR settings implementation
+bool Config::showPO2Cell1() const
+{
+    return m_showPO2Cell1;
+}
+
+void Config::setShowPO2Cell1(bool show)
+{
+    if (m_showPO2Cell1 != show) {
+        m_showPO2Cell1 = show;
+        emit showPO2Cell1Changed();
+    }
+}
+
+bool Config::showPO2Cell2() const
+{
+    return m_showPO2Cell2;
+}
+
+void Config::setShowPO2Cell2(bool show)
+{
+    if (m_showPO2Cell2 != show) {
+        m_showPO2Cell2 = show;
+        emit showPO2Cell2Changed();
+    }
+}
+
+bool Config::showPO2Cell3() const
+{
+    return m_showPO2Cell3;
+}
+
+void Config::setShowPO2Cell3(bool show)
+{
+    if (m_showPO2Cell3 != show) {
+        m_showPO2Cell3 = show;
+        emit showPO2Cell3Changed();
+    }
+}
+
+bool Config::showCompositePO2() const
+{
+    return m_showCompositePO2;
+}
+
+void Config::setShowCompositePO2(bool show)
+{
+    if (m_showCompositePO2 != show) {
+        m_showCompositePO2 = show;
+        emit showCompositePO2Changed();
+    }
+}
+
 void Config::loadConfig()
 {
     // Load general settings
@@ -225,6 +282,12 @@ void Config::loadConfig()
     m_showNDL = m_settings.value("overlay/showNDL", true).toBool();
     m_showPressure = m_settings.value("overlay/showPressure", true).toBool();
     m_showTime = m_settings.value("overlay/showTime", true).toBool();
+    
+    // Load CCR settings
+    m_showPO2Cell1 = m_settings.value("overlay/showPO2Cell1", false).toBool();
+    m_showPO2Cell2 = m_settings.value("overlay/showPO2Cell2", false).toBool();
+    m_showPO2Cell3 = m_settings.value("overlay/showPO2Cell3", false).toBool();
+    m_showCompositePO2 = m_settings.value("overlay/showCompositePO2", false).toBool();
     
     // Load unit system
     int unitSystemValue = m_settings.value("overlay/unitSystem", static_cast<int>(Units::UnitSystem::Metric)).toInt();
@@ -260,6 +323,12 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showNDL", m_showNDL);
     m_settings.setValue("overlay/showPressure", m_showPressure);
     m_settings.setValue("overlay/showTime", m_showTime);
+    
+    // Save CCR settings
+    m_settings.setValue("overlay/showPO2Cell1", m_showPO2Cell1);
+    m_settings.setValue("overlay/showPO2Cell2", m_showPO2Cell2);
+    m_settings.setValue("overlay/showPO2Cell3", m_showPO2Cell3);
+    m_settings.setValue("overlay/showCompositePO2", m_showCompositePO2);
     
     // Save unit system
     m_settings.setValue("overlay/unitSystem", static_cast<int>(m_unitSystem));

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -217,6 +217,27 @@ DiveDataPoint DiveData::dataAtTime(double time) const
         result.addPressure(interpolatedPressure, i);
     }
     
+    // Interpolate all PO2 sensors (CCR data)
+    // Get the maximum number of PO2 sensors between both points
+    int maxSensors = qMax(prev.po2SensorCount(), next.po2SensorCount());
+    for (int i = 0; i < maxSensors; i++) {
+        double prevPO2 = prev.getPO2Sensor(i);
+        double nextPO2 = next.getPO2Sensor(i);
+        
+        // Only interpolate if both points have valid PO2 data
+        if (prevPO2 > 0.0 && nextPO2 > 0.0) {
+            double interpolatedPO2 = prevPO2 + factor * (nextPO2 - prevPO2);
+            result.addPO2Sensor(interpolatedPO2, i);
+        } else if (prevPO2 > 0.0) {
+            // Use previous value if next is missing
+            result.addPO2Sensor(prevPO2, i);
+        } else if (nextPO2 > 0.0) {
+            // Use next value if previous is missing
+            result.addPO2Sensor(nextPO2, i);
+        }
+        // If both are 0 or missing, don't add the sensor (empty result will have 0 count)
+    }
+    
     return result;
 }
 

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -339,6 +339,10 @@ ApplicationWindow {
                         target: config
                         
                         function onUnitSystemChanged() { previewImage.updatePreview() }
+                        function onShowPO2Cell1Changed() { previewImage.updatePreview() }
+                        function onShowPO2Cell2Changed() { previewImage.updatePreview() }
+                        function onShowPO2Cell3Changed() { previewImage.updatePreview() }
+                        function onShowCompositePO2Changed() { previewImage.updatePreview() }
                     }
                     
                     // Add status changes monitoring
@@ -875,7 +879,7 @@ ApplicationWindow {
         modal: true
         standardButtons: Dialog.Ok | Dialog.Cancel
         width: 400
-        height: 400
+        height: 500
 
         // Ensure settings are applied when dialog is accepted
         onAccepted: {
@@ -886,6 +890,12 @@ ApplicationWindow {
             overlayGenerator.showNDL = showNDLCheckbox.checked
             overlayGenerator.showPressure = showPressureCheckbox.checked
             
+            // Apply CCR settings to config (they update automatically via bindings)
+            config.showPO2Cell1 = showPO2Cell1Checkbox.checked
+            config.showPO2Cell2 = showPO2Cell2Checkbox.checked
+            config.showPO2Cell3 = showPO2Cell3Checkbox.checked
+            config.showCompositePO2 = showCompositePO2Checkbox.checked
+            
             // Update the preview
             previewImage.updatePreview()
             
@@ -894,7 +904,11 @@ ApplicationWindow {
                         "Temp:", overlayGenerator.showTemperature,
                         "Time:", overlayGenerator.showTime,
                         "NDL:", overlayGenerator.showNDL,
-                        "Pressure:", overlayGenerator.showPressure)
+                        "Pressure:", overlayGenerator.showPressure,
+                        "PO2 Cell1:", config.showPO2Cell1,
+                        "PO2 Cell2:", config.showPO2Cell2,
+                        "PO2 Cell3:", config.showPO2Cell3,
+                        "Composite PO2:", config.showCompositePO2)
         }
         
         ColumnLayout {
@@ -954,6 +968,55 @@ ApplicationWindow {
                         checked: overlayGenerator.showPressure
                         onCheckedChanged: {
                             overlayGenerator.showPressure = checked
+                            previewImage.updatePreview()
+                        }
+                    }
+                }
+            }
+            
+            GroupBox {
+                title: qsTr("CCR Settings")
+                Layout.fillWidth: true
+                
+                ColumnLayout {
+                    anchors.fill: parent
+                    
+                    CheckBox {
+                        id: showPO2Cell1Checkbox
+                        text: qsTr("Show Cell 1 PO2")
+                        checked: config.showPO2Cell1
+                        onCheckedChanged: {
+                            config.showPO2Cell1 = checked
+                            previewImage.updatePreview()
+                        }
+                    }
+                    
+                    CheckBox {
+                        id: showPO2Cell2Checkbox
+                        text: qsTr("Show Cell 2 PO2")
+                        checked: config.showPO2Cell2
+                        onCheckedChanged: {
+                            config.showPO2Cell2 = checked
+                            previewImage.updatePreview()
+                        }
+                    }
+                    
+                    CheckBox {
+                        id: showPO2Cell3Checkbox
+                        text: qsTr("Show Cell 3 PO2")
+                        checked: config.showPO2Cell3
+                        onCheckedChanged: {
+                            config.showPO2Cell3 = checked
+                            previewImage.updatePreview()
+                        }
+                    }
+                    
+                    CheckBox {
+                        id: showCompositePO2Checkbox
+                        text: qsTr("Show Composite PO2")
+                        checked: config.showCompositePO2
+                        onCheckedChanged: {
+                            config.showCompositePO2 = checked
                             previewImage.updatePreview()
                         }
                     }


### PR DESCRIPTION
Add comprehensive support for CCR diving with PO2 sensor telemetry:

 Core CCR Data Support:
  - Extend DiveDataPoint with PO2 sensor array for multiple cell readings
  - Add PO2 sensor access methods (getPO2Sensor, addPO2Sensor, getCompositePO2)
  - Implement PO2 data interpolation in dataAtTime() for smooth telemetry
  - Update log parser to extract CCR PO2 data from Subsurface dive logs

 UI and Configuration:
  - Add CCR settings section with toggles for Cell 1-3 PO2 and Composite PO2
  - Integrate CCR configuration with existing settings persistence
  - Update QML settings dialog with CCR-specific controls

  Overlay Generation:
  - Add CCR PO2 cell and composite PO2 drawing methods
  - Implement grid layout for multiple CCR cells in overlay
  - Ensure consistent overlay layout regardless of PO2 data availability
  - Handle missing PO2 data gracefully with placeholder values
  - Clean PO2 value formatting without redundant unit suffixes