### PR TITLE
Add support for UDDF dive logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ set(PROJECT_SOURCES
     src/main.cpp
     src/core/dive_data.cpp
     src/core/log_parser.cpp
+    src/core/format_parsers/parse_utils.cpp
+    src/core/format_parsers/subsurface_parser.cpp
+    src/core/format_parsers/uddf_parser.cpp
     src/core/config.cpp
     src/core/units.cpp
     src/core/cell_data.cpp
@@ -54,6 +57,10 @@ set(PROJECT_SOURCES
 set(PROJECT_HEADERS
     include/core/dive_data.h
     include/core/log_parser.h
+    include/core/format_parsers/idive_log_format_parser.h
+    include/core/format_parsers/parse_utils.h
+    include/core/format_parsers/subsurface_parser.h
+    include/core/format_parsers/uddf_parser.h
     include/core/config.h
     include/core/units.h
     include/core/cell_data.h

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -94,7 +94,7 @@ struct GasSwitch {
 class DiveData : public QObject
 {
     Q_OBJECT
-    
+
     Q_PROPERTY(QString diveName READ diveName WRITE setDiveName NOTIFY diveNameChanged)
     Q_PROPERTY(QDateTime startTime READ startTime WRITE setStartTime NOTIFY startTimeChanged)
     Q_PROPERTY(int durationSeconds READ durationSeconds NOTIFY durationChanged)
@@ -105,10 +105,18 @@ class DiveData : public QObject
     Q_PROPERTY(int diveNumber READ diveNumber WRITE setDiveNumber NOTIFY diveNumberChanged)
     Q_PROPERTY(QString diveSiteName READ diveSiteName WRITE setDiveSiteName NOTIFY diveSiteNameChanged)
     Q_PROPERTY(QString diveSiteId READ diveSiteId WRITE setDiveSiteId NOTIFY diveSiteIdChanged)
-    
+    Q_PROPERTY(DiveMode diveMode READ diveMode WRITE setDiveMode NOTIFY diveModeChanged)
+
 public:
+    enum DiveMode {
+        UnknownMode = 0,
+        OpenCircuit = 1,
+        ClosedCircuit = 2
+    };
+    Q_ENUM(DiveMode)
+
     explicit DiveData(QObject *parent = nullptr);
-    
+
     // Getters
     QString diveName() const { return m_diveName; }
     QDateTime startTime() const { return m_startTime; }
@@ -119,7 +127,8 @@ public:
     int diveNumber() const { return m_diveNumber; }
     QString diveSiteName() const { return m_diveSiteName; }
     QString diveSiteId() const { return m_diveSiteId; }
-    
+    DiveMode diveMode() const { return m_diveMode; }
+
     // Setters
     void setDiveName(const QString &name);
     void setStartTime(const QDateTime &time);
@@ -127,6 +136,7 @@ public:
     void setDiveNumber(int number);
     void setDiveSiteName(const QString &siteName);
     void setDiveSiteId(const QString &siteId);
+    void setDiveMode(DiveMode mode);
 
     // Cylinder management
     int cylinderCount() const { return m_cylinders.size(); }
@@ -165,7 +175,8 @@ signals:
     void diveNumberChanged();
     void diveSiteNameChanged();
     void diveSiteIdChanged();
-    
+    void diveModeChanged();
+
 private:
     QString m_diveName;
     QDateTime m_startTime;
@@ -173,6 +184,7 @@ private:
     int m_diveNumber;
     QString m_diveSiteName;
     QString m_diveSiteId;
+    DiveMode m_diveMode = UnknownMode;
     QVector<DiveDataPoint> m_dataPoints;
     QVector<CylinderInfo> m_cylinders;
     QList<GasSwitch> m_gasSwitches;

--- a/include/core/format_parsers/idive_log_format_parser.h
+++ b/include/core/format_parsers/idive_log_format_parser.h
@@ -1,0 +1,29 @@
+#ifndef IDIVE_LOG_FORMAT_PARSER_H
+#define IDIVE_LOG_FORMAT_PARSER_H
+
+#include <QFile>
+#include <QList>
+#include <QString>
+#include "include/core/dive_data.h"
+
+class IDiveLogFormatParser
+{
+public:
+    virtual ~IDiveLogFormatParser() = default;
+
+    // Cheap content sniff: peek at the file's first StartElement.
+    // Implementations must restore the seek position on exit.
+    virtual bool canParse(QFile &file) const = 0;
+
+    // Parse all dives, or one if specificDive >= 0. errorOut is populated on failure.
+    // Caller takes ownership of returned DiveData* objects.
+    virtual QList<DiveData *> parse(QFile &file, int specificDive, QString &errorOut) = 0;
+
+    // Light-weight dive listing for the import-dialog picker.
+    virtual QList<QString> listDives(QFile &file, QString &errorOut) = 0;
+
+    // Human-readable name, used in error messages and logs.
+    virtual QString formatName() const = 0;
+};
+
+#endif // IDIVE_LOG_FORMAT_PARSER_H

--- a/include/core/format_parsers/parse_utils.h
+++ b/include/core/format_parsers/parse_utils.h
@@ -1,0 +1,23 @@
+#ifndef PARSE_UTILS_H
+#define PARSE_UTILS_H
+
+#include <QDateTime>
+#include <QString>
+#include <QStringView>
+
+namespace parse_utils {
+
+inline double kelvinToCelsius(double k) { return k - 273.15; }
+inline double pascalToBar(double pa)    { return pa / 1.0e5; }
+
+// Accepts either "2.1" or "2,1" (UDDF uses comma as decimal separator in many places).
+// Returns NaN on failure.
+double parseLocaleDouble(QStringView s);
+
+// ISO 8601 datetime: "2026-02-28T11:04:56", with optional "Z" or "+02:00" suffix.
+// Returns an invalid QDateTime on failure.
+QDateTime parseISO8601(QStringView s);
+
+} // namespace parse_utils
+
+#endif // PARSE_UTILS_H

--- a/include/core/format_parsers/subsurface_parser.h
+++ b/include/core/format_parsers/subsurface_parser.h
@@ -1,0 +1,55 @@
+#ifndef SUBSURFACE_PARSER_H
+#define SUBSURFACE_PARSER_H
+
+#include <QMap>
+#include <QXmlStreamReader>
+
+#include "include/core/format_parsers/idive_log_format_parser.h"
+
+class SubsurfaceParser : public IDiveLogFormatParser
+{
+public:
+    SubsurfaceParser();
+    ~SubsurfaceParser() override = default;
+
+    bool canParse(QFile &file) const override;
+    QList<DiveData *> parse(QFile &file, int specificDive, QString &errorOut) override;
+    QList<QString> listDives(QFile &file, QString &errorOut) override;
+    QString formatName() const override { return QStringLiteral("Subsurface XML"); }
+
+private:
+    struct GasSwitch {
+        double timestamp;  // Time in seconds when switch occurred
+        int cylinderIndex; // Which cylinder was switched to
+    };
+
+    struct DiveSite {
+        QString uuid;
+        QString name;
+        QString gps;
+        QString description;
+    };
+
+    DiveData *parseDiveElement(QXmlStreamReader &xml);
+    void parseDiveComputerElement(QXmlStreamReader &xml, DiveData *dive, int &sampleCount);
+    void parseSampleElement(QXmlStreamReader &xml,
+                            DiveData *dive,
+                            double &lastTemperature,
+                            double &lastNDL,
+                            double &lastTTS,
+                            QMap<int, double> &lastPressures,
+                            QMap<int, double> &lastPO2Sensors);
+    void parseCylinderElement(QXmlStreamReader &xml, DiveData *dive);
+    void parseDiveSites(QXmlStreamReader &xml);
+
+    void resetDiveState();
+
+    QMap<int, double> m_initialCylinderPressures;
+    double m_lastCeiling = 0.0;
+    QList<GasSwitch> m_gasSwitches;
+    double m_diveDuration = 0.0;
+    QMap<QString, DiveSite> m_diveSites;
+    bool m_currentDiveHasCcrCues = false;
+};
+
+#endif // SUBSURFACE_PARSER_H

--- a/include/core/format_parsers/uddf_parser.h
+++ b/include/core/format_parsers/uddf_parser.h
@@ -1,0 +1,66 @@
+#ifndef UDDF_PARSER_H
+#define UDDF_PARSER_H
+
+#include <QMap>
+#include <QString>
+#include <QXmlStreamReader>
+
+#include "include/core/format_parsers/idive_log_format_parser.h"
+
+class UDDFParser : public IDiveLogFormatParser
+{
+public:
+    UDDFParser();
+    ~UDDFParser() override = default;
+
+    bool canParse(QFile &file) const override;
+    QList<DiveData *> parse(QFile &file, int specificDive, QString &errorOut) override;
+    QList<QString> listDives(QFile &file, QString &errorOut) override;
+    QString formatName() const override { return QStringLiteral("UDDF"); }
+
+private:
+    struct GasMix {
+        QString name;
+        double o2Percent = 21.0;
+        double hePercent = 0.0;
+    };
+
+    struct DiveSite {
+        QString id;
+        QString name;
+        QString location;
+    };
+
+    void resetState();
+    void parseGasDefinitions(QXmlStreamReader &xml);
+    void parseDiveSiteContainer(QXmlStreamReader &xml);
+    void parseDiveSiteEntry(QXmlStreamReader &xml);
+    void parseProfileData(QXmlStreamReader &xml,
+                          QList<DiveData *> &out,
+                          int specificDive,
+                          bool &foundSpecific);
+
+    DiveData *parseDiveElement(QXmlStreamReader &xml);
+    void parseInformationBeforeDive(QXmlStreamReader &xml, DiveData *dive);
+    void parseTankData(QXmlStreamReader &xml, DiveData *dive);
+    void parseSamples(QXmlStreamReader &xml, DiveData *dive);
+    void parseWaypoint(QXmlStreamReader &xml,
+                       DiveData *dive,
+                       double &lastTemperature,
+                       double &lastNDL,
+                       double &lastTTS,
+                       double &lastCeiling,
+                       QMap<int, double> &lastPressures,
+                       QMap<int, double> &lastPO2Sensors,
+                       QMap<QString, int> &po2SensorRefToIndex);
+
+    int firstTankIndexForMix(const QString &mixId) const;
+
+    QMap<QString, GasMix> m_mixes;
+    QMap<QString, DiveSite> m_diveSites;
+    QMap<QString, int> m_mixToFirstTank;
+    bool m_currentDiveCcrSeen = false;
+    bool m_currentDiveOcSeen = false;
+};
+
+#endif // UDDF_PARSER_H

--- a/include/core/log_parser.h
+++ b/include/core/log_parser.h
@@ -1,73 +1,47 @@
 #ifndef LOG_PARSER_H
 #define LOG_PARSER_H
 
+#include <QFile>
+#include <QList>
 #include <QObject>
 #include <QString>
-#include <QList>
-#include <QFile>
-#include <QXmlStreamReader>
+
+#include <memory>
+#include <vector>
+
 #include "include/core/dive_data.h"
+#include "include/core/format_parsers/idive_log_format_parser.h"
 
 class LogParser : public QObject
 {
     Q_OBJECT
-    
+
     Q_PROPERTY(QString lastError READ lastError NOTIFY errorOccurred)
     Q_PROPERTY(bool busy READ isBusy NOTIFY busyChanged)
-    
+
 public:
     explicit LogParser(QObject *parent = nullptr);
-    
-    // Import a dive log file
+    ~LogParser() override;
+
     Q_INVOKABLE bool importFile(const QString &filePath);
-    
-    // Import a specific dive from the log
     Q_INVOKABLE bool importDive(const QString &filePath, int diveNumber);
-    
-    // Get the list of dives from a log file without importing them
     Q_INVOKABLE QList<QString> getDiveList(const QString &filePath);
-    
-    // Getters
+
     QString lastError() const { return m_lastError; }
     bool isBusy() const { return m_busy; }
-    
+
 signals:
     void diveImported(DiveData* dive);
     void multipleImported(QList<DiveData*> dives);
     void errorOccurred(const QString &error);
     void busyChanged();
-    
-private:
-    // Parse Subsurface XML format
-    bool parseSubsurfaceXML(QFile &file, QList<DiveData*> &result, int specificDive = -1);
-    
-    // Helper functions for XML parsing
-    DiveData* parseDiveElement(QXmlStreamReader &xml);
-    void parseDiveComputerElement(QXmlStreamReader &xml, DiveData* dive, int &sampleCount);
-    void parseSampleElement(QXmlStreamReader &xml, DiveData* dive, double &lastTemperature, double &lastNDL, double &lastTTS, QMap<int, double> &lastPressures, QMap<int, double> &lastPO2Sensors);
-    void parseCylinderElement(QXmlStreamReader &xml, DiveData* dive);
-    void parseDiveSites(QXmlStreamReader &xml);
-    bool isCylinderActiveAtTime(int cylinderIndex, double timestamp) const;
 
-    struct GasSwitch {
-        double timestamp;  // Time in minutes when switch occurred
-        int cylinderIndex; // Which cylinder was switched to
-    };
-    
-    struct DiveSite {
-        QString uuid;       // Unique identifier from the XML
-        QString name;       // Site name
-        QString gps;        // GPS coordinates
-        QString description; // Site description
-    };
-    
+private:
+    IDiveLogFormatParser *selectParser(QFile &file);
+
+    std::vector<std::unique_ptr<IDiveLogFormatParser>> m_parsers;
     QString m_lastError;
     bool m_busy;
-    QMap<int, double> m_initialCylinderPressures; // Initial pressures for all tanks
-    double m_lastCeiling; // Last parsed ceiling depth, puting it here because it's a state that persists between points.
-    QList<GasSwitch> m_gasSwitches; // List of gas switches for the current dive
-    double m_diveDuration; // Store the total dive duration
-    QMap<QString, DiveSite> m_diveSites; // Map of dive site UUID to dive site info
 };
 
 #endif // LOG_PARSER_H

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -55,6 +55,14 @@ void DiveData::setDiveSiteId(const QString &siteId)
     }
 }
 
+void DiveData::setDiveMode(DiveMode mode)
+{
+    if (m_diveMode != mode) {
+        m_diveMode = mode;
+        emit diveModeChanged();
+    }
+}
+
 int DiveData::durationSeconds() const
 {
     if (m_dataPoints.isEmpty()) {

--- a/src/core/format_parsers/parse_utils.cpp
+++ b/src/core/format_parsers/parse_utils.cpp
@@ -1,0 +1,33 @@
+#include "include/core/format_parsers/parse_utils.h"
+
+#include <cmath>
+
+namespace parse_utils {
+
+double parseLocaleDouble(QStringView s)
+{
+    QString tmp = s.toString().trimmed();
+    if (tmp.isEmpty()) {
+        return std::nan("");
+    }
+    tmp.replace(QLatin1Char(','), QLatin1Char('.'));
+    bool ok = false;
+    const double value = tmp.toDouble(&ok);
+    return ok ? value : std::nan("");
+}
+
+QDateTime parseISO8601(QStringView s)
+{
+    const QString str = s.toString().trimmed();
+    if (str.isEmpty()) {
+        return QDateTime();
+    }
+
+    QDateTime dt = QDateTime::fromString(str, Qt::ISODateWithMs);
+    if (!dt.isValid()) {
+        dt = QDateTime::fromString(str, Qt::ISODate);
+    }
+    return dt;
+}
+
+} // namespace parse_utils

--- a/src/core/format_parsers/subsurface_parser.cpp
+++ b/src/core/format_parsers/subsurface_parser.cpp
@@ -1,0 +1,780 @@
+#include "include/core/format_parsers/subsurface_parser.h"
+
+#include <QDateTime>
+#include <QDebug>
+#include <QRegularExpression>
+#include <QXmlStreamReader>
+
+#include <algorithm>
+
+SubsurfaceParser::SubsurfaceParser() = default;
+
+bool SubsurfaceParser::canParse(QFile &file) const
+{
+    const qint64 originalPos = file.pos();
+    file.seek(0);
+
+    QXmlStreamReader xml(&file);
+    bool result = false;
+    while (!xml.atEnd() && !xml.hasError()) {
+        if (xml.readNext() == QXmlStreamReader::StartElement) {
+            result = (xml.name() == QStringLiteral("divelog"));
+            break;
+        }
+    }
+
+    file.seek(originalPos);
+    return result;
+}
+
+void SubsurfaceParser::resetDiveState()
+{
+    m_initialCylinderPressures.clear();
+    m_gasSwitches.clear();
+    m_lastCeiling = 0.0;
+    m_currentDiveHasCcrCues = false;
+}
+
+QList<DiveData *> SubsurfaceParser::parse(QFile &file, int specificDive, QString &errorOut)
+{
+    QList<DiveData *> result;
+
+    file.seek(0);
+    qDebug() << "Starting to parse Subsurface XML file";
+    QXmlStreamReader xml(&file);
+
+    m_diveSites.clear();
+
+    while (!xml.atEnd() && !xml.hasError()) {
+        QXmlStreamReader::TokenType token = xml.readNext();
+
+        if (token == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("divesites")) {
+            qDebug() << "Found divesites element";
+            parseDiveSites(xml);
+        } else if (token == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("dive")) {
+            qDebug() << "Found dive element";
+
+            if (specificDive != -1) {
+                QXmlStreamAttributes attrs = xml.attributes();
+                if (attrs.hasAttribute("number")) {
+                    bool ok;
+                    int number = attrs.value("number").toInt(&ok);
+                    if (!ok || number != specificDive) {
+                        continue;
+                    }
+                }
+            }
+
+            DiveData *dive = parseDiveElement(xml);
+            if (dive) {
+                qDebug() << "Successfully parsed dive:" << dive->diveName();
+                result.append(dive);
+
+                if (specificDive != -1) {
+                    break;
+                }
+            }
+        }
+    }
+
+    if (xml.hasError()) {
+        errorOut = QStringLiteral("XML parsing error: %1").arg(xml.errorString());
+        qDebug() << "XML parsing error:" << xml.errorString();
+        qDeleteAll(result);
+        result.clear();
+        return result;
+    }
+
+    qDebug() << "Finished parsing XML file, found" << result.size() << "dives";
+    return result;
+}
+
+QList<QString> SubsurfaceParser::listDives(QFile &file, QString &errorOut)
+{
+    QList<QString> result;
+
+    file.seek(0);
+    QXmlStreamReader xml(&file);
+
+    while (!xml.atEnd() && !xml.hasError()) {
+        QXmlStreamReader::TokenType token = xml.readNext();
+
+        if (token == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("dive")) {
+            QString diveDate;
+            QString diveTime;
+            QString diveLocation;
+
+            QXmlStreamAttributes attrs = xml.attributes();
+            if (attrs.hasAttribute("number")) {
+                QString number = attrs.value("number").toString();
+
+                if (attrs.hasAttribute("date")) {
+                    diveDate = attrs.value("date").toString();
+                }
+                if (attrs.hasAttribute("time")) {
+                    diveTime = attrs.value("time").toString();
+                }
+
+                while (!xml.atEnd() && !(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("dive"))) {
+                    if (xml.tokenType() == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("location")) {
+                        diveLocation = xml.readElementText();
+                        break;
+                    }
+                    xml.readNext();
+                }
+
+                QString entry = QStringLiteral("Dive #%1").arg(number);
+                if (!diveDate.isEmpty()) {
+                    entry += " - " + diveDate;
+                }
+                if (!diveTime.isEmpty()) {
+                    entry += " " + diveTime;
+                }
+                if (!diveLocation.isEmpty()) {
+                    entry += " at " + diveLocation;
+                }
+
+                result.append(entry);
+            }
+        }
+    }
+
+    if (xml.hasError()) {
+        errorOut = QStringLiteral("XML parsing error: %1").arg(xml.errorString());
+        result.clear();
+    }
+
+    return result;
+}
+
+DiveData *SubsurfaceParser::parseDiveElement(QXmlStreamReader &xml)
+{
+    DiveData *dive = new DiveData();
+
+    resetDiveState();
+
+    QXmlStreamAttributes attrs = xml.attributes();
+
+    if (attrs.hasAttribute("number")) {
+        QString number = attrs.value("number").toString();
+        bool ok;
+        int diveNumber = number.toInt(&ok);
+        if (ok) {
+            dive->setDiveNumber(diveNumber);
+        }
+        dive->setDiveName(QStringLiteral("Dive #%1").arg(number));
+    }
+
+    if (attrs.hasAttribute("divesiteid")) {
+        QString siteId = attrs.value("divesiteid").toString();
+        dive->setDiveSiteId(siteId);
+
+        if (m_diveSites.contains(siteId)) {
+            const DiveSite &site = m_diveSites[siteId];
+            dive->setDiveSiteName(site.name);
+            if (dive->location().isEmpty() && !site.name.isEmpty()) {
+                dive->setLocation(site.name);
+            }
+        }
+    }
+
+    QDateTime diveDateTime;
+    if (attrs.hasAttribute("date")) {
+        QString dateStr = attrs.value("date").toString();
+        if (attrs.hasAttribute("time")) {
+            QString timeStr = attrs.value("time").toString();
+            diveDateTime = QDateTime::fromString(dateStr + " " + timeStr, "yyyy-MM-dd hh:mm:ss");
+        } else {
+            diveDateTime = QDateTime::fromString(dateStr, "yyyy-MM-dd");
+        }
+        dive->setStartTime(diveDateTime);
+    }
+
+    qDebug() << "Parsing dive element for" << dive->diveName();
+
+    int sampleCount = 0;
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+
+        if (xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("dive")) {
+            break;
+        }
+
+        if (xml.tokenType() == QXmlStreamReader::StartElement) {
+            QString elementName = xml.name().toString();
+
+            if (elementName == "location") {
+                dive->setLocation(xml.readElementText());
+            } else if (elementName == "cylinder") {
+                parseCylinderElement(xml, dive);
+            } else if (elementName == "divecomputer") {
+                parseDiveComputerElement(xml, dive, sampleCount);
+            }
+        }
+    }
+
+    if (dive->allDataPoints().isEmpty() && dive->cylinderCount() > 0) {
+        DiveDataPoint initialPoint;
+        initialPoint.timestamp = 0.0;
+
+        for (int i = 0; i < dive->cylinderCount(); i++) {
+            double initialPressure = m_initialCylinderPressures.value(i, 0.0);
+            if (initialPressure > 0.0) {
+                initialPoint.addPressure(initialPressure, i);
+            }
+        }
+
+        dive->addDataPoint(initialPoint);
+    }
+
+    m_diveDuration = dive->durationSeconds();
+
+    if (dive->diveMode() == DiveData::UnknownMode) {
+        dive->setDiveMode(m_currentDiveHasCcrCues ? DiveData::ClosedCircuit : DiveData::OpenCircuit);
+    }
+
+    qDebug() << "Finished parsing dive element. Total data points:" << dive->allDataPoints().size()
+             << "diveMode:" << dive->diveMode();
+    return dive;
+}
+
+void SubsurfaceParser::parseCylinderElement(QXmlStreamReader &xml, DiveData *dive)
+{
+    QXmlStreamAttributes attrs = xml.attributes();
+    CylinderInfo cylinder;
+
+    if (attrs.hasAttribute("size")) {
+        QString sizeStr = attrs.value("size").toString();
+        QRegularExpression sizeRe("(\\d+\\.?\\d*)\\s+l");
+        QRegularExpressionMatch match = sizeRe.match(sizeStr);
+
+        if (match.hasMatch()) {
+            cylinder.size = match.captured(1).toDouble();
+        }
+    }
+
+    if (attrs.hasAttribute("workpressure")) {
+        QString pressureStr = attrs.value("workpressure").toString();
+        QRegularExpression pressureRe("(\\d+\\.?\\d*)\\s+bar");
+        QRegularExpressionMatch match = pressureRe.match(pressureStr);
+
+        if (match.hasMatch()) {
+            cylinder.workPressure = match.captured(1).toDouble();
+        }
+    }
+
+    if (attrs.hasAttribute("description")) {
+        cylinder.description = attrs.value("description").toString();
+    }
+
+    if (attrs.hasAttribute("o2")) {
+        QString o2Str = attrs.value("o2").toString();
+        QRegularExpression o2Re("(\\d+\\.?\\d*)\\s*%");
+        QRegularExpressionMatch match = o2Re.match(o2Str);
+
+        if (match.hasMatch()) {
+            cylinder.o2Percent = match.captured(1).toDouble();
+        }
+    }
+
+    if (attrs.hasAttribute("he")) {
+        QString heStr = attrs.value("he").toString();
+        QRegularExpression heRe("(\\d+\\.?\\d*)\\s*%");
+        QRegularExpressionMatch match = heRe.match(heStr);
+
+        if (match.hasMatch()) {
+            cylinder.hePercent = match.captured(1).toDouble();
+        }
+    }
+
+    if (attrs.hasAttribute("start")) {
+        QString startStr = attrs.value("start").toString();
+        QRegularExpression startRe("(\\d+\\.?\\d*)\\s+bar");
+        QRegularExpressionMatch match = startRe.match(startStr);
+
+        if (match.hasMatch()) {
+            cylinder.startPressure = match.captured(1).toDouble();
+        }
+    }
+
+    if (attrs.hasAttribute("end")) {
+        QString endStr = attrs.value("end").toString();
+        QRegularExpression endRe("(\\d+\\.?\\d*)\\s+bar");
+        QRegularExpressionMatch match = endRe.match(endStr);
+
+        if (match.hasMatch()) {
+            cylinder.endPressure = match.captured(1).toDouble();
+        }
+    }
+
+    if (attrs.hasAttribute("use")) {
+        const QString useStr = attrs.value("use").toString().toLower();
+        if (useStr == QLatin1String("diluent")) {
+            m_currentDiveHasCcrCues = true;
+        }
+    }
+
+    double initialPressure = 0.0;
+    if (cylinder.startPressure > 0.0) {
+        initialPressure = cylinder.startPressure;
+    } else if (cylinder.workPressure > 0.0) {
+        initialPressure = cylinder.workPressure;
+    }
+
+    int cylinderIndex = dive->cylinderCount();
+    dive->addCylinder(cylinder);
+
+    if (initialPressure > 0.0) {
+        m_initialCylinderPressures[cylinderIndex] = initialPressure;
+    }
+
+    qDebug() << "Parsed cylinder:" << cylinder.description
+             << "Index:" << cylinderIndex
+             << "Size:" << cylinder.size << "l"
+             << "Gas mix:" << cylinder.o2Percent << "% O2"
+             << (cylinder.hePercent > 0 ? QString::number(cylinder.hePercent) + "% He" : "")
+             << "Initial pressure:" << initialPressure << "bar";
+
+    while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("cylinder"))) {
+        xml.readNext();
+        if (xml.atEnd()) break;
+    }
+}
+
+void SubsurfaceParser::parseDiveComputerElement(QXmlStreamReader &xml, DiveData *dive, int &sampleCount)
+{
+    qDebug() << "Parsing divecomputer element";
+
+    double lastTemperature = 0.0;
+    double lastNDL = 0.0;
+    double lastTTS = 0.0;
+
+    QMap<int, double> lastPressures;
+    QMap<int, double> lastPO2Sensors;
+    for (int i = 0; i < dive->cylinderCount(); i++) {
+        double initialPressure = m_initialCylinderPressures.value(i, 0.0);
+        if (initialPressure > 0.0) {
+            lastPressures[i] = initialPressure;
+        }
+    }
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+
+        if (xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("divecomputer")) {
+            break;
+        }
+
+        if (xml.tokenType() == QXmlStreamReader::StartElement) {
+            QString elementName = xml.name().toString();
+
+            if (elementName == "sample") {
+                parseSampleElement(xml, dive, lastTemperature, lastNDL, lastTTS, lastPressures, lastPO2Sensors);
+                sampleCount++;
+
+                if (sampleCount % 10 == 0) {
+                    qDebug() << "Parsed" << sampleCount << "samples";
+                }
+            } else if (elementName == "temperature") {
+                QXmlStreamAttributes attrs = xml.attributes();
+                if (attrs.hasAttribute("water")) {
+                    QString tempStr = attrs.value("water").toString();
+                    QRegularExpression tempRe("(\\d+\\.?\\d*)\\s+C");
+                    QRegularExpressionMatch match = tempRe.match(tempStr);
+
+                    if (match.hasMatch()) {
+                        lastTemperature = match.captured(1).toDouble();
+                    }
+                }
+                while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("temperature"))) {
+                    xml.readNext();
+                    if (xml.atEnd()) break;
+                }
+            } else if (elementName == "event") {
+                QXmlStreamAttributes eventAttrs = xml.attributes();
+
+                if (eventAttrs.hasAttribute("name") && eventAttrs.value("name") == QStringLiteral("gaschange")) {
+                    if (eventAttrs.hasAttribute("time") && eventAttrs.hasAttribute("cylinder")) {
+                        QString timeStr = eventAttrs.value("time").toString();
+                        double timestamp = 0.0;
+
+                        QRegularExpression timeRe("(\\d+):(\\d+)\\s+min");
+                        QRegularExpressionMatch match = timeRe.match(timeStr);
+
+                        if (match.hasMatch()) {
+                            int minutes = match.captured(1).toInt();
+                            int seconds = match.captured(2).toInt();
+                            timestamp = minutes * 60 + seconds;
+                        } else {
+                            bool ok;
+                            timestamp = timeStr.toDouble(&ok);
+                            if (!ok) timestamp = 0.0;
+                        }
+
+                        int cylinderIndex = eventAttrs.value("cylinder").toInt();
+
+                        dive->addGasSwitch(timestamp, cylinderIndex);
+
+                        qDebug() << "Parsed gas switch at time" << timestamp
+                                 << "to cylinder" << cylinderIndex;
+                    }
+                }
+
+                while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("event"))) {
+                    xml.readNext();
+                    if (xml.atEnd()) break;
+                }
+            }
+        }
+    }
+
+    std::sort(m_gasSwitches.begin(), m_gasSwitches.end(),
+              [](const GasSwitch &a, const GasSwitch &b) {
+                  return a.timestamp < b.timestamp;
+              });
+
+    qDebug() << "Finished parsing divecomputer element with" << sampleCount << "samples";
+}
+
+void SubsurfaceParser::parseSampleElement(QXmlStreamReader &xml,
+                                          DiveData *dive,
+                                          double &lastTemperature,
+                                          double &lastNDL,
+                                          double &lastTTS,
+                                          QMap<int, double> &lastPressures,
+                                          QMap<int, double> &lastPO2Sensors)
+{
+    QXmlStreamAttributes attrs = xml.attributes();
+
+    DiveDataPoint point;
+    bool hasData = false;
+    bool inDeco = false;
+
+    if (attrs.hasAttribute("time")) {
+        QString timeStr = attrs.value("time").toString();
+        QRegularExpression timeRe("(\\d+):(\\d+)\\s+min");
+        QRegularExpressionMatch match = timeRe.match(timeStr);
+
+        if (match.hasMatch()) {
+            int minutes = match.captured(1).toInt();
+            int seconds = match.captured(2).toInt();
+            point.timestamp = minutes * 60 + seconds;
+            hasData = true;
+        } else {
+            bool ok;
+            double time = timeStr.toDouble(&ok);
+            if (ok) {
+                point.timestamp = time;
+                hasData = true;
+            }
+        }
+    }
+
+    if (attrs.hasAttribute("depth")) {
+        QString depthStr = attrs.value("depth").toString();
+        QRegularExpression depthRe("(\\d+\\.?\\d*)\\s+m");
+        QRegularExpressionMatch match = depthRe.match(depthStr);
+
+        if (match.hasMatch()) {
+            point.depth = match.captured(1).toDouble();
+            hasData = true;
+        } else {
+            bool ok;
+            double depth = depthStr.toDouble(&ok);
+            if (ok) {
+                point.depth = depth;
+                hasData = true;
+            }
+        }
+    }
+
+    if (attrs.hasAttribute("temp")) {
+        QString tempStr = attrs.value("temp").toString();
+        QRegularExpression tempRe("(\\d+\\.?\\d*)\\s+C");
+        QRegularExpressionMatch match = tempRe.match(tempStr);
+
+        if (match.hasMatch()) {
+            point.temperature = match.captured(1).toDouble();
+            lastTemperature = point.temperature;
+            hasData = true;
+        } else {
+            bool ok;
+            double temp = tempStr.toDouble(&ok);
+            if (ok) {
+                point.temperature = temp;
+                lastTemperature = temp;
+                hasData = true;
+            }
+        }
+    } else {
+        if (lastTemperature > 0.0) {
+            point.temperature = lastTemperature;
+        }
+    }
+
+    if (attrs.hasAttribute("pressure")) {
+        QString pressureStr = attrs.value("pressure").toString();
+        QRegularExpression pressureRe("(\\d+\\.?\\d*)\\s+bar");
+        QRegularExpressionMatch match = pressureRe.match(pressureStr);
+
+        if (match.hasMatch()) {
+            double pressure = match.captured(1).toDouble();
+            point.addPressure(pressure, 0);
+            hasData = true;
+        } else {
+            bool ok;
+            double pressure = pressureStr.toDouble(&ok);
+            if (ok) {
+                point.addPressure(pressure, 0);
+                hasData = true;
+            }
+        }
+    }
+
+    for (int i = 0; i < 10; i++) {
+        QString pressureAttr = QString("pressure%1").arg(i);
+
+        if (attrs.hasAttribute(pressureAttr)) {
+            QString pressureStr = attrs.value(pressureAttr).toString();
+            QRegularExpression pressureRe("(\\d+\\.?\\d*)\\s+bar");
+            QRegularExpressionMatch match = pressureRe.match(pressureStr);
+
+            if (match.hasMatch()) {
+                double pressure = match.captured(1).toDouble();
+                point.addPressure(pressure, i);
+                lastPressures[i] = pressure;
+                hasData = true;
+            } else {
+                bool ok;
+                double pressure = pressureStr.toDouble(&ok);
+                if (ok) {
+                    point.addPressure(pressure, i);
+                    lastPressures[i] = pressure;
+                    hasData = true;
+                }
+            }
+        }
+    }
+
+    for (int i = 1; i <= 4; i++) {
+        QString sensorAttr = QString("sensor%1").arg(i);
+
+        if (attrs.hasAttribute(sensorAttr)) {
+            QString sensorStr = attrs.value(sensorAttr).toString();
+            QRegularExpression sensorRe("(\\d+\\.?\\d*)\\s+bar");
+            QRegularExpressionMatch match = sensorRe.match(sensorStr);
+
+            if (match.hasMatch()) {
+                double sensorValue = match.captured(1).toDouble();
+                point.addPO2Sensor(sensorValue, i - 1);
+                lastPO2Sensors[i - 1] = sensorValue;
+                m_currentDiveHasCcrCues = true;
+                hasData = true;
+            } else {
+                bool ok;
+                double sensorValue = sensorStr.toDouble(&ok);
+                if (ok) {
+                    point.addPO2Sensor(sensorValue, i - 1);
+                    lastPO2Sensors[i - 1] = sensorValue;
+                    m_currentDiveHasCcrCues = true;
+                    hasData = true;
+                }
+            }
+        }
+    }
+
+    for (auto it = lastPO2Sensors.begin(); it != lastPO2Sensors.end(); ++it) {
+        int sensorIndex = it.key();
+        double lastValue = it.value();
+
+        bool sensorSet = attrs.hasAttribute(QString("sensor%1").arg(sensorIndex + 1));
+
+        if (!sensorSet && lastValue > 0.0) {
+            point.addPO2Sensor(lastValue, sensorIndex);
+        }
+    }
+
+    for (int i = 0; i < dive->cylinderCount(); i++) {
+        bool pressureSet = false;
+        if (i == 0) {
+            pressureSet = attrs.hasAttribute("pressure") || attrs.hasAttribute("pressure0");
+        } else {
+            pressureSet = attrs.hasAttribute(QString("pressure%1").arg(i));
+        }
+
+        if (!pressureSet && lastPressures.contains(i)) {
+            point.addPressure(lastPressures[i], i);
+        }
+    }
+
+    if (attrs.hasAttribute("in_deco")) {
+        QString decoStr = attrs.value("in_deco").toString();
+        inDeco = (decoStr == "1" || decoStr.toLower() == "true");
+    }
+
+    if (attrs.hasAttribute("tts")) {
+        QString ttsStr = attrs.value("tts").toString();
+        QRegularExpression ttsRe("(\\d+):(\\d+)\\s+min");
+        QRegularExpressionMatch match = ttsRe.match(ttsStr);
+
+        if (match.hasMatch()) {
+            int minutes = match.captured(1).toInt();
+            int seconds = match.captured(2).toInt();
+            point.tts = minutes + seconds / 60.0;
+            lastTTS = point.tts;
+            hasData = true;
+        } else {
+            bool ok;
+            double tts = ttsStr.toDouble(&ok);
+            if (ok) {
+                point.tts = tts;
+                lastTTS = tts;
+                hasData = true;
+            }
+        }
+    } else {
+        if (lastTTS > 0.0) {
+            point.tts = lastTTS;
+        }
+    }
+
+    if (attrs.hasAttribute("ndl")) {
+        QString ndlStr = attrs.value("ndl").toString();
+        QRegularExpression ndlRe("(\\d+):(\\d+)\\s+min");
+        QRegularExpressionMatch match = ndlRe.match(ndlStr);
+
+        if (match.hasMatch()) {
+            int minutes = match.captured(1).toInt();
+            int seconds = match.captured(2).toInt();
+            point.ndl = minutes + seconds / 60.0;
+            lastNDL = point.ndl;
+            hasData = true;
+        } else {
+            bool ok;
+            double ndl = ndlStr.toDouble(&ok);
+            if (ok) {
+                point.ndl = ndl;
+                lastNDL = ndl;
+                hasData = true;
+            }
+        }
+    } else {
+        if (lastNDL >= 0.0) {
+            point.ndl = lastNDL;
+        }
+    }
+
+    if (inDeco) {
+        point.ndl = 0.0;
+        lastNDL = 0.0;
+
+        if (point.tts <= 0.0 && lastTTS > 0.0) {
+            point.tts = lastTTS;
+        } else if (point.tts <= 0.0) {
+            point.tts = 1.0;
+            lastTTS = 1.0;
+        }
+    }
+
+    if (attrs.hasAttribute("stopdepth")) {
+        QString stopDepthStr = attrs.value("stopdepth").toString();
+        QRegularExpression stopDepthRe("(\\d+\\.?\\d*)\\s+m");
+        QRegularExpressionMatch match = stopDepthRe.match(stopDepthStr);
+
+        if (match.hasMatch()) {
+            point.ceiling = match.captured(1).toDouble();
+            m_lastCeiling = point.ceiling;
+            qDebug() << "Parsed stopdepth:" << point.ceiling << "m for time:" << point.timestamp;
+        } else {
+            bool ok;
+            double stopDepth = stopDepthStr.toDouble(&ok);
+            if (ok) {
+                point.ceiling = stopDepth;
+                m_lastCeiling = point.ceiling;
+                qDebug() << "Parsed stopdepth (numeric):" << point.ceiling << "m for time:" << point.timestamp;
+            }
+        }
+    } else {
+        point.ceiling = m_lastCeiling;
+    }
+
+    if (hasData) {
+        static int sampleCount = 0;
+        sampleCount++;
+
+        if (sampleCount <= 5 || sampleCount % 20 == 0) {
+            qDebug() << "Sample #" << sampleCount
+                     << "time=" << point.timestamp
+                     << "depth=" << point.depth
+                     << "temp=" << point.temperature << "(lastTemp=" << lastTemperature << ")"
+                     << "ndl=" << point.ndl << "(lastNDL=" << lastNDL << ")"
+                     << "tts=" << point.tts << "(lastTTS=" << lastTTS << ")"
+                     << "in_deco=" << inDeco;
+            for (int i = 0; i < point.tankCount(); i++) {
+                qDebug() << "  Tank" << i << "pressure=" << point.getPressure(i)
+                         << "(last=" << lastPressures.value(i, 0.0) << ")";
+            }
+            for (int i = 0; i < point.po2SensorCount(); i++) {
+                qDebug() << "  Sensor" << (i + 1) << "PO2=" << point.getPO2Sensor(i)
+                         << "(last=" << lastPO2Sensors.value(i, 0.0) << ")";
+            }
+            if (point.po2SensorCount() > 0) {
+                qDebug() << "  Composite PO2=" << point.getCompositePO2();
+            }
+        }
+
+        dive->addDataPoint(point);
+    }
+
+    while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("sample"))) {
+        xml.readNext();
+        if (xml.atEnd()) break;
+    }
+}
+
+void SubsurfaceParser::parseDiveSites(QXmlStreamReader &xml)
+{
+    qDebug() << "Parsing divesites element";
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+
+        if (xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("divesites")) {
+            break;
+        }
+
+        if (xml.tokenType() == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("site")) {
+            QXmlStreamAttributes attrs = xml.attributes();
+            DiveSite site;
+
+            if (attrs.hasAttribute("uuid")) {
+                site.uuid = attrs.value("uuid").toString();
+            }
+
+            if (attrs.hasAttribute("name")) {
+                site.name = attrs.value("name").toString();
+            }
+
+            if (attrs.hasAttribute("gps")) {
+                site.gps = attrs.value("gps").toString();
+            }
+
+            if (attrs.hasAttribute("description")) {
+                site.description = attrs.value("description").toString();
+            }
+
+            if (!site.uuid.isEmpty()) {
+                m_diveSites[site.uuid] = site;
+                qDebug() << "Parsed dive site:" << site.name << "UUID:" << site.uuid;
+            }
+
+            while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("site"))) {
+                xml.readNext();
+                if (xml.atEnd()) break;
+            }
+        }
+    }
+
+    qDebug() << "Finished parsing divesites, found" << m_diveSites.size() << "sites";
+}

--- a/src/core/format_parsers/uddf_parser.cpp
+++ b/src/core/format_parsers/uddf_parser.cpp
@@ -1,0 +1,781 @@
+#include "include/core/format_parsers/uddf_parser.h"
+
+#include <QDebug>
+#include <QSet>
+#include <QStringList>
+
+#include <cmath>
+
+#include "include/core/format_parsers/parse_utils.h"
+
+UDDFParser::UDDFParser() = default;
+
+bool UDDFParser::canParse(QFile &file) const
+{
+    const qint64 originalPos = file.pos();
+    file.seek(0);
+
+    QXmlStreamReader xml(&file);
+    bool result = false;
+    while (!xml.atEnd() && !xml.hasError()) {
+        if (xml.readNext() == QXmlStreamReader::StartElement) {
+            result = (xml.name() == QStringLiteral("uddf"));
+            break;
+        }
+    }
+
+    file.seek(originalPos);
+    return result;
+}
+
+void UDDFParser::resetState()
+{
+    m_mixes.clear();
+    m_diveSites.clear();
+    m_mixToFirstTank.clear();
+    m_currentDiveCcrSeen = false;
+    m_currentDiveOcSeen = false;
+}
+
+QList<DiveData *> UDDFParser::parse(QFile &file, int specificDive, QString &errorOut)
+{
+    QList<DiveData *> result;
+
+    file.seek(0);
+    resetState();
+
+    QXmlStreamReader xml(&file);
+    bool foundSpecific = false;
+
+    while (!xml.atEnd() && !xml.hasError()) {
+        if (xml.readNext() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        const auto name = xml.name();
+        if (name == QStringLiteral("gasdefinitions")) {
+            parseGasDefinitions(xml);
+        } else if (name == QStringLiteral("divesite")) {
+            parseDiveSiteContainer(xml);
+        } else if (name == QStringLiteral("profiledata")) {
+            parseProfileData(xml, result, specificDive, foundSpecific);
+            if (specificDive != -1 && foundSpecific) {
+                break;
+            }
+        }
+    }
+
+    if (xml.hasError()) {
+        errorOut = QStringLiteral("UDDF parsing error: %1").arg(xml.errorString());
+        qDebug() << "UDDF parsing error:" << xml.errorString();
+        qDeleteAll(result);
+        result.clear();
+        return result;
+    }
+
+    qDebug() << "Finished parsing UDDF file, found" << result.size() << "dives";
+    return result;
+}
+
+QList<QString> UDDFParser::listDives(QFile &file, QString &errorOut)
+{
+    QList<QString> result;
+
+    file.seek(0);
+    QXmlStreamReader xml(&file);
+
+    QMap<QString, QString> siteNames; // id -> name (lightweight, only for listing)
+
+    while (!xml.atEnd() && !xml.hasError()) {
+        if (xml.readNext() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        if (xml.name() == QStringLiteral("site")) {
+            QString siteId = xml.attributes().value(QStringLiteral("id")).toString();
+            QString siteName;
+            while (!xml.atEnd()) {
+                xml.readNext();
+                if (xml.tokenType() == QXmlStreamReader::EndElement
+                    && xml.name() == QStringLiteral("site")) {
+                    break;
+                }
+                if (xml.tokenType() == QXmlStreamReader::StartElement
+                    && xml.name() == QStringLiteral("name")
+                    && siteName.isEmpty()) {
+                    siteName = xml.readElementText();
+                }
+            }
+            if (!siteId.isEmpty()) {
+                siteNames.insert(siteId, siteName);
+            }
+        } else if (xml.name() == QStringLiteral("dive")) {
+            QString diveNumber;
+            QString datetime;
+            QString siteRef;
+
+            while (!xml.atEnd()) {
+                xml.readNext();
+                if (xml.tokenType() == QXmlStreamReader::EndElement
+                    && xml.name() == QStringLiteral("dive")) {
+                    break;
+                }
+                if (xml.tokenType() == QXmlStreamReader::StartElement) {
+                    if (xml.name() == QStringLiteral("divenumber")) {
+                        diveNumber = xml.readElementText();
+                    } else if (xml.name() == QStringLiteral("datetime")) {
+                        datetime = xml.readElementText();
+                    } else if (xml.name() == QStringLiteral("link") && siteRef.isEmpty()) {
+                        const QString ref = xml.attributes().value(QStringLiteral("ref")).toString();
+                        if (siteNames.contains(ref)) {
+                            siteRef = ref;
+                        }
+                    } else if (xml.name() == QStringLiteral("samples")
+                               || xml.name() == QStringLiteral("informationafterdive")) {
+                        // We have everything we need — skip the rest of the dive cheaply.
+                        xml.skipCurrentElement();
+                    }
+                }
+            }
+
+            QString entry;
+            if (!diveNumber.isEmpty()) {
+                entry = QStringLiteral("Dive #%1").arg(diveNumber);
+            } else {
+                entry = QStringLiteral("Dive");
+            }
+            if (!datetime.isEmpty()) {
+                const QDateTime dt = parse_utils::parseISO8601(datetime);
+                if (dt.isValid()) {
+                    entry += " - " + dt.toString(QStringLiteral("yyyy-MM-dd hh:mm:ss"));
+                } else {
+                    entry += " - " + datetime;
+                }
+            }
+            if (!siteRef.isEmpty()) {
+                const QString name = siteNames.value(siteRef);
+                if (!name.isEmpty()) {
+                    entry += " at " + name;
+                }
+            }
+            result.append(entry);
+        }
+    }
+
+    if (xml.hasError()) {
+        errorOut = QStringLiteral("UDDF parsing error: %1").arg(xml.errorString());
+        result.clear();
+    }
+
+    return result;
+}
+
+void UDDFParser::parseGasDefinitions(QXmlStreamReader &xml)
+{
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("gasdefinitions")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+        if (xml.name() != QStringLiteral("mix")) {
+            continue;
+        }
+
+        const QString mixId = xml.attributes().value(QStringLiteral("id")).toString();
+        GasMix mix;
+
+        while (!xml.atEnd()) {
+            xml.readNext();
+            if (xml.tokenType() == QXmlStreamReader::EndElement
+                && xml.name() == QStringLiteral("mix")) {
+                break;
+            }
+            if (xml.tokenType() != QXmlStreamReader::StartElement) {
+                continue;
+            }
+            if (xml.name() == QStringLiteral("name")) {
+                mix.name = xml.readElementText();
+            } else if (xml.name() == QStringLiteral("o2")) {
+                const double frac = parse_utils::parseLocaleDouble(xml.readElementText());
+                if (!std::isnan(frac)) {
+                    mix.o2Percent = frac * 100.0;
+                }
+            } else if (xml.name() == QStringLiteral("he")) {
+                const double frac = parse_utils::parseLocaleDouble(xml.readElementText());
+                if (!std::isnan(frac)) {
+                    mix.hePercent = frac * 100.0;
+                }
+            }
+        }
+
+        if (!mixId.isEmpty()) {
+            m_mixes.insert(mixId, mix);
+            qDebug() << "Parsed UDDF mix" << mixId
+                     << "O2:" << mix.o2Percent << "% He:" << mix.hePercent << "%";
+        }
+    }
+}
+
+void UDDFParser::parseDiveSiteContainer(QXmlStreamReader &xml)
+{
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("divesite")) {
+            break;
+        }
+        if (xml.tokenType() == QXmlStreamReader::StartElement
+            && xml.name() == QStringLiteral("site")) {
+            parseDiveSiteEntry(xml);
+        }
+    }
+}
+
+void UDDFParser::parseDiveSiteEntry(QXmlStreamReader &xml)
+{
+    DiveSite site;
+    site.id = xml.attributes().value(QStringLiteral("id")).toString();
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("site")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+        if (xml.name() == QStringLiteral("name")) {
+            site.name = xml.readElementText();
+        } else if (xml.name() == QStringLiteral("geography")) {
+            while (!xml.atEnd()) {
+                xml.readNext();
+                if (xml.tokenType() == QXmlStreamReader::EndElement
+                    && xml.name() == QStringLiteral("geography")) {
+                    break;
+                }
+                if (xml.tokenType() == QXmlStreamReader::StartElement
+                    && xml.name() == QStringLiteral("location")) {
+                    site.location = xml.readElementText();
+                }
+            }
+        }
+    }
+
+    if (!site.id.isEmpty()) {
+        m_diveSites.insert(site.id, site);
+        qDebug() << "Parsed UDDF dive site" << site.id << ":" << site.name;
+    }
+}
+
+void UDDFParser::parseProfileData(QXmlStreamReader &xml,
+                                  QList<DiveData *> &out,
+                                  int specificDive,
+                                  bool &foundSpecific)
+{
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("profiledata")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        if (xml.name() == QStringLiteral("repetitiongroup")) {
+            // Walk into the repetition group.
+            continue;
+        }
+
+        if (xml.name() == QStringLiteral("dive")) {
+            DiveData *dive = parseDiveElement(xml);
+            if (!dive) {
+                continue;
+            }
+
+            if (specificDive != -1 && dive->diveNumber() != specificDive) {
+                delete dive;
+                continue;
+            }
+
+            out.append(dive);
+
+            if (specificDive != -1) {
+                foundSpecific = true;
+                return;
+            }
+        }
+    }
+}
+
+DiveData *UDDFParser::parseDiveElement(QXmlStreamReader &xml)
+{
+    DiveData *dive = new DiveData();
+
+    // Per-dive state reset.
+    m_mixToFirstTank.clear();
+    m_currentDiveCcrSeen = false;
+    m_currentDiveOcSeen = false;
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("dive")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        const auto name = xml.name();
+        if (name == QStringLiteral("informationbeforedive")) {
+            parseInformationBeforeDive(xml, dive);
+        } else if (name == QStringLiteral("tankdata")) {
+            parseTankData(xml, dive);
+        } else if (name == QStringLiteral("samples")) {
+            parseSamples(xml, dive);
+        } else {
+            // Skip everything else — informationafterdive, applieddivedurationformula, etc.
+            xml.skipCurrentElement();
+        }
+    }
+
+    if (dive->diveName().isEmpty() && dive->diveNumber() > 0) {
+        dive->setDiveName(QStringLiteral("Dive #%1").arg(dive->diveNumber()));
+    } else if (dive->diveName().isEmpty()) {
+        dive->setDiveName(QStringLiteral("Dive"));
+    }
+
+    // Empty-dive fallback: if we have cylinders but no waypoints (e.g. a
+    // header-only UDDF), seed a single point at t=0 with each cylinder's
+    // initial pressure so downstream rendering doesn't see a totally empty
+    // profile. Mirrors the SSRF parser's identical safeguard.
+    if (dive->allDataPoints().isEmpty() && dive->cylinderCount() > 0) {
+        DiveDataPoint initialPoint;
+        initialPoint.timestamp = 0.0;
+
+        for (int i = 0; i < dive->cylinderCount(); i++) {
+            const CylinderInfo &cyl = dive->cylinderInfo(i);
+            double initialPressure = 0.0;
+            if (cyl.startPressure > 0.0) {
+                initialPressure = cyl.startPressure;
+            } else if (cyl.workPressure > 0.0) {
+                initialPressure = cyl.workPressure;
+            }
+            if (initialPressure > 0.0) {
+                initialPoint.addPressure(initialPressure, i);
+            }
+        }
+
+        dive->addDataPoint(initialPoint);
+    }
+
+    if (dive->diveMode() == DiveData::UnknownMode) {
+        if (m_currentDiveCcrSeen) {
+            dive->setDiveMode(DiveData::ClosedCircuit);
+        } else if (m_currentDiveOcSeen) {
+            dive->setDiveMode(DiveData::OpenCircuit);
+        }
+    }
+
+    qDebug() << "Finished parsing UDDF dive" << dive->diveName()
+             << "data points:" << dive->allDataPoints().size()
+             << "cylinders:" << dive->cylinderCount()
+             << "diveMode:" << dive->diveMode();
+    return dive;
+}
+
+void UDDFParser::parseInformationBeforeDive(QXmlStreamReader &xml, DiveData *dive)
+{
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("informationbeforedive")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        const auto name = xml.name();
+        if (name == QStringLiteral("divenumber")) {
+            bool ok = false;
+            const int n = xml.readElementText().toInt(&ok);
+            if (ok) {
+                dive->setDiveNumber(n);
+            }
+        } else if (name == QStringLiteral("datetime")) {
+            const QDateTime dt = parse_utils::parseISO8601(xml.readElementText());
+            if (dt.isValid()) {
+                dive->setStartTime(dt);
+            }
+        } else if (name == QStringLiteral("link")) {
+            const QString ref = xml.attributes().value(QStringLiteral("ref")).toString();
+            if (m_diveSites.contains(ref)) {
+                const DiveSite &site = m_diveSites.value(ref);
+                dive->setDiveSiteId(ref);
+                if (!site.name.isEmpty()) {
+                    dive->setDiveSiteName(site.name);
+                    if (dive->location().isEmpty()) {
+                        dive->setLocation(site.name);
+                    }
+                }
+            }
+            xml.skipCurrentElement();
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+}
+
+void UDDFParser::parseTankData(QXmlStreamReader &xml, DiveData *dive)
+{
+    CylinderInfo cylinder;
+    QString mixRef;
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("tankdata")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        const auto name = xml.name();
+        if (name == QStringLiteral("link")) {
+            mixRef = xml.attributes().value(QStringLiteral("ref")).toString();
+            xml.skipCurrentElement();
+        } else if (name == QStringLiteral("tankvolume")) {
+            // UDDF: cubic meters at 1 atm — convert to liters.
+            const double m3 = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(m3)) {
+                cylinder.size = m3 * 1000.0;
+            }
+        } else if (name == QStringLiteral("tankpressurebegin")) {
+            const double pa = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(pa)) {
+                cylinder.startPressure = parse_utils::pascalToBar(pa);
+            }
+        } else if (name == QStringLiteral("tankpressureend")) {
+            const double pa = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(pa)) {
+                cylinder.endPressure = parse_utils::pascalToBar(pa);
+            }
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+
+    if (!mixRef.isEmpty() && m_mixes.contains(mixRef)) {
+        const GasMix &mix = m_mixes.value(mixRef);
+        cylinder.o2Percent = mix.o2Percent;
+        cylinder.hePercent = mix.hePercent;
+        if (cylinder.description.isEmpty() && !mix.name.isEmpty()) {
+            cylinder.description = mix.name;
+        }
+    }
+
+    const int newIndex = dive->cylinderCount();
+    dive->addCylinder(cylinder);
+
+    if (!mixRef.isEmpty() && !m_mixToFirstTank.contains(mixRef)) {
+        m_mixToFirstTank.insert(mixRef, newIndex);
+    }
+
+    qDebug() << "Parsed UDDF tank index" << newIndex
+             << "mix:" << mixRef
+             << "size:" << cylinder.size << "L"
+             << "start:" << cylinder.startPressure << "bar"
+             << "end:" << cylinder.endPressure << "bar";
+}
+
+void UDDFParser::parseSamples(QXmlStreamReader &xml, DiveData *dive)
+{
+    // UDDF waypoints record changes only — values not present in a waypoint
+    // should be inherited from the previous one. We carry forward temperature,
+    // NDL, TTS, ceiling, per-tank pressure, and per-sensor PO2 across
+    // waypoints, mirroring the SSRF parser's logic.
+    double lastTemperature = 0.0;
+    double lastNDL = 0.0;
+    double lastTTS = 0.0;
+    double lastCeiling = 0.0;
+    QMap<int, double> lastPressures;
+    QMap<int, double> lastPO2Sensors;
+    // Maps a <measuredpo2 ref="..."> identifier to its stable sensor index.
+    // First time a ref is seen it is assigned the next free index; subsequent
+    // waypoints reuse the same index even if sensors appear in a different
+    // order or some are omitted.
+    QMap<QString, int> po2SensorRefToIndex;
+
+    // Pre-seed lastPressures from each cylinder's start (or work) pressure,
+    // so the first waypoints carry sensible values even before any
+    // <tankpressure> shows up in the stream. Mirrors the SSRF parser's
+    // m_initialCylinderPressures behaviour.
+    for (int i = 0; i < dive->cylinderCount(); i++) {
+        const CylinderInfo &cyl = dive->cylinderInfo(i);
+        double initialPressure = 0.0;
+        if (cyl.startPressure > 0.0) {
+            initialPressure = cyl.startPressure;
+        } else if (cyl.workPressure > 0.0) {
+            initialPressure = cyl.workPressure;
+        }
+        if (initialPressure > 0.0) {
+            lastPressures[i] = initialPressure;
+        }
+    }
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("samples")) {
+            break;
+        }
+        if (xml.tokenType() == QXmlStreamReader::StartElement
+            && xml.name() == QStringLiteral("waypoint")) {
+            parseWaypoint(xml, dive, lastTemperature, lastNDL, lastTTS, lastCeiling,
+                          lastPressures, lastPO2Sensors, po2SensorRefToIndex);
+        }
+    }
+}
+
+void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
+                               DiveData *dive,
+                               double &lastTemperature,
+                               double &lastNDL,
+                               double &lastTTS,
+                               double &lastCeiling,
+                               QMap<int, double> &lastPressures,
+                               QMap<int, double> &lastPO2Sensors,
+                               QMap<QString, int> &po2SensorRefToIndex)
+{
+    DiveDataPoint point;
+    bool hasTimestamp = false;
+
+    // Inherit the last known temperature; <temperature> below overrides it
+    // when the waypoint actually carries a fresh reading.
+    if (lastTemperature > 0.0) {
+        point.temperature = lastTemperature;
+    }
+
+    // Track which tanks / sensors were explicitly populated by this waypoint
+    // so we know which ones to fill from the carry-forward maps at the end.
+    QSet<int> tanksSetThisWaypoint;
+    QSet<int> sensorsSetThisWaypoint;
+
+    // Defer <switchmix> until we have the final timestamp — the schema does
+    // not pin element order within a waypoint.
+    QStringList pendingSwitchMixRefs;
+
+    // <nodecotime> and <decostop> deco state. <decostop> can appear multiple
+    // times per waypoint to describe the full ascent profile, so we accumulate
+    // across the parse loop and only apply the result at the end.
+    bool ndlSetThisWaypoint = false;
+    double waypointNDL = 0.0;
+    int mandatoryDecostopCount = 0;
+    double waypointDecoCeiling = 0.0;        // metres, deepest mandatory stop
+    double waypointTotalDecoDuration = 0.0;  // seconds, summed across mandatory stops
+
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("waypoint")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        const auto name = xml.name();
+        if (name == QStringLiteral("divetime")) {
+            const double t = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(t)) {
+                point.timestamp = t;
+                hasTimestamp = true;
+            }
+        } else if (name == QStringLiteral("depth")) {
+            const double d = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(d)) {
+                point.depth = d;
+            }
+        } else if (name == QStringLiteral("temperature")) {
+            const double k = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(k)) {
+                point.temperature = parse_utils::kelvinToCelsius(k);
+                lastTemperature = point.temperature;
+            }
+        } else if (name == QStringLiteral("switchmix")) {
+            pendingSwitchMixRefs.append(xml.attributes().value(QStringLiteral("ref")).toString());
+            xml.skipCurrentElement();
+        } else if (name == QStringLiteral("tankpressure")) {
+            const QString ref = xml.attributes().value(QStringLiteral("ref")).toString();
+            int tankIdx = ref.isEmpty() ? 0 : firstTankIndexForMix(ref);
+            if (tankIdx < 0) {
+                tankIdx = 0;
+            }
+            const double pa = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(pa)) {
+                const double bar = parse_utils::pascalToBar(pa);
+                point.addPressure(bar, tankIdx);
+                lastPressures[tankIdx] = bar;
+                tanksSetThisWaypoint.insert(tankIdx);
+            }
+        } else if (name == QStringLiteral("measuredpo2")) {
+            // <measuredpo2 ref="o2sensor_1">1.22e5</measuredpo2> — value is in
+            // Pascal (1.22e5 Pa = 1.22 bar). The `ref` attribute identifies
+            // which physical O2 sensor produced the reading; we map each
+            // distinct ref to a stable sensor index that survives across
+            // waypoints regardless of element ordering or omissions.
+            const QString ref = xml.attributes().value(QStringLiteral("ref")).toString();
+            const double pa = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(pa)) {
+                int sensorIndex;
+                if (ref.isEmpty()) {
+                    // Spec violation: ref is supposed to be mandatory. Fall
+                    // back to a positional index so we don't drop the reading.
+                    sensorIndex = point.po2SensorCount();
+                } else if (po2SensorRefToIndex.contains(ref)) {
+                    sensorIndex = po2SensorRefToIndex.value(ref);
+                } else {
+                    sensorIndex = po2SensorRefToIndex.size();
+                    po2SensorRefToIndex.insert(ref, sensorIndex);
+                }
+                const double bar = parse_utils::pascalToBar(pa);
+                point.addPO2Sensor(bar, sensorIndex);
+                lastPO2Sensors[sensorIndex] = bar;
+                sensorsSetThisWaypoint.insert(sensorIndex);
+                m_currentDiveCcrSeen = true;
+            }
+        } else if (name == QStringLiteral("nodecotime")) {
+            // <nodecotime> is in seconds; DiveDataPoint::ndl is in minutes.
+            const double seconds = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(seconds) && seconds >= 0.0) {
+                waypointNDL = seconds / 60.0;
+                ndlSetThisWaypoint = true;
+            }
+        } else if (name == QStringLiteral("decostop")) {
+            // Schema: <decostop kind="mandatory|safety" decodepth="..." duration="..."/>.
+            // Multiple decostops can appear per waypoint to describe the full
+            // ascent: deepest decodepth = current ceiling, sum of durations = TTS.
+            // Only mandatory stops contribute to deco state — safety stops are
+            // voluntary and don't pin a ceiling.
+            const auto attrs = xml.attributes();
+            const QString kind = attrs.value(QStringLiteral("kind")).toString().toLower();
+            if (kind.isEmpty() || kind == QLatin1String("mandatory")) {
+                const double decodepth = parse_utils::parseLocaleDouble(
+                    attrs.value(QStringLiteral("decodepth")));
+                const double duration = parse_utils::parseLocaleDouble(
+                    attrs.value(QStringLiteral("duration")));
+                if (!std::isnan(decodepth) && decodepth > waypointDecoCeiling) {
+                    waypointDecoCeiling = decodepth;
+                }
+                if (!std::isnan(duration) && duration > 0.0) {
+                    waypointTotalDecoDuration += duration;
+                }
+                mandatoryDecostopCount++;
+            }
+            xml.skipCurrentElement();
+        } else if (name == QStringLiteral("divemode")) {
+            const QString kind = xml.attributes().value(QStringLiteral("kind")).toString().toLower();
+            if (kind == QLatin1String("closedcircuit")) {
+                if (dive->diveMode() == DiveData::UnknownMode) {
+                    dive->setDiveMode(DiveData::ClosedCircuit);
+                }
+                m_currentDiveCcrSeen = true;
+            } else if (kind == QLatin1String("opencircuit")) {
+                if (dive->diveMode() == DiveData::UnknownMode) {
+                    dive->setDiveMode(DiveData::OpenCircuit);
+                }
+                m_currentDiveOcSeen = true;
+            }
+            xml.skipCurrentElement();
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+
+    // Resolve NDL / TTS / ceiling, mirroring the SSRF parser's behaviour:
+    //  - Mandatory <decostop>s present → in deco. NDL = 0; ceiling = deepest
+    //    decodepth seen; TTS = sum of durations (or fallback to lastTTS, or
+    //    1.0 minimum, matching SSRF).
+    //  - Else if <nodecotime> present → NDL = nodecotime; carry TTS / ceiling
+    //    forward from previous waypoints.
+    //  - Else → carry NDL, TTS, ceiling forward.
+    if (mandatoryDecostopCount > 0) {
+        point.ndl = 0.0;
+        lastNDL = 0.0;
+
+        if (waypointTotalDecoDuration > 0.0) {
+            point.tts = waypointTotalDecoDuration / 60.0;
+            lastTTS = point.tts;
+        } else if (lastTTS > 0.0) {
+            point.tts = lastTTS;
+        } else {
+            point.tts = 1.0;
+            lastTTS = 1.0;
+        }
+
+        point.ceiling = waypointDecoCeiling;
+        lastCeiling = point.ceiling;
+    } else if (ndlSetThisWaypoint) {
+        point.ndl = waypointNDL;
+        lastNDL = point.ndl;
+        if (lastTTS > 0.0) {
+            point.tts = lastTTS;
+        }
+        point.ceiling = lastCeiling;
+    } else {
+        if (lastNDL >= 0.0) {
+            point.ndl = lastNDL;
+        }
+        if (lastTTS > 0.0) {
+            point.tts = lastTTS;
+        }
+        point.ceiling = lastCeiling;
+    }
+
+    // Apply pending gas switches now that the timestamp is final.
+    for (const QString &ref : pendingSwitchMixRefs) {
+        const int tankIdx = firstTankIndexForMix(ref);
+        if (tankIdx >= 0) {
+            dive->addGasSwitch(point.timestamp, tankIdx);
+        } else {
+            qDebug() << "UDDF switchmix references unknown mix:" << ref;
+        }
+    }
+
+    // Carry forward any PO2 sensor values that this waypoint did not override.
+    for (auto it = lastPO2Sensors.cbegin(); it != lastPO2Sensors.cend(); ++it) {
+        const int sensorIndex = it.key();
+        const double lastValue = it.value();
+        if (!sensorsSetThisWaypoint.contains(sensorIndex) && lastValue > 0.0) {
+            point.addPO2Sensor(lastValue, sensorIndex);
+        }
+    }
+
+    // Apply last known pressures for ALL declared cylinders, so every data
+    // point has a pressure value for every cylinder — same invariant as SSRF.
+    for (int i = 0; i < dive->cylinderCount(); i++) {
+        if (!tanksSetThisWaypoint.contains(i) && lastPressures.contains(i)) {
+            point.addPressure(lastPressures.value(i), i);
+        }
+    }
+
+    if (hasTimestamp) {
+        dive->addDataPoint(point);
+    }
+}
+
+int UDDFParser::firstTankIndexForMix(const QString &mixId) const
+{
+    if (mixId.isEmpty()) {
+        return -1;
+    }
+    return m_mixToFirstTank.value(mixId, -1);
+}

--- a/src/core/log_parser.cpp
+++ b/src/core/log_parser.cpp
@@ -1,31 +1,45 @@
 #include "include/core/log_parser.h"
+
+#include <QDebug>
 #include <QFile>
 #include <QFileInfo>
-#include <QXmlStreamReader>
-#include <QDateTime>
-#include <QRegularExpression>
-#include <QDebug>
+
+#include "include/core/format_parsers/subsurface_parser.h"
+#include "include/core/format_parsers/uddf_parser.h"
 
 LogParser::LogParser(QObject *parent)
     : QObject(parent)
     , m_busy(false)
-    , m_lastCeiling(0.0)
 {
+    m_parsers.push_back(std::make_unique<SubsurfaceParser>());
+    m_parsers.push_back(std::make_unique<UDDFParser>());
+}
+
+LogParser::~LogParser() = default;
+
+IDiveLogFormatParser *LogParser::selectParser(QFile &file)
+{
+    for (const auto &parser : m_parsers) {
+        if (parser->canParse(file)) {
+            return parser.get();
+        }
+    }
+    return nullptr;
 }
 
 bool LogParser::importFile(const QString &filePath)
 {
     qDebug() << "LogParser::importFile called with path:" << filePath;
-    
+
     if (m_busy) {
         m_lastError = tr("Already processing a file");
         emit errorOccurred(m_lastError);
         return false;
     }
-    
+
     m_busy = true;
     emit busyChanged();
-    
+
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         m_lastError = tr("Could not open file: %1 - Error: %2").arg(filePath).arg(file.errorString());
@@ -35,48 +49,45 @@ bool LogParser::importFile(const QString &filePath)
         emit busyChanged();
         return false;
     }
-    
-    QList<DiveData*> dives;
-    bool success = false;
-    
-    // Check file extension to determine format
-    QFileInfo fileInfo(filePath);
-    QString ext = fileInfo.suffix().toLower();
-    
-    qDebug() << "File extension:" << ext;
-    
-    if (ext == "xml" || ext == "ssrf") {
-        // Make sure we're at the beginning of the file
-        file.seek(0);
-        qDebug() << "Starting to parse Subsurface XML file";
-        success = parseSubsurfaceXML(file, dives);
+
+    IDiveLogFormatParser *parser = selectParser(file);
+    if (!parser) {
+        m_lastError = tr("Unsupported file format: %1").arg(QFileInfo(filePath).fileName());
+        qDebug() << "Unsupported file format:" << filePath;
+        emit errorOccurred(m_lastError);
+        file.close();
+        m_busy = false;
+        emit busyChanged();
+        return false;
+    }
+
+    qDebug() << "Selected parser:" << parser->formatName();
+    QString parserError;
+    QList<DiveData *> dives = parser->parse(file, -1, parserError);
+    file.close();
+
+    bool success = parserError.isEmpty();
+    if (!success) {
+        m_lastError = parserError;
+        emit errorOccurred(m_lastError);
+        qDeleteAll(dives);
+        dives.clear();
+    } else if (dives.size() == 1) {
+        qDebug() << "Emitting diveImported signal for dive:" << dives.first()->diveName();
+        emit diveImported(dives.first());
+    } else if (dives.size() > 1) {
+        qDebug() << "Emitting multipleImported signal with" << dives.size() << "dives";
+        emit multipleImported(dives);
     } else {
-        m_lastError = tr("Unsupported file format: %1").arg(ext);
-        qDebug() << "Unsupported file format:" << ext;
+        m_lastError = tr("No dives found in file");
+        qDebug() << "No dives found in file";
         emit errorOccurred(m_lastError);
         success = false;
     }
-    
-    file.close();
-    
-    if (success) {
-        if (dives.size() == 1) {
-            qDebug() << "Emitting diveImported signal for dive:" << dives.first()->diveName();
-            emit diveImported(dives.first());
-        } else if (dives.size() > 1) {
-            qDebug() << "Emitting multipleImported signal with" << dives.size() << "dives";
-            emit multipleImported(dives);
-        } else {
-            m_lastError = tr("No dives found in file");
-            qDebug() << "No dives found in file";
-            emit errorOccurred(m_lastError);
-            success = false;
-        }
-    }
-    
+
     m_busy = false;
     emit busyChanged();
-    
+
     return success;
 }
 
@@ -87,10 +98,10 @@ bool LogParser::importDive(const QString &filePath, int diveNumber)
         emit errorOccurred(m_lastError);
         return false;
     }
-    
+
     m_busy = true;
     emit busyChanged();
-    
+
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         m_lastError = tr("Could not open file: %1").arg(file.errorString());
@@ -99,51 +110,54 @@ bool LogParser::importDive(const QString &filePath, int diveNumber)
         emit busyChanged();
         return false;
     }
-    
-    QList<DiveData*> dives;
-    bool success = false;
-    
-    // Check file extension to determine format
-    QFileInfo fileInfo(filePath);
-    QString ext = fileInfo.suffix().toLower();
-    
-    if (ext == "xml" || ext == "ssrf") {
-        success = parseSubsurfaceXML(file, dives, diveNumber);
-    } else {
-        m_lastError = tr("Unsupported file format: %1").arg(ext);
+
+    IDiveLogFormatParser *parser = selectParser(file);
+    if (!parser) {
+        m_lastError = tr("Unsupported file format: %1").arg(QFileInfo(filePath).fileName());
         emit errorOccurred(m_lastError);
-        success = false;
+        file.close();
+        m_busy = false;
+        emit busyChanged();
+        return false;
     }
-    
+
+    QString parserError;
+    QList<DiveData *> dives = parser->parse(file, diveNumber, parserError);
     file.close();
-    
-    if (success && !dives.isEmpty()) {
+
+    bool success = parserError.isEmpty();
+    if (!success) {
+        m_lastError = parserError;
+        emit errorOccurred(m_lastError);
+        qDeleteAll(dives);
+        dives.clear();
+    } else if (!dives.isEmpty()) {
         emit diveImported(dives.first());
-    } else if (success) {
+    } else {
         m_lastError = tr("Dive number %1 not found in file").arg(diveNumber);
         emit errorOccurred(m_lastError);
         success = false;
     }
-    
+
     m_busy = false;
     emit busyChanged();
-    
+
     return success;
 }
 
 QList<QString> LogParser::getDiveList(const QString &filePath)
 {
     QList<QString> result;
-    
+
     if (m_busy) {
         m_lastError = tr("Already processing a file");
         emit errorOccurred(m_lastError);
         return result;
     }
-    
+
     m_busy = true;
     emit busyChanged();
-    
+
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         m_lastError = tr("Could not open file: %1").arg(file.errorString());
@@ -152,864 +166,29 @@ QList<QString> LogParser::getDiveList(const QString &filePath)
         emit busyChanged();
         return result;
     }
-    
-    // Check file extension to determine format
-    QFileInfo fileInfo(filePath);
-    QString ext = fileInfo.suffix().toLower();
-    
-    if (ext == "xml" || ext == "ssrf") {
-        QXmlStreamReader xml(&file);
-        
-        while (!xml.atEnd() && !xml.hasError()) {
-            QXmlStreamReader::TokenType token = xml.readNext();
-            
-            if (token == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("dive")) {
-                QString diveDate;
-                QString diveTime;
-                QString diveLocation;
-                
-                // Get dive number
-                QXmlStreamAttributes attrs = xml.attributes();
-                if (attrs.hasAttribute("number")) {
-                    QString number = attrs.value("number").toString();
-                    
-                    // Get date and time
-                    if (attrs.hasAttribute("date")) {
-                        diveDate = attrs.value("date").toString();
-                    }
-                    if (attrs.hasAttribute("time")) {
-                        diveTime = attrs.value("time").toString();
-                    }
-                    
-                    // Read dive location
-                    while (!xml.atEnd() && !(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("dive"))) {
-                        if (xml.tokenType() == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("location")) {
-                            diveLocation = xml.readElementText();
-                            break;
-                        }
-                        xml.readNext();
-                    }
-                    
-                    // Create the dive entry for the list
-                    QString entry = tr("Dive #%1").arg(number);
-                    if (!diveDate.isEmpty()) {
-                        entry += " - " + diveDate;
-                    }
-                    if (!diveTime.isEmpty()) {
-                        entry += " " + diveTime;
-                    }
-                    if (!diveLocation.isEmpty()) {
-                        entry += " at " + diveLocation;
-                    }
-                    
-                    result.append(entry);
-                }
-            }
-        }
-        
-        if (xml.hasError()) {
-            m_lastError = tr("XML parsing error: %1").arg(xml.errorString());
-            emit errorOccurred(m_lastError);
-            result.clear();
-        }
-    } else {
-        m_lastError = tr("Unsupported file format: %1").arg(ext);
+
+    IDiveLogFormatParser *parser = selectParser(file);
+    if (!parser) {
+        m_lastError = tr("Unsupported file format: %1").arg(QFileInfo(filePath).fileName());
         emit errorOccurred(m_lastError);
+        file.close();
+        m_busy = false;
+        emit busyChanged();
+        return result;
     }
-    
+
+    QString parserError;
+    result = parser->listDives(file, parserError);
     file.close();
-    
+
+    if (!parserError.isEmpty()) {
+        m_lastError = parserError;
+        emit errorOccurred(m_lastError);
+        result.clear();
+    }
+
     m_busy = false;
     emit busyChanged();
-    
+
     return result;
-}
-
-bool LogParser::parseSubsurfaceXML(QFile &file, QList<DiveData*> &result, int specificDive)
-{
-    qDebug() << "Starting to parse Subsurface XML file";
-    QXmlStreamReader xml(&file);
-    
-    // Clear dive sites for this file
-    m_diveSites.clear();
-    
-    while (!xml.atEnd() && !xml.hasError()) {
-        QXmlStreamReader::TokenType token = xml.readNext();
-        
-        if (token == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("divesites")) {
-            qDebug() << "Found divesites element";
-            parseDiveSites(xml);
-        } else if (token == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("dive")) {
-            qDebug() << "Found dive element";
-            // Check if we're looking for a specific dive
-            if (specificDive != -1) {
-                QXmlStreamAttributes attrs = xml.attributes();
-                if (attrs.hasAttribute("number")) {
-                    bool ok;
-                    int number = attrs.value("number").toInt(&ok);
-                    if (!ok || number != specificDive) {
-                        // Skip this dive and continue with the next one
-                        continue;
-                    }
-                }
-            }
-            
-            DiveData* dive = parseDiveElement(xml);
-            if (dive) {
-                qDebug() << "Successfully parsed dive:" << dive->diveName();
-                result.append(dive);
-                
-                // If we found the specific dive we were looking for, we can stop
-                if (specificDive != -1) {
-                    break;
-                }
-            }
-        }
-    }
-    
-    if (xml.hasError()) {
-        m_lastError = tr("XML parsing error: %1").arg(xml.errorString());
-        qDebug() << "XML parsing error:" << xml.errorString();
-        emit errorOccurred(m_lastError);
-        
-        // Clean up any dives we've created so far
-        qDeleteAll(result);
-        result.clear();
-        
-        return false;
-    }
-    
-    qDebug() << "Finished parsing XML file, found" << result.size() << "dives";
-    return true;
-}
-
-DiveData* LogParser::parseDiveElement(QXmlStreamReader &xml)
-{
-    // Create a new dive data object
-    DiveData* dive = new DiveData(this);
-    
-    // Reset the initial cylinder pressures map
-    m_initialCylinderPressures.clear();
-    m_gasSwitches.clear();
-    
-    // Parse dive attributes
-    QXmlStreamAttributes attrs = xml.attributes();
-    
-    // Get dive number and name
-    if (attrs.hasAttribute("number")) {
-        QString number = attrs.value("number").toString();
-        bool ok;
-        int diveNumber = number.toInt(&ok);
-        if (ok) {
-            dive->setDiveNumber(diveNumber);
-        }
-        dive->setDiveName(tr("Dive #%1").arg(number));
-    }
-    
-    // Get dive site ID and link to site info
-    if (attrs.hasAttribute("divesiteid")) {
-        QString siteId = attrs.value("divesiteid").toString();
-        dive->setDiveSiteId(siteId);
-        
-        // Look up the dive site name if available
-        if (m_diveSites.contains(siteId)) {
-            const DiveSite &site = m_diveSites[siteId];
-            dive->setDiveSiteName(site.name);
-            if (dive->location().isEmpty() && !site.name.isEmpty()) {
-                dive->setLocation(site.name);
-            }
-        }
-    }
-    
-    // Get date and time
-    QDateTime diveDateTime;
-    if (attrs.hasAttribute("date")) {
-        QString dateStr = attrs.value("date").toString();
-        if (attrs.hasAttribute("time")) {
-            QString timeStr = attrs.value("time").toString();
-            diveDateTime = QDateTime::fromString(dateStr + " " + timeStr, "yyyy-MM-dd hh:mm:ss");
-        } else {
-            diveDateTime = QDateTime::fromString(dateStr, "yyyy-MM-dd");
-        }
-        dive->setStartTime(diveDateTime);
-    }
-    
-    qDebug() << "Parsing dive element for" << dive->diveName();
-    
-    // Parse dive elements - continue until we reach the end of the dive element
-    int sampleCount = 0;  // Track how many samples we've parsed - ADDED THIS LINE
-    
-    // We need to continue reading until we hit the end of the dive element
-    while (!xml.atEnd()) {
-        xml.readNext();
-        
-        if (xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("dive")) {
-            break;
-        }
-        
-        if (xml.tokenType() == QXmlStreamReader::StartElement) {
-            QString elementName = xml.name().toString();
-            
-            if (elementName == "location") {
-                dive->setLocation(xml.readElementText());
-            } else if (elementName == "cylinder") {
-                // Parse cylinder information
-                parseCylinderElement(xml, dive);
-            } else if (elementName == "divecomputer") {
-                // In Subsurface, samples are inside the divecomputer element
-                // We need to process the divecomputer element without consuming its end tag
-                parseDiveComputerElement(xml, dive, sampleCount);
-            }
-        }
-    }
-    
-    // Ensure we have at least one dummy point with all cylinders initialized if no samples were found
-    if (dive->allDataPoints().isEmpty() && dive->cylinderCount() > 0) {
-        DiveDataPoint initialPoint;
-        initialPoint.timestamp = 0.0;
-        
-        // Initialize all cylinders with their default pressures
-        for (int i = 0; i < dive->cylinderCount(); i++) {
-            double initialPressure = m_initialCylinderPressures.value(i, 0.0);
-            if (initialPressure > 0.0) {
-                initialPoint.addPressure(initialPressure, i);
-            }
-        }
-        
-        dive->addDataPoint(initialPoint);
-    }
-    
-    m_diveDuration = dive->durationSeconds();
-
-    qDebug() << "Finished parsing dive element. Total data points:" << dive->allDataPoints().size();
-    return dive;
-}
-
-void LogParser::parseCylinderElement(QXmlStreamReader &xml, DiveData* dive)
-{
-    // Get cylinder attributes
-    QXmlStreamAttributes attrs = xml.attributes();
-    CylinderInfo cylinder;
-    
-    // Parse cylinder size
-    if (attrs.hasAttribute("size")) {
-        QString sizeStr = attrs.value("size").toString();
-        QRegularExpression sizeRe("(\\d+\\.?\\d*)\\s+l");
-        QRegularExpressionMatch match = sizeRe.match(sizeStr);
-        
-        if (match.hasMatch()) {
-            cylinder.size = match.captured(1).toDouble();
-        }
-    }
-    
-    // Parse working pressure
-    if (attrs.hasAttribute("workpressure")) {
-        QString pressureStr = attrs.value("workpressure").toString();
-        QRegularExpression pressureRe("(\\d+\\.?\\d*)\\s+bar");
-        QRegularExpressionMatch match = pressureRe.match(pressureStr);
-        
-        if (match.hasMatch()) {
-            cylinder.workPressure = match.captured(1).toDouble();
-        }
-    }
-    
-    // Parse description
-    if (attrs.hasAttribute("description")) {
-        cylinder.description = attrs.value("description").toString();
-    }
-    
-    // Parse O2 percentage
-    if (attrs.hasAttribute("o2")) {
-        QString o2Str = attrs.value("o2").toString();
-        QRegularExpression o2Re("(\\d+\\.?\\d*)\\s*%");
-        QRegularExpressionMatch match = o2Re.match(o2Str);
-        
-        if (match.hasMatch()) {
-            cylinder.o2Percent = match.captured(1).toDouble();
-        }
-    }
-    
-    // Parse Helium percentage for trimix
-    if (attrs.hasAttribute("he")) {
-        QString heStr = attrs.value("he").toString();
-        QRegularExpression heRe("(\\d+\\.?\\d*)\\s*%");
-        QRegularExpressionMatch match = heRe.match(heStr);
-        
-        if (match.hasMatch()) {
-            cylinder.hePercent = match.captured(1).toDouble();
-        }
-    }
-    
-    // Parse start pressure
-    if (attrs.hasAttribute("start")) {
-        QString startStr = attrs.value("start").toString();
-        QRegularExpression startRe("(\\d+\\.?\\d*)\\s+bar");
-        QRegularExpressionMatch match = startRe.match(startStr);
-        
-        if (match.hasMatch()) {
-            cylinder.startPressure = match.captured(1).toDouble();
-        }
-    }
-    
-    // Parse end pressure
-    if (attrs.hasAttribute("end")) {
-        QString endStr = attrs.value("end").toString();
-        QRegularExpression endRe("(\\d+\\.?\\d*)\\s+bar");
-        QRegularExpressionMatch match = endRe.match(endStr);
-        
-        if (match.hasMatch()) {
-            cylinder.endPressure = match.captured(1).toDouble();
-        }
-    }
-    
-    // Determine initial pressure (start pressure if available, otherwise work pressure)
-    double initialPressure = 0.0;
-    if (cylinder.startPressure > 0.0) {
-        initialPressure = cylinder.startPressure;
-    } else if (cylinder.workPressure > 0.0) {
-        initialPressure = cylinder.workPressure;
-    }
-    
-    // Add the cylinder to the dive
-    int cylinderIndex = dive->cylinderCount();
-    dive->addCylinder(cylinder);
-    
-    // Initialize the lastPressures map with this cylinder's initial pressure
-    if (initialPressure > 0.0) {
-        // Store this initial pressure as the first value for this tank
-        // Note: We'll need to make this available to parseSampleElement somehow
-        // This could be done by adding it to a member variable in LogParser
-        m_initialCylinderPressures[cylinderIndex] = initialPressure;
-    }
-    
-    qDebug() << "Parsed cylinder:" << cylinder.description 
-             << "Index:" << cylinderIndex
-             << "Size:" << cylinder.size << "l"
-             << "Gas mix:" << cylinder.o2Percent << "% O2" 
-             << (cylinder.hePercent > 0 ? QString::number(cylinder.hePercent) + "% He" : "")
-             << "Initial pressure:" << initialPressure << "bar";
-    
-    // Skip to the end of this element
-    while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("cylinder"))) {
-        xml.readNext();
-        if (xml.atEnd()) break;
-    }
-}
-
-void LogParser::parseDiveComputerElement(QXmlStreamReader &xml, DiveData* dive, int &sampleCount)
-{
-    qDebug() << "Parsing divecomputer element";
-    
-    // Variables to remember the last known values
-    double lastTemperature = 0.0;
-    double lastNDL = 0.0;
-    double lastTTS = 0.0;
-
-    // Keep track of the last pressure for each tank - use map for sparse storage
-    // Initialize last pressures with the initial values for all cylinders
-    QMap<int, double> lastPressures;
-    QMap<int, double> lastPO2Sensors;
-    for (int i = 0; i < dive->cylinderCount(); i++) {
-        double initialPressure = m_initialCylinderPressures.value(i, 0.0);
-        if (initialPressure > 0.0) {
-            lastPressures[i] = initialPressure;
-        }
-    }
-    
-    // Process all elements within the divecomputer element
-    while (!xml.atEnd()) {
-        xml.readNext();
-        
-        if (xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("divecomputer")) {
-            break;  // Exit when we reach the end of divecomputer
-        }
-        
-        if (xml.tokenType() == QXmlStreamReader::StartElement) {
-            QString elementName = xml.name().toString();
-            
-            if (elementName == "sample") {
-                // Process this sample
-                parseSampleElement(xml, dive, lastTemperature, lastNDL, lastTTS, lastPressures, lastPO2Sensors);
-                sampleCount++;
-                
-                // Log every 10th sample for debugging
-                if (sampleCount % 10 == 0) {
-                    qDebug() << "Parsed" << sampleCount << "samples";
-                }
-            } else if (elementName == "temperature") {
-                // Handle temperature element at divecomputer level
-                QXmlStreamAttributes attrs = xml.attributes();
-                if (attrs.hasAttribute("water")) {
-                    QString tempStr = attrs.value("water").toString();
-                    QRegularExpression tempRe("(\\d+\\.?\\d*)\\s+C");
-                    QRegularExpressionMatch match = tempRe.match(tempStr);
-                    
-                    if (match.hasMatch()) {
-                        lastTemperature = match.captured(1).toDouble();
-                    }
-                }
-                // Skip to the end of this element
-                while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("temperature"))) {
-                    xml.readNext();
-                    if (xml.atEnd()) break;
-                }
-            } else if (elementName == "event") {
-                // Handle events, including gas switches
-                QXmlStreamAttributes eventAttrs = xml.attributes();
-                
-                if (eventAttrs.hasAttribute("name") && eventAttrs.value("name") == QStringLiteral("gaschange")) {
-                    // This is a gas change event
-                    if (eventAttrs.hasAttribute("time") && eventAttrs.hasAttribute("cylinder")) {
-                        // Extract timestamp
-                        QString timeStr = eventAttrs.value("time").toString();
-                        double timestamp = 0.0;
-                        
-                        // Parse the time (similar to sample element time parsing)
-                        QRegularExpression timeRe("(\\d+):(\\d+)\\s+min");
-                        QRegularExpressionMatch match = timeRe.match(timeStr);
-                        
-                        if (match.hasMatch()) {
-                            int minutes = match.captured(1).toInt();
-                            int seconds = match.captured(2).toInt();
-                            timestamp = minutes * 60 + seconds;
-                        } else {
-                            // Try direct numeric parsing as fallback
-                            bool ok;
-                            timestamp = timeStr.toDouble(&ok);
-                            if (!ok) timestamp = 0.0;
-                        }
-                        
-                        // Extract cylinder index
-                        int cylinderIndex = eventAttrs.value("cylinder").toInt();
-                        
-                        // Add the gas switch to the dive data
-                        dive->addGasSwitch(timestamp, cylinderIndex);
-                        
-                        qDebug() << "Parsed gas switch at time" << timestamp 
-                                 << "to cylinder" << cylinderIndex;
-                    }
-                }
-                
-                // Skip to the end of this event
-                while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("event"))) {
-                    xml.readNext();
-                    if (xml.atEnd()) break;
-                }
-            }
-        }
-    }
-
-    // Sort gas switches by timestamp to ensure chronological order
-    std::sort(m_gasSwitches.begin(), m_gasSwitches.end(), 
-              [](const GasSwitch &a, const GasSwitch &b) {
-                  return a.timestamp < b.timestamp;
-              });
-    
-    qDebug() << "Finished parsing divecomputer element with" << sampleCount << "samples";
-}
-
-void LogParser::parseSampleElement(QXmlStreamReader &xml, DiveData* dive, double &lastTemperature, double &lastNDL, double &lastTTS, QMap<int, double> &lastPressures, QMap<int, double> &lastPO2Sensors)
-{
-    QXmlStreamAttributes attrs = xml.attributes();
-    
-    DiveDataPoint point;
-    bool hasData = false;
-    bool inDeco = false;
-    
-    // Get time - Subsurface uses format "mm:ss min"
-    if (attrs.hasAttribute("time")) {
-        QString timeStr = attrs.value("time").toString();
-        // Extract minutes and seconds from "mm:ss min" format
-        QRegularExpression timeRe("(\\d+):(\\d+)\\s+min");
-        QRegularExpressionMatch match = timeRe.match(timeStr);
-        
-        if (match.hasMatch()) {
-            int minutes = match.captured(1).toInt();
-            int seconds = match.captured(2).toInt();
-            point.timestamp = minutes * 60 + seconds;
-            hasData = true;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double time = timeStr.toDouble(&ok);
-            if (ok) {
-                point.timestamp = time;
-                hasData = true;
-            }
-        }
-    }
-    
-    // Get depth - Subsurface uses format "xx.x m"
-    if (attrs.hasAttribute("depth")) {
-        QString depthStr = attrs.value("depth").toString();
-        QRegularExpression depthRe("(\\d+\\.?\\d*)\\s+m");
-        QRegularExpressionMatch match = depthRe.match(depthStr);
-        
-        if (match.hasMatch()) {
-            point.depth = match.captured(1).toDouble();
-            hasData = true;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double depth = depthStr.toDouble(&ok);
-            if (ok) {
-                point.depth = depth;
-                hasData = true;
-            }
-        }
-    }
-    
-    // Get temperature - Subsurface uses format "xx.x C"
-    if (attrs.hasAttribute("temp")) {
-        QString tempStr = attrs.value("temp").toString();
-        QRegularExpression tempRe("(\\d+\\.?\\d*)\\s+C");
-        QRegularExpressionMatch match = tempRe.match(tempStr);
-        
-        if (match.hasMatch()) {
-            point.temperature = match.captured(1).toDouble();
-            lastTemperature = point.temperature;  // Update last known temperature
-            hasData = true;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double temp = tempStr.toDouble(&ok);
-            if (ok) {
-                point.temperature = temp;
-                lastTemperature = temp;  // Update last known temperature
-                hasData = true;
-            }
-        }
-    } else {
-        // Use the last known temperature if available
-        if (lastTemperature > 0.0) {
-            point.temperature = lastTemperature;
-        }
-    }
-    
-    // Process pressure attributes (standard and numbered for multiple tanks)
-
-    // First check for the standard "pressure" attribute (single tank)
-    if (attrs.hasAttribute("pressure")) {
-        QString pressureStr = attrs.value("pressure").toString();
-        QRegularExpression pressureRe("(\\d+\\.?\\d*)\\s+bar");
-        QRegularExpressionMatch match = pressureRe.match(pressureStr);
-        
-        if (match.hasMatch()) {
-            double pressure = match.captured(1).toDouble();
-            point.addPressure(pressure, 0); // Add to first tank (index 0)
-            hasData = true;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double pressure = pressureStr.toDouble(&ok);
-            if (ok) {
-                point.addPressure(pressure, 0);
-                hasData = true;
-            }
-        }
-    }
-
-    // Now check for numbered pressure attributes (multiple tanks)
-    for (int i = 0; i < 10; i++) { // Check up to 10 tanks (reasonable limit)
-        QString pressureAttr = QString("pressure%1").arg(i);
-        
-        if (attrs.hasAttribute(pressureAttr)) {
-            QString pressureStr = attrs.value(pressureAttr).toString();
-            QRegularExpression pressureRe("(\\d+\\.?\\d*)\\s+bar");
-            QRegularExpressionMatch match = pressureRe.match(pressureStr);
-            
-            if (match.hasMatch()) {
-                double pressure = match.captured(1).toDouble();
-                point.addPressure(pressure, i);
-                lastPressures[i] = pressure;  // Update last known pressure for this tank
-                hasData = true;
-            } else {
-                // Try direct numeric parsing as fallback
-                bool ok;
-                double pressure = pressureStr.toDouble(&ok);
-                if (ok) {
-                    point.addPressure(pressure, i);
-                    lastPressures[i] = pressure;
-                    hasData = true;
-                }
-            }
-        }
-    }
-
-    // Parse PO2 sensor values (sensor1, sensor2, sensor3, sensor4)
-    for (int i = 1; i <= 4; i++) {
-        QString sensorAttr = QString("sensor%1").arg(i);
-        
-        if (attrs.hasAttribute(sensorAttr)) {
-            QString sensorStr = attrs.value(sensorAttr).toString();
-            QRegularExpression sensorRe("(\\d+\\.?\\d*)\\s+bar");
-            QRegularExpressionMatch match = sensorRe.match(sensorStr);
-            
-            if (match.hasMatch()) {
-                double sensorValue = match.captured(1).toDouble();
-                point.addPO2Sensor(sensorValue, i - 1); // Convert to 0-based index
-                lastPO2Sensors[i - 1] = sensorValue;
-                hasData = true;
-            } else {
-                // Try direct numeric parsing as fallback
-                bool ok;
-                double sensorValue = sensorStr.toDouble(&ok);
-                if (ok) {
-                    point.addPO2Sensor(sensorValue, i - 1);
-                    lastPO2Sensors[i - 1] = sensorValue;
-                    hasData = true;
-                }
-            }
-        }
-    }
-
-    // Apply last known PO2 sensor values for continuity
-    for (auto it = lastPO2Sensors.begin(); it != lastPO2Sensors.end(); ++it) {
-        int sensorIndex = it.key();
-        double lastValue = it.value();
-        
-        // Check if this sensor already has a value set for this sample
-        bool sensorSet = attrs.hasAttribute(QString("sensor%1").arg(sensorIndex + 1));
-        
-        // If sensor not explicitly given in this sample but we have a last known value
-        if (!sensorSet && lastValue > 0.0) {
-            point.addPO2Sensor(lastValue, sensorIndex);
-        }
-    }
-
-    // Apply last known pressures for ALL cylinders declared in the dive
-    // This ensures every cylinder has a pressure value in every sample
-    for (int i = 0; i < dive->cylinderCount(); i++) {
-        // Check if this tank already has a pressure set for this sample
-        bool pressureSet = false;
-        if (i == 0) {
-            pressureSet = attrs.hasAttribute("pressure") || attrs.hasAttribute("pressure0");
-        } else {
-            pressureSet = attrs.hasAttribute(QString("pressure%1").arg(i));
-        }
-        
-        // If pressure not explicitly given in this sample but we have a last known pressure
-        if (!pressureSet && lastPressures.contains(i)) {
-            // Keep the last known pressure for continuity
-            point.addPressure(lastPressures[i], i);
-        }
-    }
-    
-    // Check for in_deco flag
-    if (attrs.hasAttribute("in_deco")) {
-        QString decoStr = attrs.value("in_deco").toString();
-        inDeco = (decoStr == "1" || decoStr.toLower() == "true");
-    }
-    
-    // Get TTS (Time To Surface) - Subsurface uses format "mm:ss min"
-    if (attrs.hasAttribute("tts")) {
-        QString ttsStr = attrs.value("tts").toString();
-        QRegularExpression ttsRe("(\\d+):(\\d+)\\s+min");
-        QRegularExpressionMatch match = ttsRe.match(ttsStr);
-        
-        if (match.hasMatch()) {
-            int minutes = match.captured(1).toInt();
-            int seconds = match.captured(2).toInt();
-            point.tts = minutes + seconds / 60.0;
-            lastTTS = point.tts;  // Update last known TTS
-            hasData = true;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double tts = ttsStr.toDouble(&ok);
-            if (ok) {
-                point.tts = tts;
-                lastTTS = tts;  // Update last known TTS
-                hasData = true;
-            }
-        }
-    } else {
-        // Use the last known TTS if available
-        if (lastTTS > 0.0) {
-            point.tts = lastTTS;
-        }
-    }
-    
-    // Get NDL - Subsurface uses format "xx:xx min"
-    if (attrs.hasAttribute("ndl")) {
-        QString ndlStr = attrs.value("ndl").toString();
-        QRegularExpression ndlRe("(\\d+):(\\d+)\\s+min");
-        QRegularExpressionMatch match = ndlRe.match(ndlStr);
-        
-        if (match.hasMatch()) {
-            int minutes = match.captured(1).toInt();
-            int seconds = match.captured(2).toInt();
-            point.ndl = minutes + seconds / 60.0;
-            lastNDL = point.ndl;  // Update last known NDL
-            hasData = true;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double ndl = ndlStr.toDouble(&ok);
-            if (ok) {
-                point.ndl = ndl;
-                lastNDL = ndl;  // Update last known NDL
-                hasData = true;
-            }
-        }
-    } else {
-        // Use the last known NDL if available
-        if (lastNDL >= 0.0) {
-            point.ndl = lastNDL;
-        }
-    }
-    
-    // When in deco, NDL should be 0 and TTS should be positive
-    if (inDeco) {
-        point.ndl = 0.0;
-        lastNDL = 0.0;
-        
-        // Ensure TTS is set when in deco
-        if (point.tts <= 0.0 && lastTTS > 0.0) {
-            point.tts = lastTTS;
-        } else if (point.tts <= 0.0) {
-            // If we don't have a lastTTS, set a minimum value
-            point.tts = 1.0;
-            lastTTS = 1.0;
-        }
-    }
-
-    if (attrs.hasAttribute("stopdepth")) {
-        QString stopDepthStr = attrs.value("stopdepth").toString();
-        QRegularExpression stopDepthRe("(\\d+\\.?\\d*)\\s+m");
-        QRegularExpressionMatch match = stopDepthRe.match(stopDepthStr);
-        
-        if (match.hasMatch()) {
-            point.ceiling = match.captured(1).toDouble();
-            m_lastCeiling = point.ceiling; // Store for future samples
-            qDebug() << "Parsed stopdepth:" << point.ceiling << "m for time:" << point.timestamp;
-        } else {
-            // Try direct numeric parsing as fallback
-            bool ok;
-            double stopDepth = stopDepthStr.toDouble(&ok);
-            if (ok) {
-                point.ceiling = stopDepth;
-                m_lastCeiling = point.ceiling; // Store for future samples
-                qDebug() << "Parsed stopdepth (numeric):" << point.ceiling << "m for time:" << point.timestamp;
-            }
-        }
-    } else {
-        // If no stopdepth in this sample, use the last known ceiling value
-        point.ceiling = m_lastCeiling;
-    }
-    
-    // If we have any valid data, add the point to the dive
-    if (hasData) {
-        static int sampleCount = 0;
-        sampleCount++;
-        
-        // Print debug info for every 10th sample
-        if (sampleCount <= 5 || sampleCount % 20 == 0) {
-            qDebug() << "Sample #" << sampleCount 
-                     << "time=" << point.timestamp 
-                     << "depth=" << point.depth
-                     << "temp=" << point.temperature << "(lastTemp=" << lastTemperature << ")"
-                     << "ndl=" << point.ndl << "(lastNDL=" << lastNDL << ")"
-                     << "tts=" << point.tts << "(lastTTS=" << lastTTS << ")"
-                     << "in_deco=" << inDeco;
-            // Debug tank pressures
-            for (int i = 0; i < point.tankCount(); i++) {
-                qDebug() << "  Tank" << i << "pressure=" << point.getPressure(i) 
-                         << "(last=" << lastPressures.value(i, 0.0) << ")";
-            }
-            // Debug PO2 sensors
-            for (int i = 0; i < point.po2SensorCount(); i++) {
-                qDebug() << "  Sensor" << (i + 1) << "PO2=" << point.getPO2Sensor(i) 
-                         << "(last=" << lastPO2Sensors.value(i, 0.0) << ")";
-            }
-            if (point.po2SensorCount() > 0) {
-                qDebug() << "  Composite PO2=" << point.getCompositePO2();
-            }
-        }
-        
-        dive->addDataPoint(point);
-    }
-    
-    // Skip to the end of the sample element
-    while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("sample"))) {
-        xml.readNext();
-        if (xml.atEnd()) break;
-    }
-}
-
-// Check if a cylinder is actively being used at a specific time
-bool LogParser::isCylinderActiveAtTime(int cylinderIndex, double timestamp) const
-{
-    // If we have no gas switches, assume first cylinder is always active
-    if (m_gasSwitches.isEmpty()) {
-        return cylinderIndex == 0;
-    }
-    
-    // Find the active cylinder at this timestamp
-    int activeCylinder = 0; // Default to first cylinder
-    
-    for (const GasSwitch &gasSwitch : m_gasSwitches) {
-        if (gasSwitch.timestamp <= timestamp) {
-            activeCylinder = gasSwitch.cylinderIndex;
-        } else {
-            // Gas switches are sorted by time, so once we find one
-            // that's after our timestamp, we can stop looking
-            break;
-        }
-    }
-    
-    return (cylinderIndex == activeCylinder);
-}
-
-void LogParser::parseDiveSites(QXmlStreamReader &xml)
-{
-    qDebug() << "Parsing divesites element";
-    
-    while (!xml.atEnd()) {
-        xml.readNext();
-        
-        if (xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("divesites")) {
-            break;  // Exit when we reach the end of divesites
-        }
-        
-        if (xml.tokenType() == QXmlStreamReader::StartElement && xml.name() == QStringLiteral("site")) {
-            // Parse individual dive site
-            QXmlStreamAttributes attrs = xml.attributes();
-            DiveSite site;
-            
-            // Get site UUID
-            if (attrs.hasAttribute("uuid")) {
-                site.uuid = attrs.value("uuid").toString();
-            }
-            
-            // Get site name
-            if (attrs.hasAttribute("name")) {
-                site.name = attrs.value("name").toString();
-            }
-            
-            // Get GPS coordinates
-            if (attrs.hasAttribute("gps")) {
-                site.gps = attrs.value("gps").toString();
-            }
-            
-            // Get description
-            if (attrs.hasAttribute("description")) {
-                site.description = attrs.value("description").toString();
-            }
-            
-            // Store the site if we have a UUID
-            if (!site.uuid.isEmpty()) {
-                m_diveSites[site.uuid] = site;
-                qDebug() << "Parsed dive site:" << site.name << "UUID:" << site.uuid;
-            }
-            
-            // Skip to the end of this site element
-            while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("site"))) {
-                xml.readNext();
-                if (xml.atEnd()) break;
-            }
-        }
-    }
-    
-    qDebug() << "Finished parsing divesites, found" << m_diveSites.size() << "sites";
 }

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -496,7 +496,7 @@ ApplicationWindow {
     FileDialog {
         id: importDiveLogFileDialog
         title: qsTr("Import Dive Log")
-        nameFilters: ["Subsurface XML files (*.xml *.ssrf)", "All files (*)"]
+        nameFilters: ["Dive log files (*.xml *.ssrf *.uddf)", "All files (*)"]
         onAccepted: {
             console.log("Selected file path:", selectedFile.toString());
             // Use our C++ helper to convert the URL to a local file path

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -1,0 +1,46 @@
+# Parser Smoke Test Checklist
+
+Run this before merging any change to the dive log parser. Each row below is a single import via the **File → Import Dive Log** dialog (use `tests/data/`). For each file:
+
+1. Confirm the dive list dialog (if multiple dives) shows the expected count.
+2. Pick a dive and confirm the timeline renders without errors in the log.
+3. Spot-check the values listed in the **Expected** column.
+
+## SSRF regression (priority — this section is a pure code move from the old monolithic parser)
+
+| File | Expected |
+|---|---|
+| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. |
+| `CCR_Halcyon_Benoit_cleaned.ssrf` | CCR dive — sensor1/2/3 still populate. |
+| `test_multidive.ssrf` | Multiple dives — picker shows them all; opening any one renders correctly. |
+| `OC_ScubaproG2_Benoit.ssrf` | Open-circuit, multi-tank pressures present. `diveMode` resolves to `OpenCircuit`. |
+
+## UDDF format
+
+| File | Expected |
+|---|---|
+| `2026-02-28-Monastery_Beach.uddf` | Same dive as the SSRF version above (CCR, dive #143). ~40.5 m max depth; 3 cylinders with begin/end pressure (Pa→bar conversion correct). Per-sample tank pressure / `<measuredpo2>` absent — Subsurface UDDF export limitation; cells just stay blank. Comma-decimal `<depth>` values (e.g. `2,1`) parse as 2.1. |
+| `Shearwater.uddf` | Loads; depth/temperature populated; comma decimals parsed. |
+| `Garmin.uddf` | Loads from a different exporter; verifies UDDF dialect handling. |
+
+## Format detection
+
+- Rename a UDDF file to `.xml` and import — the file should still load (sniff-based detection, not extension).
+- Rename an SSRF file to `.uddf` — same.
+
+## Error handling
+
+- Try to import a non-XML file (e.g. an image): expect `errorOccurred` with a useful message, no crash.
+
+## What gets verified
+
+| Behaviour | SSRF | UDDF |
+|---|---|---|
+| Dive metadata (number, datetime, site name) | ✓ | ✓ |
+| Cylinders with start/end pressure | ✓ | ✓ |
+| Per-sample depth | ✓ | ✓ |
+| Per-sample temperature | Celsius | Kelvin → Celsius |
+| Per-sample tank pressure | bar | Pa → bar (via `<tankpressure>` when exporter provides it) |
+| Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) |
+| Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index |
+| Dive mode | inferred from CCR cues | `<divemode kind>` or inferred |


### PR DESCRIPTION
Refactor the parser to allow for easy future additions.
Add support for the UDDF file format.
Carry over the logic adjustments done in the SSRF parser.
Add a Smoke test plan.
Update UI.
Update build system

This was tested with only a handful of dive profiles. This should be considered in beta version until there are more feedback from the end users.

Fixes #21