### PR TITLE
feat: Make the data cells label optional.

### DIFF
--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -49,7 +49,9 @@ public:
     QSizeF calculatedSize() const { return m_calculatedSize; }
     bool hasCustomFont() const { return m_hasCustomFont; }
     bool hasCustomColor() const { return m_hasCustomColor; }
+    bool hasCustomShowLabel() const { return m_hasCustomShowLabel; }
     int tankIndex() const { return m_tankIndex; }
+    bool showLabel() const { return m_showLabel; }
 
     // Setters
     void setCellId(const QString& id) { m_cellId = id; }
@@ -58,12 +60,14 @@ public:
     void setVisible(bool visible) { m_visible = visible; }
     void setFont(const QFont& font, bool isCustom = true);
     void setTextColor(const QColor& color, bool isCustom = true);
+    void setShowLabel(bool show, bool isCustom = true);
     void setCalculatedSize(const QSizeF& size) { m_calculatedSize = size; }
     void setTankIndex(int index) { m_tankIndex = index; }
 
     // Reset custom properties to inherit from global
     void resetFont() { m_hasCustomFont = false; }
     void resetColor() { m_hasCustomColor = false; }
+    void resetShowLabel() { m_hasCustomShowLabel = false; }
 
     // Serialization
     QJsonObject toJson() const;
@@ -83,6 +87,8 @@ private:
     QSizeF m_calculatedSize;       // Calculated size based on content and font
     bool m_hasCustomFont;          // True if font differs from global default
     bool m_hasCustomColor;         // True if color differs from global default
+    bool m_showLabel;              // Whether the label row ("DEPTH" etc.) is rendered above the value
+    bool m_hasCustomShowLabel;     // True if showLabel differs from global default
     int m_tankIndex;               // For pressure cells: which tank (0-based), -1 for N/A
 };
 

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -22,6 +22,7 @@ class OverlayGenerator : public QObject
     Q_PROPERTY(int templateHeight READ templateHeight NOTIFY templateChanged)
     Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
     Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor NOTIFY textColorChanged)
+    Q_PROPERTY(bool showLabel READ showLabel WRITE setShowLabel NOTIFY showLabelChanged)
     Q_PROPERTY(double backgroundOpacity READ backgroundOpacity WRITE setBackgroundOpacity NOTIFY backgroundOpacityChanged)
     Q_PROPERTY(bool showDepth READ showDepth WRITE setShowDepth NOTIFY showDepthChanged)
     Q_PROPERTY(bool showTemperature READ showTemperature WRITE setShowTemperature NOTIFY showTemperatureChanged)
@@ -55,6 +56,7 @@ public:
     int templateHeight() const { return m_templateHeight; }
     QFont font() const { return m_font; }
     QColor textColor() const { return m_textColor; }
+    bool showLabel() const { return m_showLabel; }
     double backgroundOpacity() const { return m_backgroundOpacity; }
     bool showDepth() const { return m_showDepth; }
     bool showTemperature() const { return m_showTemperature; }
@@ -83,6 +85,7 @@ public:
     void setTemplatePath(const QString &path);
     void setFont(const QFont &font);
     void setTextColor(const QColor &color);
+    void setShowLabel(bool show);
     void setBackgroundOpacity(double opacity);
     void setShowDepth(bool show);
     void setShowTemperature(bool show);
@@ -117,9 +120,12 @@ public:
     Q_INVOKABLE QColor getCellColor(const QString& cellId) const;
     Q_INVOKABLE void setCellFont(const QString& cellId, const QFont& font);
     Q_INVOKABLE void setCellColor(const QString& cellId, const QColor& color);
+    Q_INVOKABLE void setCellShowLabel(const QString& cellId, bool show);
+    Q_INVOKABLE bool getCellShowLabel(const QString& cellId) const;
     Q_INVOKABLE void setCellVisible(const QString& cellId, bool visible);
     Q_INVOKABLE void resetCellFont(const QString& cellId);
     Q_INVOKABLE void resetCellColor(const QString& cellId);
+    Q_INVOKABLE void resetCellShowLabel(const QString& cellId);
     bool useCellBasedLayout() const { return m_useCellBasedLayout; }
     void setUseCellBasedLayout(bool use);
 
@@ -149,6 +155,7 @@ signals:
     void templateChanged();
     void fontChanged();
     void textColorChanged();
+    void showLabelChanged();
     void backgroundOpacityChanged();
     void showDepthChanged();
     void showTemperatureChanged();
@@ -187,6 +194,7 @@ private:
     int m_templateHeight;
     QFont m_font;
     QColor m_textColor;
+    bool m_showLabel;
     double m_backgroundOpacity;
     bool m_showDepth;
     bool m_showTemperature;
@@ -245,7 +253,8 @@ private:
 
     // Generate display text for a cell (matches CellModel::formatValue for QML consistency)
     QString generateCellDisplayText(Unabara::CellType cellType, const DiveDataPoint& dataPoint,
-                                    int tankIndex, DiveData* dive) const;
+                                    int tankIndex, DiveData* dive,
+                                    bool showLabel = true) const;
 };
 
 #endif // OVERLAY_GEN_H

--- a/include/ui/cell_model.h
+++ b/include/ui/cell_model.h
@@ -29,7 +29,9 @@ public:
         CalculatedSizeRole,
         HasCustomFontRole,
         HasCustomColorRole,
-        TankIndexRole
+        TankIndexRole,
+        ShowLabelRole,
+        HasCustomShowLabelRole
     };
 
     explicit CellModel(QObject *parent = nullptr);
@@ -62,7 +64,8 @@ private:
 
     // Helper to generate display text for a cell
     QString generateDisplayText(const Unabara::CellData& cell) const;
-    QString formatValue(Unabara::CellType type, const DiveDataPoint& dataPoint, int tankIndex = 0) const;
+    QString formatValue(Unabara::CellType type, const DiveDataPoint& dataPoint,
+                        int tankIndex = 0, bool showLabel = true) const;
 };
 
 #endif // CELL_MODEL_H

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -12,6 +12,8 @@ CellData::CellData()
     , m_calculatedSize(0.0, 0.0)
     , m_hasCustomFont(false)
     , m_hasCustomColor(false)
+    , m_showLabel(true)
+    , m_hasCustomShowLabel(false)
     , m_tankIndex(-1)
 {
 }
@@ -26,6 +28,8 @@ CellData::CellData(const QString& cellId, CellType cellType)
     , m_calculatedSize(0.0, 0.0)
     , m_hasCustomFont(false)
     , m_hasCustomColor(false)
+    , m_showLabel(true)
+    , m_hasCustomShowLabel(false)
     , m_tankIndex(-1)
 {
 }
@@ -40,6 +44,12 @@ void CellData::setTextColor(const QColor& color, bool isCustom)
 {
     m_textColor = color;
     m_hasCustomColor = isCustom;
+}
+
+void CellData::setShowLabel(bool show, bool isCustom)
+{
+    m_showLabel = show;
+    m_hasCustomShowLabel = isCustom;
 }
 
 QJsonObject CellData::toJson() const
@@ -87,6 +97,9 @@ QJsonObject CellData::toJson() const
     json["hasCustomFont"] = m_hasCustomFont;
     json["hasCustomColor"] = m_hasCustomColor;
 
+    json["showLabel"] = m_showLabel;
+    json["hasCustomShowLabel"] = m_hasCustomShowLabel;
+
     return json;
 }
 
@@ -131,6 +144,11 @@ CellData CellData::fromJson(const QJsonObject& json)
 
     // Tank index
     cell.m_tankIndex = json["tankIndex"].toInt(-1);
+
+    // Show-label toggle (defaults: visible label, no per-cell override —
+    // matches behaviour for old .utp files predating this field).
+    cell.m_showLabel = json["showLabel"].toBool(true);
+    cell.m_hasCustomShowLabel = json["hasCustomShowLabel"].toBool(false);
 
     return cell;
 }

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -16,6 +16,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_templateHeight(120)
     , m_font(QFont("Sans Serif", 12))
     , m_textColor(Qt::white)
+    , m_showLabel(true)
     , m_backgroundOpacity(1.0)
     , m_showDepth(true)
     , m_showTemperature(true)
@@ -152,6 +153,33 @@ void OverlayGenerator::setTextColor(const QColor &color)
         Unabara::CellData* cell = getCellData(m_selectedCellId);
         if (cell && cell->textColor() != color) {
             cell->setTextColor(color, true); // true = custom color
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setShowLabel(bool show)
+{
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_showLabel != show) {
+            m_showLabel = show;
+
+            // Apply to all cells that don't have a per-cell override
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomShowLabel()) {
+                    cell.setShowLabel(show, false); // false = inherited from global
+                }
+            }
+
+            emit showLabelChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell as a per-cell override
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->showLabel() != show) {
+            cell->setShowLabel(show, true); // true = custom override
             emit cellsChanged();
         }
     }
@@ -409,6 +437,16 @@ void OverlayGenerator::resetCellColor(const QString& cellId)
     }
 }
 
+void OverlayGenerator::resetCellShowLabel(const QString& cellId)
+{
+    Unabara::CellData* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShowLabel()) {
+        // Reset to global default
+        cell->setShowLabel(m_showLabel, false);  // false = inherited from global
+        emit cellsChanged();
+    }
+}
+
 // Cell-based layout management methods
 
 Unabara::CellData* OverlayGenerator::getCellData(const QString& cellId)
@@ -480,6 +518,26 @@ void OverlayGenerator::setCellColor(const QString& cellId, const QColor& color)
     } else {
         qWarning() << "setCellColor: Cell not found:" << cellId;
     }
+}
+
+void OverlayGenerator::setCellShowLabel(const QString& cellId, bool show)
+{
+    Unabara::CellData* cell = getCellData(cellId);
+    if (cell) {
+        cell->setShowLabel(show, true);  // true = per-cell override
+        emit cellsChanged();
+    } else {
+        qWarning() << "setCellShowLabel: Cell not found:" << cellId;
+    }
+}
+
+bool OverlayGenerator::getCellShowLabel(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShowLabel()) {
+        return cell->showLabel();
+    }
+    return m_showLabel;
 }
 
 void OverlayGenerator::setCellVisible(const QString& cellId, bool visible)
@@ -1031,23 +1089,29 @@ QImage OverlayGenerator::generateOverlay(DiveData* dive, double timePoint)
 // Generate display text for a cell - matches CellModel::formatValue() for QML consistency
 QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
                                                    const DiveDataPoint& dataPoint,
-                                                   int tankIndex, DiveData* dive) const
+                                                   int tankIndex, DiveData* dive,
+                                                   bool showLabel) const
 {
     Units::UnitSystem unitSystem = Config::instance()->unitSystem();
     bool inDeco = (dataPoint.ndl <= 0);
 
+    auto format = [showLabel](const QString& label, const QString& value) {
+        return showLabel ? QString("%1\n%2").arg(label, value) : value;
+    };
+
     switch (cellType) {
     case Unabara::CellType::Depth:
-        return QString("DEPTH\n%1").arg(Units::formatDepthValue(dataPoint.depth, unitSystem));
+        return format("DEPTH", Units::formatDepthValue(dataPoint.depth, unitSystem));
 
     case Unabara::CellType::Temperature:
-        return QString("TEMP\n%1").arg(Units::formatTemperatureValue(dataPoint.temperature, unitSystem));
+        return format("TEMP", Units::formatTemperatureValue(dataPoint.temperature, unitSystem));
 
     case Unabara::CellType::Time: {
         int totalSeconds = static_cast<int>(dataPoint.timestamp);
         int minutes = totalSeconds / 60;
         int seconds = totalSeconds % 60;
-        return QString("DIVE TIME\n%1:%2").arg(minutes).arg(seconds, 2, 10, QChar('0'));
+        return format("DIVE TIME",
+                      QString("%1:%2").arg(minutes).arg(seconds, 2, 10, QChar('0')));
     }
 
     case Unabara::CellType::NDL:
@@ -1058,15 +1122,15 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
             if (dataPoint.ceiling > 0) {
                 decoInfo = QString("\nDECO (%1)").arg(Units::formatDepthValue(dataPoint.ceiling, unitSystem));
             }
-            return QString("TTS\n%1%2").arg(ttsStr).arg(decoInfo);
+            return format("TTS", ttsStr + decoInfo);
         } else {
             QString ndlStr = dataPoint.ndl > 0 ? QString("%1 min").arg(qRound(dataPoint.ndl)) : "---";
-            return QString("NDL\n%1").arg(ndlStr);
+            return format("NDL", ndlStr);
         }
 
     case Unabara::CellType::TTS: {
         QString ttsStr = dataPoint.tts > 0 ? QString("%1 min").arg(qRound(dataPoint.tts)) : "---";
-        return QString("TTS\n%1").arg(ttsStr);
+        return format("TTS", ttsStr);
     }
 
     case Unabara::CellType::Pressure: {
@@ -1114,28 +1178,28 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
             label = "PRESSURE";
         }
 
-        return QString("%1\n%2").arg(label).arg(value);
+        return format(label, value);
     }
 
     case Unabara::CellType::PO2Cell1: {
         QString value = (!dataPoint.po2Sensors.isEmpty() && dataPoint.po2Sensors.size() > 0)
             ? QString("%1").arg(dataPoint.po2Sensors[0], 0, 'f', 2)
             : "---";
-        return QString("CELL 1\n%1").arg(value);
+        return format("CELL 1", value);
     }
 
     case Unabara::CellType::PO2Cell2: {
         QString value = (dataPoint.po2Sensors.size() > 1)
             ? QString("%1").arg(dataPoint.po2Sensors[1], 0, 'f', 2)
             : "---";
-        return QString("CELL 2\n%1").arg(value);
+        return format("CELL 2", value);
     }
 
     case Unabara::CellType::PO2Cell3: {
         QString value = (dataPoint.po2Sensors.size() > 2)
             ? QString("%1").arg(dataPoint.po2Sensors[2], 0, 'f', 2)
             : "---";
-        return QString("CELL 3\n%1").arg(value);
+        return format("CELL 3", value);
     }
 
     case Unabara::CellType::CompositePO2: {
@@ -1143,7 +1207,7 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
         QString value = (compositePO2 > 0)
             ? QString("%1").arg(compositePO2, 0, 'f', 2)
             : "---";
-        return QString("PO2\n%1").arg(value);
+        return format("PO2", value);
     }
 
     default:
@@ -1168,7 +1232,8 @@ void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& im
 
         // Generate displayText (same format as QML CellModel)
         QString displayText = generateCellDisplayText(cell.cellType(), dataPoint,
-                                                       cell.tankIndex(), dive);
+                                                       cell.tankIndex(), dive,
+                                                       cell.showLabel());
 
         // Scale font for template resolution (match calculateCellSize behavior)
         // QML renders at preview size, but C++ renders at full template resolution

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -47,6 +47,10 @@ QVariant CellModel::data(const QModelIndex &index, int role) const
         return cell.hasCustomColor();
     case TankIndexRole:
         return cell.tankIndex();
+    case ShowLabelRole:
+        return cell.showLabel();
+    case HasCustomShowLabelRole:
+        return cell.hasCustomShowLabel();
     default:
         return QVariant();
     }
@@ -66,6 +70,8 @@ QHash<int, QByteArray> CellModel::roleNames() const
     roles[HasCustomFontRole] = "hasCustomFont";
     roles[HasCustomColorRole] = "hasCustomColor";
     roles[TankIndexRole] = "tankIndex";
+    roles[ShowLabelRole] = "showLabel";
+    roles[HasCustomShowLabelRole] = "hasCustomShowLabel";
     return roles;
 }
 
@@ -201,22 +207,27 @@ QString CellModel::generateDisplayText(const Unabara::CellData& cell) const
         return "No Data";
 
     DiveDataPoint dataPoint = m_dive->dataAtTime(m_timePoint);
-    return formatValue(cell.cellType(), dataPoint, cell.tankIndex());
+    return formatValue(cell.cellType(), dataPoint, cell.tankIndex(), cell.showLabel());
 }
 
-QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& dataPoint, int tankIndex) const
+QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& dataPoint,
+                               int tankIndex, bool showLabel) const
 {
     Units::UnitSystem unitSystem = Config::instance()->unitSystem();
+
+    auto format = [showLabel](const QString& label, const QString& value) {
+        return showLabel ? QString("%1\n%2").arg(label, value) : value;
+    };
 
     switch (type) {
     case Unabara::CellType::Depth: {
         QString value = Units::formatDepthValue(dataPoint.depth, unitSystem);
-        return QString("DEPTH\n%1").arg(value);
+        return format("DEPTH", value);
     }
 
     case Unabara::CellType::Temperature: {
         QString value = Units::formatTemperatureValue(dataPoint.temperature, unitSystem);
-        return QString("TEMP\n%1").arg(value);
+        return format("TEMP", value);
     }
 
     case Unabara::CellType::Time: {
@@ -224,7 +235,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         int minutes = totalSeconds / 60;
         int seconds = totalSeconds % 60;
         QString value = QString("%1:%2").arg(minutes, 2, 10, QChar('0')).arg(seconds, 2, 10, QChar('0'));
-        return QString("DIVE TIME\n%1").arg(value);
+        return format("DIVE TIME", value);
     }
 
     case Unabara::CellType::NDL: {
@@ -247,7 +258,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
                 decoInfo = QString("\nDECO (%1)").arg(ceilingStr);
             }
 
-            return QString("TTS\n%1%2").arg(value).arg(decoInfo);
+            return format("TTS", value + decoInfo);
         } else {
             // Show NDL when not in decompression
             QString value;
@@ -256,7 +267,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
             } else {
                 value = "---";
             }
-            return QString("NDL\n%1").arg(value);
+            return format("NDL", value);
         }
     }
 
@@ -267,7 +278,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         } else {
             value = "---";
         }
-        return QString("TTS\n%1").arg(value);
+        return format("TTS", value);
     }
 
     case Unabara::CellType::Pressure: {
@@ -325,7 +336,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
             label = "PRESSURE";
         }
 
-        return QString("%1\n%2").arg(label).arg(value);
+        return format(label, value);
     }
 
     case Unabara::CellType::PO2Cell1: {
@@ -335,7 +346,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         } else {
             value = "---";
         }
-        return QString("CELL 1\n%1").arg(value);
+        return format("CELL 1", value);
     }
 
     case Unabara::CellType::PO2Cell2: {
@@ -345,7 +356,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         } else {
             value = "---";
         }
-        return QString("CELL 2\n%1").arg(value);
+        return format("CELL 2", value);
     }
 
     case Unabara::CellType::PO2Cell3: {
@@ -355,7 +366,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         } else {
             value = "---";
         }
-        return QString("CELL 3\n%1").arg(value);
+        return format("CELL 3", value);
     }
 
     case Unabara::CellType::CompositePO2: {
@@ -366,7 +377,7 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         } else {
             value = "---";
         }
-        return QString("PO2\n%1").arg(value);
+        return format("PO2", value);
     }
 
     default:

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -19,6 +19,8 @@ Item {
     property var currentColor: getCurrentColor()
     property bool currentHasCustomFont: getSelectedCellHasCustomFont()
     property bool currentHasCustomColor: getSelectedCellHasCustomColor()
+    property bool currentShowLabel: getCurrentShowLabel()
+    property bool currentHasCustomShowLabel: getSelectedCellHasCustomShowLabel()
 
     implicitHeight: mainColumn.implicitHeight
 
@@ -74,6 +76,24 @@ Item {
         return hasCustom === true
     }
 
+    // Get the effective showLabel (selected cell or global)
+    function getCurrentShowLabel() {
+        if (!generator) return true
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellShowLabel(selectedCellId)
+        }
+
+        return generator.showLabel
+    }
+
+    function getSelectedCellHasCustomShowLabel() {
+        if (!hasSelection || !selectedCellId) return false
+
+        var hasCustom = getCellProperty(selectedCellId, "hasCustomShowLabel")
+        return hasCustom === true
+    }
+
     // Update reactive properties when selection or cells change
     onSelectedCellIdChanged: {
         console.log("Selection changed to:", selectedCellId)
@@ -101,6 +121,13 @@ Item {
                 updateCurrentProperties()
             }
         }
+
+        function onShowLabelChanged() {
+            if (!hasSelection) {
+                console.log("Global showLabel changed")
+                updateCurrentProperties()
+            }
+        }
     }
 
     function updateCurrentProperties() {
@@ -111,6 +138,8 @@ Item {
         currentColor = newColor
         currentHasCustomFont = getSelectedCellHasCustomFont()
         currentHasCustomColor = getSelectedCellHasCustomColor()
+        currentShowLabel = getCurrentShowLabel()
+        currentHasCustomShowLabel = getSelectedCellHasCustomShowLabel()
     }
 
     // Cell model for interactive preview
@@ -660,6 +689,39 @@ Item {
                     onClicked: {
                         if (root.generator && root.selectedCellId) {
                             root.generator.resetCellColor(root.selectedCellId)
+                        }
+                    }
+                }
+
+                Label { text: qsTr("Label:") }
+                CheckBox {
+                    id: showLabelCheckBox
+                    Layout.fillWidth: true
+                    text: qsTr("Show label")
+                    checked: root.currentShowLabel
+                    Connections {
+                        target: root
+                        function onCurrentShowLabelChanged() {
+                            showLabelCheckBox.checked = root.currentShowLabel
+                        }
+                    }
+                    onClicked: {
+                        if (root.generator) {
+                            root.generator.showLabel = checked
+                        }
+                    }
+                }
+
+                Button {
+                    text: "↺"
+                    Layout.preferredWidth: 40
+                    enabled: root.hasSelection && root.currentHasCustomShowLabel
+                    opacity: enabled ? 1.0 : 0.3
+                    ToolTip.visible: hovered
+                    ToolTip.text: enabled ? qsTr("Reset to global label setting") : qsTr("No custom label setting")
+                    onClicked: {
+                        if (root.generator && root.selectedCellId) {
+                            root.generator.resetCellShowLabel(root.selectedCellId)
                         }
                     }
                 }


### PR DESCRIPTION
- add a checkbox in the text settings to show label or not.
- respect the normal behavior of the text settings (if no cell is selected apply to all cells, otherwise to the selected data cell only)
- add relevant option (showLabel) to the template system for persistence.

Fixes #16