### PR TITLE
feat: add a dive profile editor/generator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ set(PROJECT_SOURCES
     src/ui/cell_model.cpp
     src/generators/overlay_gen.cpp
     src/generators/overlay_image_provider.cpp
+    src/generators/profile_renderer.cpp
+    src/generators/profile_gen.cpp
+    src/generators/profile_image_provider.cpp
     src/export/image_export.cpp
     src/core/update_checker.cpp
     src/export/video_export.cpp
@@ -70,6 +73,10 @@ set(PROJECT_HEADERS
     include/ui/cell_model.h
     include/generators/overlay_gen.h
     include/generators/overlay_image_provider.h
+    include/generators/i_frame_generator.h
+    include/generators/profile_renderer.h
+    include/generators/profile_gen.h
+    include/generators/profile_image_provider.h
     include/export/image_export.h
     include/core/update_checker.h
     include/export/video_export.h

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -42,7 +42,18 @@ class Config : public QObject
 
     // Export settings
     Q_PROPERTY(double frameRate READ frameRate WRITE setFrameRate NOTIFY frameRateChanged)
-    
+
+    // Dive profile settings
+    Q_PROPERTY(QColor profileBackgroundColor READ profileBackgroundColor WRITE setProfileBackgroundColor NOTIFY profileBackgroundColorChanged)
+    Q_PROPERTY(double profileBackgroundOpacity READ profileBackgroundOpacity WRITE setProfileBackgroundOpacity NOTIFY profileBackgroundOpacityChanged)
+    Q_PROPERTY(QColor profileCurveColor READ profileCurveColor WRITE setProfileCurveColor NOTIFY profileCurveColorChanged)
+    Q_PROPERTY(QColor profileIndicatorColor READ profileIndicatorColor WRITE setProfileIndicatorColor NOTIFY profileIndicatorColorChanged)
+    Q_PROPERTY(int profileIndicatorMode READ profileIndicatorMode WRITE setProfileIndicatorMode NOTIFY profileIndicatorModeChanged)
+    Q_PROPERTY(int profileIndicatorRadius READ profileIndicatorRadius WRITE setProfileIndicatorRadius NOTIFY profileIndicatorRadiusChanged)
+    Q_PROPERTY(int profilePulsePeriodMs READ profilePulsePeriodMs WRITE setProfilePulsePeriodMs NOTIFY profilePulsePeriodMsChanged)
+    Q_PROPERTY(int profileOutputWidth READ profileOutputWidth WRITE setProfileOutputWidth NOTIFY profileOutputWidthChanged)
+    Q_PROPERTY(int profileOutputHeight READ profileOutputHeight WRITE setProfileOutputHeight NOTIFY profileOutputHeightChanged)
+
 public:
     static Config* instance();
     
@@ -108,7 +119,35 @@ public:
     // Export settings
     double frameRate() const;
     void setFrameRate(double fps);
-    
+
+    // Dive profile settings
+    QColor profileBackgroundColor() const;
+    void setProfileBackgroundColor(const QColor& color);
+
+    double profileBackgroundOpacity() const;
+    void setProfileBackgroundOpacity(double opacity);
+
+    QColor profileCurveColor() const;
+    void setProfileCurveColor(const QColor& color);
+
+    QColor profileIndicatorColor() const;
+    void setProfileIndicatorColor(const QColor& color);
+
+    int profileIndicatorMode() const;
+    void setProfileIndicatorMode(int mode);
+
+    int profileIndicatorRadius() const;
+    void setProfileIndicatorRadius(int radius);
+
+    int profilePulsePeriodMs() const;
+    void setProfilePulsePeriodMs(int periodMs);
+
+    int profileOutputWidth() const;
+    void setProfileOutputWidth(int w);
+
+    int profileOutputHeight() const;
+    void setProfileOutputHeight(int h);
+
     // Save configuration to disk
     void saveConfig();
     
@@ -134,7 +173,18 @@ signals:
     void showPO2Cell2Changed();
     void showPO2Cell3Changed();
     void showCompositePO2Changed();
-    
+
+    // Profile signals
+    void profileBackgroundColorChanged();
+    void profileBackgroundOpacityChanged();
+    void profileCurveColorChanged();
+    void profileIndicatorColorChanged();
+    void profileIndicatorModeChanged();
+    void profileIndicatorRadiusChanged();
+    void profilePulsePeriodMsChanged();
+    void profileOutputWidthChanged();
+    void profileOutputHeightChanged();
+
 private:
     explicit Config(QObject *parent = nullptr);
     ~Config();
@@ -167,7 +217,18 @@ private:
     bool m_showPO2Cell2;
     bool m_showPO2Cell3;
     bool m_showCompositePO2;
-    
+
+    // Profile settings
+    QColor m_profileBackgroundColor;
+    double m_profileBackgroundOpacity;
+    QColor m_profileCurveColor;
+    QColor m_profileIndicatorColor;
+    int m_profileIndicatorMode;
+    int m_profileIndicatorRadius;
+    int m_profilePulsePeriodMs;
+    int m_profileOutputWidth;
+    int m_profileOutputHeight;
+
     // Load configuration from disk
     void loadConfig();
 };

--- a/include/export/image_export.h
+++ b/include/export/image_export.h
@@ -6,7 +6,7 @@
 #include <QDir>
 #include <QImage>
 #include "include/core/dive_data.h"
-#include "include/generators/overlay_gen.h"
+#include "include/generators/i_frame_generator.h"
 
 class ImageExporter : public QObject
 {
@@ -30,13 +30,21 @@ public:
     void setExportPath(const QString &path);
     void setFrameRate(double fps);
     
-    // Export methods
-    Q_INVOKABLE bool exportImages(DiveData* dive, OverlayGenerator* generator);
-    Q_INVOKABLE bool exportImageRange(DiveData* dive, OverlayGenerator* generator,
+    // Export methods. `generator` is accepted as a QObject* so QML can pass
+    // either OverlayGenerator or ProfileGenerator transparently (the meta-
+    // object system can't convert to a non-QObject interface). Internally
+    // we dynamic_cast to IFrameGenerator and fail fast if the cast doesn't
+    // succeed.
+    Q_INVOKABLE bool exportImages(DiveData* dive, QObject* generator);
+    Q_INVOKABLE bool exportImageRange(DiveData* dive, QObject* generator,
                                       double startTime, double endTime);
-    
-    // Create default export directory
-    Q_INVOKABLE QString createDefaultExportDir(DiveData* dive, const QString &videoFilePath = QString());
+
+    // Create default export directory. `contentType` (e.g. "dive_computer",
+    // "dive_profile") is appended to the directory name so that exports of
+    // different overlays for the same dive end up in distinct directories.
+    Q_INVOKABLE QString createDefaultExportDir(DiveData* dive,
+                                               const QString &videoFilePath = QString(),
+                                               const QString &contentType = QString());
     
 signals:
     void exportPathChanged();
@@ -54,7 +62,9 @@ private:
     bool m_busy;
     
     // Helper methods
-    QString generateUniqueDirectoryName(DiveData* dive, const QString &videoFilePath = QString());
+    QString generateUniqueDirectoryName(DiveData* dive,
+                                        const QString &videoFilePath = QString(),
+                                        const QString &contentType = QString());
     QString sanitizeFileName(const QString &fileName);
 };
 

--- a/include/export/video_export.h
+++ b/include/export/video_export.h
@@ -8,7 +8,7 @@
 #include <QTemporaryDir>
 #include <QSize>
 #include "include/core/dive_data.h"
-#include "include/generators/overlay_gen.h"
+#include "include/generators/i_frame_generator.h"
 
 class VideoExporter : public QObject
 {
@@ -51,14 +51,21 @@ public:
     void setVideoCodec(const QString &codec);
     void setCustomResolution(const QSize &size);
     
-    // Export methods
-    Q_INVOKABLE bool exportVideo(DiveData* dive, OverlayGenerator* generator,
+    // Export methods. Accepts `generator` as a QObject* — internally
+    // dynamic_cast to IFrameGenerator, so both OverlayGenerator and
+    // ProfileGenerator work transparently from QML.
+    Q_INVOKABLE bool exportVideo(DiveData* dive, QObject* generator,
                                 double startTime, double endTime);
     Q_INVOKABLE void cancelExport();
-    
+
     // Helper methods
     Q_INVOKABLE bool isFFmpegAvailable();
-    Q_INVOKABLE QString createDefaultExportFile(DiveData* dive, const QString &videoFilePath = QString());
+    // `contentType` (e.g. "dive_computer", "dive_profile") is appended to the
+    // output filename so exports of different overlays for the same dive land
+    // in distinct files.
+    Q_INVOKABLE QString createDefaultExportFile(DiveData* dive,
+                                                const QString &videoFilePath = QString(),
+                                                const QString &contentType = QString());
     Q_INVOKABLE QSize detectVideoResolution(const QString &videoPath);
     Q_INVOKABLE double extractVideoTimecode(const QString &videoPath);
     
@@ -105,7 +112,7 @@ private:
     // QObject* m_worker;
     
     // Frame generation stages
-    bool generateFrames(DiveData* dive, OverlayGenerator* generator,
+    bool generateFrames(DiveData* dive, IFrameGenerator* generator,
                         double startTime, double endTime);
     bool encodeFramesToVideo(const QString &outputPath);
     
@@ -117,7 +124,10 @@ private:
                                  const QString &outputFile);
     QString getFormatOptions(const QString &codec);
     QString sanitizeFileName(const QString &fileName);
-    QString generateUniqueFileName(DiveData* dive, const QString &extension, const QString &videoFilePath = QString());
+    QString generateUniqueFileName(DiveData* dive,
+                                   const QString &extension,
+                                   const QString &videoFilePath = QString(),
+                                   const QString &contentType = QString());
     void cleanupTempFiles();
     QSize getDefaultOverlaySize();
     QStringList createFFmpegArgs(const QString &outputPath);

--- a/include/generators/i_frame_generator.h
+++ b/include/generators/i_frame_generator.h
@@ -1,0 +1,33 @@
+#ifndef I_FRAME_GENERATOR_H
+#define I_FRAME_GENERATOR_H
+
+#include <QImage>
+
+class DiveData;
+
+/**
+ * Minimal abstract interface for anything that can render a single overlay frame
+ * for a dive at a given timestamp.
+ *
+ * Both OverlayGenerator (dive computer cells) and ProfileGenerator (depth curve
+ * with animated indicator) implement this interface so the export pipeline
+ * (ImageExporter / VideoExporter) can drive either renderer without caring which.
+ */
+class IFrameGenerator
+{
+public:
+    virtual ~IFrameGenerator() = default;
+
+    // Render the overlay for the given dive at the given dive-time (seconds).
+    // Returns a transparent-background QImage sized for compositing.
+    virtual QImage generate(DiveData* dive, double timePoint) = 0;
+
+    // Optional hooks for generators that need to stage/restore state for
+    // export passes (e.g. hide editor-only chrome). Default no-op.
+    // Exporters MUST call beginExport() before the first generate() and
+    // endExport() after the last, in a symmetric pair.
+    virtual void beginExport() {}
+    virtual void endExport() {}
+};
+
+#endif // I_FRAME_GENERATOR_H

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -12,8 +12,9 @@
 #include "include/core/units.h"
 #include "include/core/cell_data.h"
 #include "include/core/overlay_template.h"
+#include "include/generators/i_frame_generator.h"
 
-class OverlayGenerator : public QObject
+class OverlayGenerator : public QObject, public IFrameGenerator
 {
     Q_OBJECT
     
@@ -150,6 +151,11 @@ public:
 
     // Generate a preview image
     Q_INVOKABLE QImage generatePreview(DiveData* dive);
+
+    // IFrameGenerator
+    QImage generate(DiveData* dive, double timePoint) override { return generateOverlay(dive, timePoint); }
+    void beginExport() override;
+    void endExport() override;
     
 signals:
     void templateChanged();
@@ -226,6 +232,9 @@ private:
     bool m_snapToGrid;
     int m_gridSpacing;  // Grid spacing in pixels
     bool m_showGrid;
+
+    // Export-pass state stash (saved by beginExport, restored by endExport)
+    bool m_savedShowCellBackgrounds = true;
 
     // Helper methods for drawing
     int getScaledFontSize(const QFont& baseFont, double scale = 1.0) const;

--- a/include/generators/profile_gen.h
+++ b/include/generators/profile_gen.h
@@ -1,0 +1,92 @@
+#ifndef PROFILE_GEN_H
+#define PROFILE_GEN_H
+
+#include <QColor>
+#include <QImage>
+#include <QObject>
+
+#include "include/core/dive_data.h"
+#include "include/generators/i_frame_generator.h"
+
+/**
+ * Renders the dive depth-profile graphic: a curve of depth-over-time with an
+ * indicator dot positioned at the current dive-time. Mirrors OverlayGenerator's
+ * shape so both can flow through the same export pipeline (via IFrameGenerator).
+ *
+ * All settings are mirrored to/from Config so they persist across sessions.
+ */
+class ProfileGenerator : public QObject, public IFrameGenerator
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged)
+    Q_PROPERTY(double backgroundOpacity READ backgroundOpacity WRITE setBackgroundOpacity NOTIFY backgroundOpacityChanged)
+    Q_PROPERTY(QColor curveColor READ curveColor WRITE setCurveColor NOTIFY curveColorChanged)
+    Q_PROPERTY(QColor indicatorColor READ indicatorColor WRITE setIndicatorColor NOTIFY indicatorColorChanged)
+    Q_PROPERTY(IndicatorMode indicatorMode READ indicatorMode WRITE setIndicatorMode NOTIFY indicatorModeChanged)
+    Q_PROPERTY(int indicatorRadius READ indicatorRadius WRITE setIndicatorRadius NOTIFY indicatorRadiusChanged)
+    Q_PROPERTY(int pulsePeriodMs READ pulsePeriodMs WRITE setPulsePeriodMs NOTIFY pulsePeriodMsChanged)
+    Q_PROPERTY(int outputWidth READ outputWidth WRITE setOutputWidth NOTIFY outputWidthChanged)
+    Q_PROPERTY(int outputHeight READ outputHeight WRITE setOutputHeight NOTIFY outputHeightChanged)
+
+public:
+    enum IndicatorMode {
+        Static = 0,
+        Pulsing = 1
+    };
+    Q_ENUM(IndicatorMode)
+
+    explicit ProfileGenerator(QObject* parent = nullptr);
+
+    QColor backgroundColor() const { return m_backgroundColor; }
+    double backgroundOpacity() const { return m_backgroundOpacity; }
+    QColor curveColor() const { return m_curveColor; }
+    QColor indicatorColor() const { return m_indicatorColor; }
+    IndicatorMode indicatorMode() const { return m_indicatorMode; }
+    int indicatorRadius() const { return m_indicatorRadius; }
+    int pulsePeriodMs() const { return m_pulsePeriodMs; }
+    int outputWidth() const { return m_outputWidth; }
+    int outputHeight() const { return m_outputHeight; }
+
+    void setBackgroundColor(const QColor& c);
+    void setBackgroundOpacity(double o);
+    void setCurveColor(const QColor& c);
+    void setIndicatorColor(const QColor& c);
+    void setIndicatorMode(IndicatorMode m);
+    void setIndicatorRadius(int r);
+    void setPulsePeriodMs(int ms);
+    void setOutputWidth(int w);
+    void setOutputHeight(int h);
+
+    // IFrameGenerator — for exports, pulse phase is timestamp-derived so each
+    // frame in a sequence has a deterministic pulse state.
+    Q_INVOKABLE QImage generate(DiveData* dive, double timePoint) override;
+
+    // Like generate() but with an explicit pulse phase (0..1). Used by the live
+    // preview to animate the indicator while the user is idle on the timeline.
+    QImage renderFrame(DiveData* dive, double timePoint, double pulsePhase01);
+
+signals:
+    void backgroundColorChanged();
+    void backgroundOpacityChanged();
+    void curveColorChanged();
+    void indicatorColorChanged();
+    void indicatorModeChanged();
+    void indicatorRadiusChanged();
+    void pulsePeriodMsChanged();
+    void outputWidthChanged();
+    void outputHeightChanged();
+
+private:
+    QColor m_backgroundColor;
+    double m_backgroundOpacity;
+    QColor m_curveColor;
+    QColor m_indicatorColor;
+    IndicatorMode m_indicatorMode;
+    int m_indicatorRadius;
+    int m_pulsePeriodMs;
+    int m_outputWidth;
+    int m_outputHeight;
+};
+
+#endif // PROFILE_GEN_H

--- a/include/generators/profile_image_provider.h
+++ b/include/generators/profile_image_provider.h
@@ -1,0 +1,31 @@
+#ifndef PROFILE_IMAGE_PROVIDER_H
+#define PROFILE_IMAGE_PROVIDER_H
+
+#include <QQuickImageProvider>
+
+#include "include/core/dive_data.h"
+#include "include/generators/profile_gen.h"
+
+class ProfileImageProvider;
+
+// Global pointer mirroring g_imageProvider so Timeline (or anything else)
+// can push the current dive/time without holding a QML/context reference.
+extern ProfileImageProvider* g_profileImageProvider;
+
+class ProfileImageProvider : public QQuickImageProvider
+{
+public:
+    explicit ProfileImageProvider(ProfileGenerator* generator);
+
+    QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
+
+    void setCurrentDive(DiveData* dive);
+    void setCurrentTime(double time);
+
+private:
+    ProfileGenerator* m_generator;
+    DiveData* m_currentDive;
+    double m_currentTime;
+};
+
+#endif // PROFILE_IMAGE_PROVIDER_H

--- a/include/generators/profile_renderer.h
+++ b/include/generators/profile_renderer.h
@@ -1,0 +1,43 @@
+#ifndef PROFILE_RENDERER_H
+#define PROFILE_RENDERER_H
+
+#include <QColor>
+#include <QPainter>
+#include <QRectF>
+
+class DiveData;
+
+/**
+ * Stateless rendering helpers for the dive profile graphic.
+ *
+ * All functions paint into `rect` (in the painter's coordinate space) and
+ * use the dive's max depth and total duration to compute coordinate mappings.
+ *
+ * Depth grows downward in screen coordinates: y = rect.top + (depth / maxDepth) * rect.height.
+ * Time grows left-to-right: x = rect.left + (t / duration) * rect.width.
+ *
+ * The "rect" is meant to be the full target image rect. There is no padding —
+ * if you want padding, pass an inset rect.
+ */
+namespace ProfileRenderer {
+
+// Fill `rect` with the background color at the given opacity (0..1).
+// Skipped entirely when opacity == 0 so the resulting image stays transparent.
+void drawBackground(QPainter& p, const QRectF& rect, const QColor& bg, double opacity);
+
+// Stroke a depth curve across `rect`. No-op if the dive has fewer than 2 samples
+// or a zero max depth.
+void drawDepthCurve(QPainter& p, const QRectF& rect, DiveData* dive,
+                    const QColor& color, double lineWidth = 2.0);
+
+// Draw a filled indicator dot at the (time, depth) interpolated for currentTimeSec.
+// When `pulsing` is true, the dot's radius is modulated by `pulsePhase01` (0..1
+// fraction of the pulse cycle) so the same phase always produces the same visual
+// — making animated previews and exported frames perfectly aligned.
+void drawIndicator(QPainter& p, const QRectF& rect, DiveData* dive,
+                   double currentTimeSec, const QColor& color,
+                   double radius, bool pulsing, double pulsePhase01);
+
+} // namespace ProfileRenderer
+
+#endif // PROFILE_RENDERER_H

--- a/resources.qrc
+++ b/resources.qrc
@@ -6,6 +6,7 @@
         <file alias="OverlayEditor.qml">src/ui/qml/OverlayEditor.qml</file>
         <file alias="InteractiveOverlayPreview.qml">src/ui/qml/InteractiveOverlayPreview.qml</file>
         <file alias="OverlayCell.qml">src/ui/qml/OverlayCell.qml</file>
+        <file alias="ProfileEditor.qml">src/ui/qml/ProfileEditor.qml</file>
         <file>resources/styles/style.qss</file>
         <file alias="templates/OC_Rec_NoTanks_Ocean.utp">resources/templates/OC_Rec_NoTanks_Ocean.utp</file>
         <file alias="templates/OC_Rec_NoTanks_Titanium.utp">resources/templates/OC_Rec_NoTanks_Titanium.utp</file>

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -30,6 +30,15 @@ Config::Config(QObject *parent)
     , m_showPO2Cell2(false)
     , m_showPO2Cell3(false)
     , m_showCompositePO2(false)
+    , m_profileBackgroundColor(Qt::black)
+    , m_profileBackgroundOpacity(0.0)
+    , m_profileCurveColor(QColor("#9C27B0"))
+    , m_profileIndicatorColor(QColor(0, 255, 0))
+    , m_profileIndicatorMode(0)   // 0 = Static, 1 = Pulsing
+    , m_profileIndicatorRadius(8)
+    , m_profilePulsePeriodMs(2000)
+    , m_profileOutputWidth(1920)
+    , m_profileOutputHeight(400)
 {
     // Load settings from disk
     loadConfig();
@@ -298,6 +307,94 @@ void Config::setShowCompositePO2(bool show)
     }
 }
 
+// ---- Profile settings -----------------------------------------------------
+
+QColor Config::profileBackgroundColor() const { return m_profileBackgroundColor; }
+void Config::setProfileBackgroundColor(const QColor& color)
+{
+    if (m_profileBackgroundColor != color) {
+        m_profileBackgroundColor = color;
+        emit profileBackgroundColorChanged();
+    }
+}
+
+double Config::profileBackgroundOpacity() const { return m_profileBackgroundOpacity; }
+void Config::setProfileBackgroundOpacity(double opacity)
+{
+    opacity = qBound(0.0, opacity, 1.0);
+    if (qAbs(m_profileBackgroundOpacity - opacity) > 0.001) {
+        m_profileBackgroundOpacity = opacity;
+        emit profileBackgroundOpacityChanged();
+    }
+}
+
+QColor Config::profileCurveColor() const { return m_profileCurveColor; }
+void Config::setProfileCurveColor(const QColor& color)
+{
+    if (m_profileCurveColor != color) {
+        m_profileCurveColor = color;
+        emit profileCurveColorChanged();
+    }
+}
+
+QColor Config::profileIndicatorColor() const { return m_profileIndicatorColor; }
+void Config::setProfileIndicatorColor(const QColor& color)
+{
+    if (m_profileIndicatorColor != color) {
+        m_profileIndicatorColor = color;
+        emit profileIndicatorColorChanged();
+    }
+}
+
+int Config::profileIndicatorMode() const { return m_profileIndicatorMode; }
+void Config::setProfileIndicatorMode(int mode)
+{
+    if (m_profileIndicatorMode != mode) {
+        m_profileIndicatorMode = mode;
+        emit profileIndicatorModeChanged();
+    }
+}
+
+int Config::profileIndicatorRadius() const { return m_profileIndicatorRadius; }
+void Config::setProfileIndicatorRadius(int radius)
+{
+    radius = qMax(1, radius);
+    if (m_profileIndicatorRadius != radius) {
+        m_profileIndicatorRadius = radius;
+        emit profileIndicatorRadiusChanged();
+    }
+}
+
+int Config::profilePulsePeriodMs() const { return m_profilePulsePeriodMs; }
+void Config::setProfilePulsePeriodMs(int periodMs)
+{
+    periodMs = qMax(100, periodMs);
+    if (m_profilePulsePeriodMs != periodMs) {
+        m_profilePulsePeriodMs = periodMs;
+        emit profilePulsePeriodMsChanged();
+    }
+}
+
+int Config::profileOutputWidth() const { return m_profileOutputWidth; }
+void Config::setProfileOutputWidth(int w)
+{
+    w = qMax(16, w);
+    if (m_profileOutputWidth != w) {
+        m_profileOutputWidth = w;
+        emit profileOutputWidthChanged();
+    }
+}
+
+int Config::profileOutputHeight() const { return m_profileOutputHeight; }
+void Config::setProfileOutputHeight(int h)
+{
+    h = qMax(16, h);
+    if (m_profileOutputHeight != h) {
+        m_profileOutputHeight = h;
+        emit profileOutputHeightChanged();
+    }
+}
+
 void Config::loadConfig()
 {
     // Load general settings
@@ -359,6 +456,32 @@ void Config::loadConfig()
 
     // Load export settings
     m_frameRate = m_settings.value("export/frameRate", 10.0).toDouble();
+
+    // Load profile settings
+    {
+        const int bgR = m_settings.value("profile/backgroundColorR", 0).toInt();
+        const int bgG = m_settings.value("profile/backgroundColorG", 0).toInt();
+        const int bgB = m_settings.value("profile/backgroundColorB", 0).toInt();
+        m_profileBackgroundColor = QColor(bgR, bgG, bgB);
+    }
+    m_profileBackgroundOpacity = m_settings.value("profile/backgroundOpacity", 0.0).toDouble();
+    {
+        const int cR = m_settings.value("profile/curveColorR", 0x9C).toInt();
+        const int cG = m_settings.value("profile/curveColorG", 0x27).toInt();
+        const int cB = m_settings.value("profile/curveColorB", 0xB0).toInt();
+        m_profileCurveColor = QColor(cR, cG, cB);
+    }
+    {
+        const int iR = m_settings.value("profile/indicatorColorR", 0).toInt();
+        const int iG = m_settings.value("profile/indicatorColorG", 255).toInt();
+        const int iB = m_settings.value("profile/indicatorColorB", 0).toInt();
+        m_profileIndicatorColor = QColor(iR, iG, iB);
+    }
+    m_profileIndicatorMode = m_settings.value("profile/indicatorMode", 0).toInt();
+    m_profileIndicatorRadius = m_settings.value("profile/indicatorRadius", 8).toInt();
+    m_profilePulsePeriodMs = m_settings.value("profile/pulsePeriodMs", 2000).toInt();
+    m_profileOutputWidth = m_settings.value("profile/outputWidth", 1920).toInt();
+    m_profileOutputHeight = m_settings.value("profile/outputHeight", 400).toInt();
 }
 
 void Config::saveConfig()
@@ -408,7 +531,24 @@ void Config::saveConfig()
 
     // Save export settings
     m_settings.setValue("export/frameRate", m_frameRate);
-    
+
+    // Save profile settings
+    m_settings.setValue("profile/backgroundColorR", m_profileBackgroundColor.red());
+    m_settings.setValue("profile/backgroundColorG", m_profileBackgroundColor.green());
+    m_settings.setValue("profile/backgroundColorB", m_profileBackgroundColor.blue());
+    m_settings.setValue("profile/backgroundOpacity", m_profileBackgroundOpacity);
+    m_settings.setValue("profile/curveColorR", m_profileCurveColor.red());
+    m_settings.setValue("profile/curveColorG", m_profileCurveColor.green());
+    m_settings.setValue("profile/curveColorB", m_profileCurveColor.blue());
+    m_settings.setValue("profile/indicatorColorR", m_profileIndicatorColor.red());
+    m_settings.setValue("profile/indicatorColorG", m_profileIndicatorColor.green());
+    m_settings.setValue("profile/indicatorColorB", m_profileIndicatorColor.blue());
+    m_settings.setValue("profile/indicatorMode", m_profileIndicatorMode);
+    m_settings.setValue("profile/indicatorRadius", m_profileIndicatorRadius);
+    m_settings.setValue("profile/pulsePeriodMs", m_profilePulsePeriodMs);
+    m_settings.setValue("profile/outputWidth", m_profileOutputWidth);
+    m_settings.setValue("profile/outputHeight", m_profileOutputHeight);
+
     // Force write to disk
     m_settings.sync();
 }

--- a/src/export/image_export.cpp
+++ b/src/export/image_export.cpp
@@ -38,33 +38,34 @@ void ImageExporter::setFrameRate(double fps)
     }
 }
 
-bool ImageExporter::exportImages(DiveData* dive, OverlayGenerator* generator)
+bool ImageExporter::exportImages(DiveData* dive, QObject* generator)
 {
     if (!dive || !generator) {
-        emit exportError(tr("Invalid dive data or overlay generator"));
+        emit exportError(tr("Invalid dive data or generator"));
         return false;
     }
-    
+
     // Export the full dive
     return exportImageRange(dive, generator, 0, dive->durationSeconds());
 }
 
-bool ImageExporter::exportImageRange(DiveData* dive, OverlayGenerator* generator,
+bool ImageExporter::exportImageRange(DiveData* dive, QObject* generator,
                                      double startTime, double endTime)
 {
     if (m_busy) {
         emit exportError(tr("Already exporting images"));
         return false;
     }
-    
-    if (!dive || !generator) {
-        emit exportError(tr("Invalid dive data or overlay generator"));
+
+    IFrameGenerator* gen = dynamic_cast<IFrameGenerator*>(generator);
+    if (!dive || !gen) {
+        emit exportError(tr("Invalid dive data or generator"));
         return false;
     }
-    
+
     m_busy = true;
     emit busyChanged();
-    
+
     // Create the export directory if it doesn't exist
     QDir dir(m_exportPath);
     if (!dir.exists() && !dir.mkpath(".")) {
@@ -73,56 +74,56 @@ bool ImageExporter::exportImageRange(DiveData* dive, OverlayGenerator* generator
         emit busyChanged();
         return false;
     }
-    
+
     // Notify that export has started
     emit exportStarted();
 
-    // Disable cell backgrounds for export
-    bool prevShowCellBg = generator->showCellBackgrounds();
-    generator->setShowCellBackgrounds(false);
+    // Let the generator stage any export-only state (e.g. overlay hides its
+    // editor-only cell backgrounds).
+    gen->beginExport();
 
     // Calculate the number of frames to generate
     double timeStep = 1.0 / m_frameRate;
     int totalFrames = qRound((endTime - startTime) * m_frameRate);
     int processedFrames = 0;
-    
-    qDebug() << "Exporting images from" << startTime << "to" << endTime 
+
+    qDebug() << "Exporting images from" << startTime << "to" << endTime
              << "at" << m_frameRate << "fps (" << totalFrames << "frames)";
-    
+
     // Generate and save images
     for (double time = startTime; time <= endTime; time += timeStep) {
-        // Generate the overlay for this time point
-        QImage overlay = generator->generateOverlay(dive, time);
-        
+        // Generate the frame for this time point
+        QImage overlay = gen->generate(dive, time);
+
         if (overlay.isNull()) {
-            qWarning() << "Failed to generate overlay at time:" << time;
+            qWarning() << "Failed to generate frame at time:" << time;
             continue;
         }
-        
+
         // Create a filename with the frame number
         QString frameNumberStr = QString("%1").arg(processedFrames, 6, 10, QChar('0'));
         QString filename = QString("frame_%1.png").arg(frameNumberStr);
         QString filePath = QDir(m_exportPath).filePath(filename);
-        
+
         // Save the image
         if (!overlay.save(filePath, "PNG")) {
+            gen->endExport();
             emit exportError(tr("Failed to save image: %1").arg(filePath));
             m_busy = false;
             emit busyChanged();
             return false;
         }
-        
+
         // Update progress
         processedFrames++;
         m_progress = (processedFrames * 100) / totalFrames;
         emit progressChanged();
-        
+
         // Process events to keep UI responsive
         QCoreApplication::processEvents();
     }
-    
-    // Restore cell background setting
-    generator->setShowCellBackgrounds(prevShowCellBg);
+
+    gen->endExport();
 
     // Export completed successfully
     m_progress = 100;
@@ -135,14 +136,16 @@ bool ImageExporter::exportImageRange(DiveData* dive, OverlayGenerator* generator
     return true;
 }
 
-QString ImageExporter::createDefaultExportDir(DiveData* dive, const QString &videoFilePath)
+QString ImageExporter::createDefaultExportDir(DiveData* dive,
+                                              const QString &videoFilePath,
+                                              const QString &contentType)
 {
     if (!dive) {
         return QString();
     }
 
     // Create a unique directory for this dive
-    QString dirName = generateUniqueDirectoryName(dive, videoFilePath);
+    QString dirName = generateUniqueDirectoryName(dive, videoFilePath, contentType);
     QString path = QDir(m_exportPath).filePath(dirName);
 
     QDir dir;
@@ -154,7 +157,9 @@ QString ImageExporter::createDefaultExportDir(DiveData* dive, const QString &vid
     return path;
 }
 
-QString ImageExporter::generateUniqueDirectoryName(DiveData* dive, const QString &videoFilePath)
+QString ImageExporter::generateUniqueDirectoryName(DiveData* dive,
+                                                   const QString &videoFilePath,
+                                                   const QString &contentType)
 {
     QString baseName;
 
@@ -182,6 +187,12 @@ QString ImageExporter::generateUniqueDirectoryName(DiveData* dive, const QString
         if (!videoStem.isEmpty()) {
             baseName += "_" + sanitizeFileName(videoStem);
         }
+    }
+
+    // Append the content-type tag (e.g. "dive_computer" / "dive_profile")
+    // so exports of different overlays for the same dive don't collide.
+    if (!contentType.isEmpty()) {
+        baseName += "_" + sanitizeFileName(contentType);
     }
 
     return baseName;

--- a/src/export/video_export.cpp
+++ b/src/export/video_export.cpp
@@ -177,12 +177,12 @@ QString VideoExporter::getFileExtensionForCodec(const QString &codec)
     return "mp4";
 }
 
-bool VideoExporter::exportVideo(DiveData* dive, OverlayGenerator* generator,
+bool VideoExporter::exportVideo(DiveData* dive, QObject* generator,
                               double startTime, double endTime)
 {
     qDebug() << "======== EXPORT VIDEO CALLED ========";
     qDebug() << "Parameters:" << startTime << "to" << endTime;
-    
+
     m_exportStartTime = startTime;
     m_exportEndTime = endTime;
 
@@ -190,9 +190,10 @@ bool VideoExporter::exportVideo(DiveData* dive, OverlayGenerator* generator,
         emit exportError(tr("Already exporting video"));
         return false;
     }
-    
-    if (!dive || !generator) {
-        emit exportError(tr("Invalid dive data or overlay generator"));
+
+    IFrameGenerator* gen = dynamic_cast<IFrameGenerator*>(generator);
+    if (!dive || !gen) {
+        emit exportError(tr("Invalid dive data or generator"));
         return false;
     }
     
@@ -242,7 +243,7 @@ bool VideoExporter::exportVideo(DiveData* dive, OverlayGenerator* generator,
     }
     
     // First generate all the frames
-    bool framesGenerated = generateFrames(dive, generator, startTime, endTime);
+    bool framesGenerated = generateFrames(dive, gen, startTime, endTime);
     if (!framesGenerated) {
         cleanupTempFiles();
         m_busy = false;
@@ -305,62 +306,62 @@ void VideoExporter::cleanupTempFiles()
     }
 }
 
-bool VideoExporter::generateFrames(DiveData* dive, OverlayGenerator* generator,
+bool VideoExporter::generateFrames(DiveData* dive, IFrameGenerator* generator,
                                  double startTime, double endTime)
 {
     // Calculate the number of frames to generate
     double timeStep = 1.0 / m_frameRate;
     int totalFrames = qRound((endTime - startTime) * m_frameRate);
     int processedFrames = 0;
-    
+
     qDebug() << "Generating frames from" << startTime << "to" << endTime
              << "at" << m_frameRate << "fps (" << totalFrames << "frames)";
 
-    // Disable cell backgrounds for export
-    bool prevShowCellBg = generator->showCellBackgrounds();
-    generator->setShowCellBackgrounds(false);
-    
+    // Stage any export-only generator state (e.g. overlay's editor-only
+    // cell backgrounds get hidden for the duration of this loop).
+    generator->beginExport();
+
     // Clear any previous temp files and ensure the temp directory exists
     if (!m_tempDir.isValid()) {
+        generator->endExport();
         emit exportError(tr("Failed to create temporary directory for frame storage"));
         return false;
     }
-    
+
     QString tempDirPath = m_tempDir.path();
-    
+
     // Generate and save frames
     for (double time = startTime; time <= endTime; time += timeStep) {
-        // Generate the overlay for this time point
-        QImage overlay = generator->generateOverlay(dive, time);
-        
+        // Generate the frame for this time point
+        QImage overlay = generator->generate(dive, time);
+
         if (overlay.isNull()) {
-            qWarning() << "Failed to generate overlay at time:" << time;
+            qWarning() << "Failed to generate frame at time:" << time;
             continue;
         }
-        
+
         // Create a filename with the frame number
         QString frameNumberStr = QString("%1").arg(processedFrames, 6, 10, QChar('0'));
         QString filename = QString("frame_%1.png").arg(frameNumberStr);
         QString filePath = QDir(tempDirPath).filePath(filename);
-        
+
         // Save the image
         if (!overlay.save(filePath, "PNG")) {
+            generator->endExport();
             emit exportError(tr("Failed to save frame: %1").arg(filePath));
             return false;
         }
-        
+
         // Update progress
         processedFrames++;
         m_progress = (processedFrames * 50) / totalFrames; // Frame generation is 50% of total progress
         emit progressChanged();
-        
+
         // Process events to keep UI responsive
         QCoreApplication::processEvents();
     }
 
-    // Restore cell background setting
-    generator->setShowCellBackgrounds(prevShowCellBg);
-
+    generator->endExport();
     return true;
 }
 
@@ -800,7 +801,9 @@ QSize VideoExporter::detectVideoResolution(const QString &videoPath)
     return getDefaultOverlaySize();
 }
 
-QString VideoExporter::createDefaultExportFile(DiveData* dive, const QString &videoFilePath)
+QString VideoExporter::createDefaultExportFile(DiveData* dive,
+                                               const QString &videoFilePath,
+                                               const QString &contentType)
 {
     if (!dive) {
         return QString();
@@ -808,11 +811,14 @@ QString VideoExporter::createDefaultExportFile(DiveData* dive, const QString &vi
 
     // Generate a unique file name for this dive
     QString extension = getFileExtensionForCodec(m_videoCodec);
-    m_pendingOutputPath = generateUniqueFileName(dive, extension, videoFilePath);
+    m_pendingOutputPath = generateUniqueFileName(dive, extension, videoFilePath, contentType);
     return m_pendingOutputPath;
 }
 
-QString VideoExporter::generateUniqueFileName(DiveData* dive, const QString &extension, const QString &videoFilePath)
+QString VideoExporter::generateUniqueFileName(DiveData* dive,
+                                              const QString &extension,
+                                              const QString &videoFilePath,
+                                              const QString &contentType)
 {
     QString baseName;
 
@@ -840,6 +846,12 @@ QString VideoExporter::generateUniqueFileName(DiveData* dive, const QString &ext
         if (!videoStem.isEmpty()) {
             baseName += "_" + sanitizeFileName(videoStem);
         }
+    }
+
+    // Append the content-type tag (e.g. "dive_computer" / "dive_profile")
+    // so two exports of the same dive land in distinct files.
+    if (!contentType.isEmpty()) {
+        baseName += "_" + sanitizeFileName(contentType);
     }
 
     // Add extension

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -317,6 +317,19 @@ void OverlayGenerator::setShowCellBackgrounds(bool show)
     }
 }
 
+void OverlayGenerator::beginExport()
+{
+    // Cell backgrounds are an editor-only affordance — never render them
+    // into export frames. Stash the user's current value and force off.
+    m_savedShowCellBackgrounds = m_showCellBackgrounds;
+    m_showCellBackgrounds = false;
+}
+
+void OverlayGenerator::endExport()
+{
+    m_showCellBackgrounds = m_savedShowCellBackgrounds;
+}
+
 QStringList OverlayGenerator::getAvailableTemplates()
 {
     if (m_templateNames.isEmpty()) {

--- a/src/generators/profile_gen.cpp
+++ b/src/generators/profile_gen.cpp
@@ -1,0 +1,179 @@
+#include "include/generators/profile_gen.h"
+
+#include <QPainter>
+
+#include <cmath>
+
+#include "include/core/config.h"
+#include "include/generators/profile_renderer.h"
+
+ProfileGenerator::ProfileGenerator(QObject* parent)
+    : QObject(parent)
+{
+    // Seed from Config so settings persist across sessions.
+    Config* cfg = Config::instance();
+    m_backgroundColor   = cfg->profileBackgroundColor();
+    m_backgroundOpacity = cfg->profileBackgroundOpacity();
+    m_curveColor        = cfg->profileCurveColor();
+    m_indicatorColor    = cfg->profileIndicatorColor();
+    m_indicatorMode     = static_cast<IndicatorMode>(cfg->profileIndicatorMode());
+    m_indicatorRadius   = cfg->profileIndicatorRadius();
+    m_pulsePeriodMs     = cfg->profilePulsePeriodMs();
+    m_outputWidth       = cfg->profileOutputWidth();
+    m_outputHeight      = cfg->profileOutputHeight();
+
+    // Stay in sync with Config — settings changes flowing in from anywhere
+    // (e.g. another window, future preferences dialog) propagate to here.
+    connect(cfg, &Config::profileBackgroundColorChanged, this, [this]() {
+        m_backgroundColor = Config::instance()->profileBackgroundColor();
+        emit backgroundColorChanged();
+    });
+    connect(cfg, &Config::profileBackgroundOpacityChanged, this, [this]() {
+        m_backgroundOpacity = Config::instance()->profileBackgroundOpacity();
+        emit backgroundOpacityChanged();
+    });
+    connect(cfg, &Config::profileCurveColorChanged, this, [this]() {
+        m_curveColor = Config::instance()->profileCurveColor();
+        emit curveColorChanged();
+    });
+    connect(cfg, &Config::profileIndicatorColorChanged, this, [this]() {
+        m_indicatorColor = Config::instance()->profileIndicatorColor();
+        emit indicatorColorChanged();
+    });
+    connect(cfg, &Config::profileIndicatorModeChanged, this, [this]() {
+        m_indicatorMode = static_cast<IndicatorMode>(Config::instance()->profileIndicatorMode());
+        emit indicatorModeChanged();
+    });
+    connect(cfg, &Config::profileIndicatorRadiusChanged, this, [this]() {
+        m_indicatorRadius = Config::instance()->profileIndicatorRadius();
+        emit indicatorRadiusChanged();
+    });
+    connect(cfg, &Config::profilePulsePeriodMsChanged, this, [this]() {
+        m_pulsePeriodMs = Config::instance()->profilePulsePeriodMs();
+        emit pulsePeriodMsChanged();
+    });
+    connect(cfg, &Config::profileOutputWidthChanged, this, [this]() {
+        m_outputWidth = Config::instance()->profileOutputWidth();
+        emit outputWidthChanged();
+    });
+    connect(cfg, &Config::profileOutputHeightChanged, this, [this]() {
+        m_outputHeight = Config::instance()->profileOutputHeight();
+        emit outputHeightChanged();
+    });
+}
+
+void ProfileGenerator::setBackgroundColor(const QColor& c)
+{
+    if (m_backgroundColor != c) {
+        m_backgroundColor = c;
+        Config::instance()->setProfileBackgroundColor(c);
+        emit backgroundColorChanged();
+    }
+}
+
+void ProfileGenerator::setBackgroundOpacity(double o)
+{
+    o = qBound(0.0, o, 1.0);
+    if (qAbs(m_backgroundOpacity - o) > 0.001) {
+        m_backgroundOpacity = o;
+        Config::instance()->setProfileBackgroundOpacity(o);
+        emit backgroundOpacityChanged();
+    }
+}
+
+void ProfileGenerator::setCurveColor(const QColor& c)
+{
+    if (m_curveColor != c) {
+        m_curveColor = c;
+        Config::instance()->setProfileCurveColor(c);
+        emit curveColorChanged();
+    }
+}
+
+void ProfileGenerator::setIndicatorColor(const QColor& c)
+{
+    if (m_indicatorColor != c) {
+        m_indicatorColor = c;
+        Config::instance()->setProfileIndicatorColor(c);
+        emit indicatorColorChanged();
+    }
+}
+
+void ProfileGenerator::setIndicatorMode(IndicatorMode m)
+{
+    if (m_indicatorMode != m) {
+        m_indicatorMode = m;
+        Config::instance()->setProfileIndicatorMode(static_cast<int>(m));
+        emit indicatorModeChanged();
+    }
+}
+
+void ProfileGenerator::setIndicatorRadius(int r)
+{
+    r = qMax(1, r);
+    if (m_indicatorRadius != r) {
+        m_indicatorRadius = r;
+        Config::instance()->setProfileIndicatorRadius(r);
+        emit indicatorRadiusChanged();
+    }
+}
+
+void ProfileGenerator::setPulsePeriodMs(int ms)
+{
+    ms = qMax(100, ms);
+    if (m_pulsePeriodMs != ms) {
+        m_pulsePeriodMs = ms;
+        Config::instance()->setProfilePulsePeriodMs(ms);
+        emit pulsePeriodMsChanged();
+    }
+}
+
+void ProfileGenerator::setOutputWidth(int w)
+{
+    w = qMax(16, w);
+    if (m_outputWidth != w) {
+        m_outputWidth = w;
+        Config::instance()->setProfileOutputWidth(w);
+        emit outputWidthChanged();
+    }
+}
+
+void ProfileGenerator::setOutputHeight(int h)
+{
+    h = qMax(16, h);
+    if (m_outputHeight != h) {
+        m_outputHeight = h;
+        Config::instance()->setProfileOutputHeight(h);
+        emit outputHeightChanged();
+    }
+}
+
+QImage ProfileGenerator::generate(DiveData* dive, double timePoint)
+{
+    // Export path: pulse phase is deterministic from the dive-time so a
+    // sequence of exported frames advances the pulse predictably.
+    const double pulsePhase01 = (m_pulsePeriodMs > 0)
+        ? std::fmod(timePoint * 1000.0, static_cast<double>(m_pulsePeriodMs)) / m_pulsePeriodMs
+        : 0.0;
+    return renderFrame(dive, timePoint, pulsePhase01);
+}
+
+QImage ProfileGenerator::renderFrame(DiveData* dive, double timePoint, double pulsePhase01)
+{
+    QImage img(m_outputWidth, m_outputHeight, QImage::Format_ARGB32_Premultiplied);
+    img.fill(Qt::transparent);
+    if (!dive) {
+        return img;
+    }
+
+    QPainter painter(&img);
+    const QRectF rect(0, 0, m_outputWidth, m_outputHeight);
+
+    ProfileRenderer::drawBackground(painter, rect, m_backgroundColor, m_backgroundOpacity);
+    ProfileRenderer::drawDepthCurve(painter, rect, dive, m_curveColor);
+    ProfileRenderer::drawIndicator(painter, rect, dive, timePoint, m_indicatorColor,
+                                   static_cast<double>(m_indicatorRadius),
+                                   m_indicatorMode == Pulsing, pulsePhase01);
+
+    return img;
+}

--- a/src/generators/profile_image_provider.cpp
+++ b/src/generators/profile_image_provider.cpp
@@ -1,0 +1,83 @@
+#include "include/generators/profile_image_provider.h"
+
+#include <QDebug>
+
+ProfileImageProvider* g_profileImageProvider = nullptr;
+
+ProfileImageProvider::ProfileImageProvider(ProfileGenerator* generator)
+    : QQuickImageProvider(QQuickImageProvider::Image)
+    , m_generator(generator)
+    , m_currentDive(nullptr)
+    , m_currentTime(0.0)
+{
+}
+
+QImage ProfileImageProvider::requestImage(const QString& id, QSize* size, const QSize& requestedSize)
+{
+    if (!m_generator || !m_currentDive) {
+        QImage empty(m_generator ? m_generator->outputWidth() : 1920,
+                     m_generator ? m_generator->outputHeight() : 400,
+                     QImage::Format_ARGB32_Premultiplied);
+        empty.fill(Qt::transparent);
+        if (size) {
+            *size = empty.size();
+        }
+        return empty;
+    }
+
+    QImage result;
+    if (id.startsWith("preview/")) {
+        // Preview path. The URL may carry an explicit pulse phase so the live
+        // preview can animate the indicator on wall-clock time while the dive
+        // cursor is idle. URL form: preview/phase=<0..1>/<cachebust>
+        // Without a phase, fall back to timestamp-derived (matches export).
+        double phase = -1.0;
+        const int phaseIdx = id.indexOf(QStringLiteral("phase="));
+        if (phaseIdx >= 0) {
+            const int valStart = phaseIdx + 6;
+            const int valEnd = id.indexOf(QLatin1Char('/'), valStart);
+            const QString phaseStr = (valEnd >= 0)
+                ? id.mid(valStart, valEnd - valStart)
+                : id.mid(valStart);
+            bool ok = false;
+            const double v = phaseStr.toDouble(&ok);
+            if (ok) {
+                phase = v;
+            }
+        }
+        if (phase >= 0.0) {
+            result = m_generator->renderFrame(m_currentDive, m_currentTime, phase);
+        } else {
+            result = m_generator->generate(m_currentDive, m_currentTime);
+        }
+    } else {
+        // Numeric id path — used for explicit timestamp requests (e.g. exports).
+        bool ok = false;
+        const double t = id.toDouble(&ok);
+        result = m_generator->generate(m_currentDive, ok ? t : m_currentTime);
+    }
+
+    if (result.isNull()) {
+        result = QImage(m_generator->outputWidth(), m_generator->outputHeight(),
+                        QImage::Format_ARGB32_Premultiplied);
+        result.fill(Qt::transparent);
+    }
+
+    if (size) {
+        *size = result.size();
+    }
+    if (requestedSize.isValid() && requestedSize != result.size()) {
+        result = result.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    }
+    return result;
+}
+
+void ProfileImageProvider::setCurrentDive(DiveData* dive)
+{
+    m_currentDive = dive;
+}
+
+void ProfileImageProvider::setCurrentTime(double time)
+{
+    m_currentTime = time;
+}

--- a/src/generators/profile_renderer.cpp
+++ b/src/generators/profile_renderer.cpp
@@ -1,0 +1,154 @@
+#include "include/generators/profile_renderer.h"
+#include "include/core/dive_data.h"
+
+#include <QPainterPath>
+#include <QtMath>
+
+#include <algorithm>
+
+namespace ProfileRenderer {
+
+namespace {
+
+// Compute the depth-axis maximum, with a 5% headroom above the actual maxDepth
+// so the curve never touches the very bottom of the rect. Returns 0 for invalid
+// dives (caller should skip drawing).
+double depthAxisMax(DiveData* dive)
+{
+    if (!dive) {
+        return 0.0;
+    }
+    const double m = dive->maxDepth();
+    if (m <= 0.0) {
+        return 0.0;
+    }
+    return m * 1.05;
+}
+
+double timeAxisMax(DiveData* dive)
+{
+    if (!dive) {
+        return 0.0;
+    }
+    return static_cast<double>(dive->durationSeconds());
+}
+
+// Map a (timestamp, depth) sample into pixel coords inside rect.
+QPointF samplePoint(const QRectF& rect, double t, double depth,
+                    double tMax, double depthMax)
+{
+    const double xFrac = (tMax > 0.0) ? (t / tMax) : 0.0;
+    const double yFrac = (depthMax > 0.0) ? (depth / depthMax) : 0.0;
+    return QPointF(rect.left() + xFrac * rect.width(),
+                   rect.top() + yFrac * rect.height());
+}
+
+} // anonymous namespace
+
+void drawBackground(QPainter& p, const QRectF& rect, const QColor& bg, double opacity)
+{
+    if (opacity <= 0.0) {
+        return; // fully transparent — leave the canvas alone
+    }
+    QColor c = bg;
+    c.setAlphaF(std::clamp(opacity, 0.0, 1.0) * (bg.alphaF() > 0 ? bg.alphaF() : 1.0));
+    p.fillRect(rect, c);
+}
+
+void drawDepthCurve(QPainter& p, const QRectF& rect, DiveData* dive,
+                    const QColor& color, double lineWidth)
+{
+    if (!dive) {
+        return;
+    }
+    const auto& points = dive->allDataPoints();
+    if (points.size() < 2) {
+        return;
+    }
+    const double depthMax = depthAxisMax(dive);
+    const double tMax = timeAxisMax(dive);
+    if (depthMax <= 0.0 || tMax <= 0.0) {
+        return;
+    }
+
+    QPainterPath path;
+    bool first = true;
+    for (const DiveDataPoint& pt : points) {
+        const QPointF pix = samplePoint(rect, pt.timestamp, pt.depth, tMax, depthMax);
+        if (first) {
+            path.moveTo(pix);
+            first = false;
+        } else {
+            path.lineTo(pix);
+        }
+    }
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, true);
+    QPen pen(color);
+    pen.setWidthF(lineWidth);
+    pen.setJoinStyle(Qt::RoundJoin);
+    pen.setCapStyle(Qt::RoundCap);
+    p.setPen(pen);
+    p.setBrush(Qt::NoBrush);
+    p.drawPath(path);
+    p.restore();
+}
+
+void drawIndicator(QPainter& p, const QRectF& rect, DiveData* dive,
+                   double currentTimeSec, const QColor& color,
+                   double radius, bool pulsing, double pulsePhase01)
+{
+    if (!dive || radius <= 0.0) {
+        return;
+    }
+    const double depthMax = depthAxisMax(dive);
+    const double tMax = timeAxisMax(dive);
+    if (depthMax <= 0.0 || tMax <= 0.0) {
+        return;
+    }
+
+    const DiveDataPoint sample = dive->dataAtTime(currentTimeSec);
+    const QPointF center = samplePoint(rect, currentTimeSec, sample.depth, tMax, depthMax);
+
+    // Pulse envelope: cosine ramp giving a deterministic 0..1..0 amplitude
+    // over the period. We use this both for the dot size and for a translucent
+    // "halo" ring drawn around it, so the pulse is visible even when the
+    // radius setting is small.
+    double envelope = 0.0;
+    double scale = 1.0;
+    if (pulsing) {
+        const double phase = std::clamp(pulsePhase01, 0.0, 1.0);
+        envelope = 0.5 - 0.5 * std::cos(phase * 2.0 * M_PI); // 0..1..0
+        scale = 1.0 + 0.6 * envelope;                         // 1.0 → 1.6 → 1.0
+    }
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    // Halo: expanding translucent ring while pulsing (more visible than
+    // size modulation alone, especially with small indicator radii).
+    if (pulsing && envelope > 0.01) {
+        const double haloRadius = radius * (1.0 + 1.6 * envelope);
+        QColor halo = color;
+        halo.setAlphaF(std::clamp(color.alphaF() * (1.0 - envelope) * 0.6, 0.0, 1.0));
+        p.setPen(Qt::NoPen);
+        p.setBrush(halo);
+        p.drawEllipse(center, haloRadius, haloRadius);
+    }
+
+    // Core dot — subtle dark outline so it stays visible on any background.
+    QColor outline = Qt::black;
+    outline.setAlphaF(0.6);
+    QPen pen(outline);
+    pen.setWidthF(1.5);
+    p.setPen(pen);
+    p.setBrush(color);
+
+    const double r = radius * scale;
+    p.drawEllipse(center, r, r);
+
+    p.restore();
+}
+
+} // namespace ProfileRenderer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,8 @@
 #include "include/export/image_export.h"
 #include "include/export/video_export.h"
 #include "include/generators/overlay_image_provider.h"
+#include "include/generators/profile_gen.h"
+#include "include/generators/profile_image_provider.h"
 #include "include/core/config.h"
 #include "include/core/units.h"
 #include "include/core/update_checker.h"
@@ -41,10 +43,19 @@ int main(int argc, char *argv[])
     qmlRegisterType<Timeline>("Unabara.UI", 1, 0, "Timeline");
     qmlRegisterType<CellModel>("Unabara.UI", 1, 0, "CellModel");
     qmlRegisterType<OverlayGenerator>("Unabara.Generators", 1, 0, "OverlayGenerator");
+    qmlRegisterType<ProfileGenerator>("Unabara.Generators", 1, 0, "ProfileGenerator");
     qmlRegisterType<ImageExporter>("Unabara.Export", 1, 0, "ImageExporter");
     qmlRegisterType<VideoExporter>("Unabara.Export", 1, 0, "VideoExporter");
     qmlRegisterUncreatableMetaObject(Units::staticMetaObject, "Unabara.Core", 1, 0, "Units", "Units is a utility class");
     
+    // Persist configuration on application quit. Config's destructor calls
+    // saveConfig(), but the singleton is never explicitly deleted, so without
+    // this hook only the few setters that explicitly call saveConfig() persist
+    // their values across runs.
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, []() {
+        Config::instance()->saveConfig();
+    });
+
     // Create the QML engine
     QQmlApplicationEngine engine;
     
@@ -63,17 +74,25 @@ int main(int argc, char *argv[])
     engine.addImageProvider("overlay", imageProvider);
 
     g_imageProvider = imageProvider;  // Set the global variable
-    
+
+    // Create the profile generator and image provider (mirrors the overlay pair)
+    ProfileGenerator* profileGenerator = new ProfileGenerator();
+    ProfileImageProvider* profileImageProvider = new ProfileImageProvider(profileGenerator);
+    engine.addImageProvider("profile", profileImageProvider);
+    g_profileImageProvider = profileImageProvider;
+
     // Connect the LogParser signals to MainWindow slots
-    QObject::connect(&logParser, &LogParser::diveImported, 
+    QObject::connect(&logParser, &LogParser::diveImported,
                      &mainWindow, &MainWindow::onDiveImported);
-    QObject::connect(&logParser, &LogParser::multipleImported, 
+    QObject::connect(&logParser, &LogParser::multipleImported,
                      &mainWindow, &MainWindow::onMultipleDivesImported);
-    
-    // Connect signals to update the image provider
-    QObject::connect(&mainWindow, &MainWindow::currentDiveChanged, 
-                    [imageProvider, &mainWindow]() {
-                        imageProvider->setCurrentDive(mainWindow.currentDive());
+
+    // Connect signals to update the image providers when the active dive changes
+    QObject::connect(&mainWindow, &MainWindow::currentDiveChanged,
+                    [imageProvider, profileImageProvider, &mainWindow]() {
+                        DiveData* dive = mainWindow.currentDive();
+                        imageProvider->setCurrentDive(dive);
+                        profileImageProvider->setCurrentDive(dive);
                     });
     
     qDebug() << "Connected LogParser::diveImported to MainWindow::onDiveImported";
@@ -82,6 +101,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("mainWindow", &mainWindow);
     engine.rootContext()->setContextProperty("logParser", &logParser);
     engine.rootContext()->setContextProperty("overlayGenerator", overlayGenerator);
+    engine.rootContext()->setContextProperty("profileGenerator", profileGenerator);
     engine.rootContext()->setContextProperty("config", Config::instance());
 
     // Expose version to QML

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1,5 +1,6 @@
 #include "include/ui/main_window.h"
 #include "include/generators/overlay_image_provider.h"
+#include "include/generators/profile_image_provider.h"
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QCoreApplication>
@@ -22,12 +23,16 @@ void MainWindow::setCurrentDive(DiveData* dive)
     if (m_currentDive != dive) {
         m_currentDive = dive;
         
-        // Update the global image provider with the new dive
+        // Update the global image providers with the new dive
         extern OverlayImageProvider* g_imageProvider;
         if (g_imageProvider) {
             g_imageProvider->setCurrentDive(dive);
         }
-        
+        extern ProfileImageProvider* g_profileImageProvider;
+        if (g_profileImageProvider) {
+            g_profileImageProvider->setCurrentDive(dive);
+        }
+
         emit currentDiveChanged();
     }
 }

--- a/src/ui/qml/ProfileEditor.qml
+++ b/src/ui/qml/ProfileEditor.qml
@@ -1,0 +1,224 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Dialogs
+import Unabara.Generators 1.0
+
+Item {
+    id: root
+
+    property var generator
+    implicitHeight: mainColumn.implicitHeight
+    implicitWidth: 400
+
+    // Which color the active ColorDialog is currently editing.
+    // Set when one of the three color buttons is clicked; consumed by the dialog's onAccepted.
+    property string colorTarget: ""
+
+    ColumnLayout {
+        id: mainColumn
+        anchors.fill: parent
+        anchors.margins: 10
+        spacing: 12
+
+        GroupBox {
+            title: qsTr("Background")
+            Layout.fillWidth: true
+
+            GridLayout {
+                anchors.fill: parent
+                columns: 3
+                rowSpacing: 8
+                columnSpacing: 8
+
+                Label { text: qsTr("Color:") }
+                Button {
+                    id: bgColorButton
+                    Layout.fillWidth: true
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.generator ? root.generator.backgroundColor : "black"
+                        border.color: palette.mid
+                        border.width: 1
+                    }
+                    onClicked: {
+                        root.colorTarget = "background"
+                        colorDialog.selectedColor = root.generator ? root.generator.backgroundColor : "black"
+                        colorDialog.open()
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                Label { text: qsTr("Opacity:") }
+                Slider {
+                    id: bgOpacitySlider
+                    Layout.fillWidth: true
+                    from: 0.0
+                    to: 1.0
+                    value: root.generator ? root.generator.backgroundOpacity : 0.0
+                    onMoved: {
+                        if (root.generator) root.generator.backgroundOpacity = value
+                    }
+                }
+                Label {
+                    text: bgOpacitySlider.value.toFixed(2)
+                    Layout.preferredWidth: 40
+                }
+            }
+        }
+
+        GroupBox {
+            title: qsTr("Depth Curve")
+            Layout.fillWidth: true
+
+            GridLayout {
+                anchors.fill: parent
+                columns: 2
+                rowSpacing: 8
+                columnSpacing: 8
+
+                Label { text: qsTr("Color:") }
+                Button {
+                    id: curveColorButton
+                    Layout.fillWidth: true
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.generator ? root.generator.curveColor : "purple"
+                        border.color: palette.mid
+                        border.width: 1
+                    }
+                    onClicked: {
+                        root.colorTarget = "curve"
+                        colorDialog.selectedColor = root.generator ? root.generator.curveColor : "purple"
+                        colorDialog.open()
+                    }
+                }
+            }
+        }
+
+        GroupBox {
+            title: qsTr("Indicator")
+            Layout.fillWidth: true
+
+            GridLayout {
+                anchors.fill: parent
+                columns: 2
+                rowSpacing: 8
+                columnSpacing: 8
+
+                Label { text: qsTr("Color:") }
+                Button {
+                    id: indicatorColorButton
+                    Layout.fillWidth: true
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.generator ? root.generator.indicatorColor : "lime"
+                        border.color: palette.mid
+                        border.width: 1
+                    }
+                    onClicked: {
+                        root.colorTarget = "indicator"
+                        colorDialog.selectedColor = root.generator ? root.generator.indicatorColor : "lime"
+                        colorDialog.open()
+                    }
+                }
+
+                Label { text: qsTr("Mode:") }
+                ComboBox {
+                    id: modeCombo
+                    Layout.fillWidth: true
+                    model: [qsTr("Static"), qsTr("Pulsing")]
+                    currentIndex: root.generator ? root.generator.indicatorMode : 0
+                    onActivated: {
+                        if (root.generator) root.generator.indicatorMode = currentIndex
+                    }
+                }
+
+                Label { text: qsTr("Radius (px):") }
+                SpinBox {
+                    id: radiusSpin
+                    Layout.fillWidth: true
+                    from: 1
+                    to: 64
+                    value: root.generator ? root.generator.indicatorRadius : 8
+                    onValueModified: {
+                        if (root.generator) root.generator.indicatorRadius = value
+                    }
+                }
+
+                Label {
+                    text: qsTr("Pulse period (ms):")
+                    visible: modeCombo.currentIndex === 1
+                }
+                SpinBox {
+                    id: pulseSpin
+                    Layout.fillWidth: true
+                    from: 200
+                    to: 10000
+                    stepSize: 100
+                    value: root.generator ? root.generator.pulsePeriodMs : 2000
+                    visible: modeCombo.currentIndex === 1
+                    onValueModified: {
+                        if (root.generator) root.generator.pulsePeriodMs = value
+                    }
+                }
+            }
+        }
+
+        GroupBox {
+            title: qsTr("Output Resolution")
+            Layout.fillWidth: true
+
+            GridLayout {
+                anchors.fill: parent
+                columns: 2
+                rowSpacing: 8
+                columnSpacing: 8
+
+                Label { text: qsTr("Width (px):") }
+                SpinBox {
+                    id: widthSpin
+                    Layout.fillWidth: true
+                    from: 64
+                    to: 7680
+                    stepSize: 16
+                    value: root.generator ? root.generator.outputWidth : 1920
+                    onValueModified: {
+                        if (root.generator) root.generator.outputWidth = value
+                    }
+                }
+
+                Label { text: qsTr("Height (px):") }
+                SpinBox {
+                    id: heightSpin
+                    Layout.fillWidth: true
+                    from: 64
+                    to: 4320
+                    stepSize: 16
+                    value: root.generator ? root.generator.outputHeight : 400
+                    onValueModified: {
+                        if (root.generator) root.generator.outputHeight = value
+                    }
+                }
+            }
+        }
+
+        Item { Layout.fillHeight: true }
+    }
+
+    ColorDialog {
+        id: colorDialog
+        title: qsTr("Select Color")
+        onAccepted: {
+            if (!root.generator) return
+            switch (root.colorTarget) {
+            case "background": root.generator.backgroundColor = selectedColor; break
+            case "curve":      root.generator.curveColor = selectedColor; break
+            case "indicator":  root.generator.indicatorColor = selectedColor; break
+            }
+        }
+    }
+}

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -263,10 +263,26 @@ ApplicationWindow {
             }
             
             ToolButton {
-                text: qsTr("Export")
+                // Exports whichever overlay the currently active tab represents.
+                // Tab 0 = dive computer overlay, Tab 1 = dive profile. Tab 2
+                // (video preview placeholder) has nothing to export yet, so
+                // the button is disabled there.
+                text: {
+                    if (contentTabs.currentIndex === 1) return qsTr("Export Profile")
+                    return qsTr("Export Overlay")
+                }
                 icon.name: "document-save"
-                enabled: mainWindow.hasActiveDive
+                enabled: mainWindow.hasActiveDive && contentTabs.currentIndex !== 2
                 onClicked: {
+                    if (contentTabs.currentIndex === 1) {
+                        exportImagesDialog.targetGenerator = profileGenerator
+                        exportImagesDialog.contentType = "dive_profile"
+                        exportImagesDialog.title = qsTr("Export Dive Profile")
+                    } else {
+                        exportImagesDialog.targetGenerator = overlayGenerator
+                        exportImagesDialog.contentType = "dive_computer"
+                        exportImagesDialog.title = qsTr("Export Dive Computer Overlay")
+                    }
                     exportImagesDialog.open()
                 }
             }
@@ -298,12 +314,34 @@ ApplicationWindow {
         anchors.fill: parent
         orientation: Qt.Vertical
         
-        // Main content area with horizontal split for overlay editor panel
-        SplitView {
-            id: mainContentArea
+        // Tab container: overlay (Tab 1), dive profile (Tab 2), video preview (Tab 3).
+        // Timeline below stays global so all tabs share the same temporal state.
+        Item {
+            id: tabContainer
             SplitView.fillHeight: true
             SplitView.minimumHeight: 300
-            orientation: Qt.Horizontal
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 0
+
+                TabBar {
+                    id: contentTabs
+                    Layout.fillWidth: true
+                    TabButton { text: qsTr("Dive Computer Overlay") }
+                    TabButton { text: qsTr("Dive Profile") }
+                    TabButton { text: qsTr("Video Preview") }
+                }
+
+                StackLayout {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    currentIndex: contentTabs.currentIndex
+
+                    // Tab 1: Overlay (existing flow — preview + editor)
+                    SplitView {
+                        id: mainContentArea
+                        orientation: Qt.Horizontal
 
             // Main preview area
             Item {
@@ -455,8 +493,194 @@ ApplicationWindow {
                     }
                 }
             }
-        }
-        
+                    } // end Tab 1 SplitView (mainContentArea)
+
+                    // Tab 2: Dive Profile — preview (depth curve + indicator) + editor sidebar
+                    SplitView {
+                        id: profileTab
+                        orientation: Qt.Horizontal
+
+                        // Preview area
+                        Item {
+                            id: profilePreviewArea
+                            SplitView.fillWidth: true
+                            SplitView.minimumWidth: 400
+
+                            Rectangle {
+                                id: profilePreviewFrame
+                                anchors.centerIn: parent
+                                width: parent.width * 0.95
+                                height: parent.height * 0.95
+                                color: "transparent"
+                                border.color: palette.mid
+                                border.width: 1
+                                visible: mainWindow.hasActiveDive
+
+                                // Double-buffered preview: two Image elements share the
+                                // same anchored rect. We always load the next frame into
+                                // the BACK buffer (the hidden one); once it reports Ready
+                                // we flip `useA` so the freshly-loaded buffer becomes the
+                                // visible one. The previously-visible buffer stays on
+                                // screen until the next frame's load completes, so the
+                                // user never sees a blank gap between frames.
+                                Item {
+                                    id: profilePreviewImage
+                                    anchors.fill: parent
+                                    anchors.margins: 1
+
+                                    property bool useA: true
+                                    property real pulseAnchorMs: Date.now()
+
+                                    function setSource(url) {
+                                        if (useA) {
+                                            bufferB.source = url
+                                        } else {
+                                            bufferA.source = url
+                                        }
+                                    }
+
+                                    Image {
+                                        id: bufferA
+                                        anchors.fill: parent
+                                        fillMode: Image.PreserveAspectFit
+                                        cache: false
+                                        asynchronous: true
+                                        visible: profilePreviewImage.useA
+                                        onStatusChanged: {
+                                            if (status === Image.Ready && !profilePreviewImage.useA) {
+                                                profilePreviewImage.useA = true
+                                            }
+                                        }
+                                    }
+                                    Image {
+                                        id: bufferB
+                                        anchors.fill: parent
+                                        fillMode: Image.PreserveAspectFit
+                                        cache: false
+                                        asynchronous: true
+                                        visible: !profilePreviewImage.useA
+                                        onStatusChanged: {
+                                            if (status === Image.Ready && profilePreviewImage.useA) {
+                                                profilePreviewImage.useA = false
+                                            }
+                                        }
+                                    }
+
+                                    // 100 ms debounce — used for property-change triggered
+                                    // refreshes (e.g. color change). The pulse-mode tick
+                                    // skips this debounce to keep its own cadence.
+                                    Timer {
+                                        id: profileUpdateTimer
+                                        interval: 100
+                                        repeat: false
+                                        onTriggered: {
+                                            profilePreviewImage.setSource("image://profile/preview/" + Date.now())
+                                        }
+                                    }
+
+                                    property var updatePreview: function() {
+                                        if (mainWindow.hasActiveDive && timelineView.visible) {
+                                            profileUpdateTimer.restart()
+                                        }
+                                    }
+
+                                    Component.onCompleted: {
+                                        Qt.callLater(function() {
+                                            profilePreviewImage.setSource("image://profile/preview/" + Date.now())
+                                        })
+                                    }
+
+                                    Connections {
+                                        target: profileGenerator
+                                        function onBackgroundColorChanged()   { profilePreviewImage.updatePreview() }
+                                        function onBackgroundOpacityChanged() { profilePreviewImage.updatePreview() }
+                                        function onCurveColorChanged()        { profilePreviewImage.updatePreview() }
+                                        function onIndicatorColorChanged()    { profilePreviewImage.updatePreview() }
+                                        function onIndicatorModeChanged()     { profilePreviewImage.updatePreview() }
+                                        function onIndicatorRadiusChanged()   { profilePreviewImage.updatePreview() }
+                                        function onPulsePeriodMsChanged()     { profilePreviewImage.updatePreview() }
+                                        function onOutputWidthChanged()       { profilePreviewImage.updatePreview() }
+                                        function onOutputHeightChanged()      { profilePreviewImage.updatePreview() }
+                                    }
+
+                                    Connections {
+                                        target: timelineView.timeline
+                                        function onCurrentTimeChanged() {
+                                            profilePreviewImage.updatePreview()
+                                        }
+                                    }
+
+                                    // Pulse-mode animation tick. Wall-clock phase passes
+                                    // through the URL so each tick produces a distinct
+                                    // frame even when the dive cursor is idle. Goes
+                                    // straight through setSource — the double-buffer
+                                    // handles smooth swap-on-Ready.
+                                    Timer {
+                                        interval: 80
+                                        repeat: true
+                                        running: profileGenerator && profileGenerator.indicatorMode === 1 && mainWindow.hasActiveDive
+                                        onTriggered: {
+                                            var period = profileGenerator ? profileGenerator.pulsePeriodMs : 2000
+                                            if (period < 100) period = 100
+                                            var elapsed = Date.now() - profilePreviewImage.pulseAnchorMs
+                                            var phase = (elapsed % period) / period
+                                            profilePreviewImage.setSource(
+                                                "image://profile/preview/phase=" + phase.toFixed(4) +
+                                                "/" + Date.now())
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Placeholder when no dive is loaded
+                            Label {
+                                anchors.centerIn: parent
+                                visible: !mainWindow.hasActiveDive
+                                text: qsTr("Import a dive log to see the profile")
+                                font.pixelSize: 16
+                                color: palette.placeholderText
+                            }
+                        }
+
+                        // Editor sidebar
+                        Rectangle {
+                            id: profileEditorPanel
+                            SplitView.preferredWidth: 400
+                            SplitView.minimumWidth: 280
+                            color: palette.window
+                            border.color: palette.mid
+                            border.width: 1
+
+                            ScrollView {
+                                anchors.fill: parent
+                                anchors.margins: 5
+                                clip: true
+                                contentWidth: profileEditorPanel.width - 10
+                                contentHeight: profileEditor.implicitHeight
+
+                                ProfileEditor {
+                                    id: profileEditor
+                                    width: profileEditorPanel.width - 10
+                                    generator: profileGenerator
+                                }
+                            }
+                        }
+                    }
+
+                    // Tab 3: Video Preview placeholder
+                    Item {
+                        Label {
+                            anchors.centerIn: parent
+                            text: qsTr("Coming soon — video preview.\nYou'll be able to preview your video with the dive computer overlay and dive profile composited here.")
+                            horizontalAlignment: Text.AlignHCenter
+                            font.pixelSize: 18
+                            color: palette.placeholderText
+                        }
+                    }
+                } // end StackLayout
+            } // end ColumnLayout
+        } // end tabContainer Item
+
         // Timeline area
         Rectangle {
             id: timelineArea
@@ -579,9 +803,19 @@ ApplicationWindow {
     
     Dialog {
         id: exportImagesDialog
-        title: qsTr("Export Overlay")
+        title: qsTr("Export")
         modal: true
         width: 500
+
+        // Parameters set by the caller (the per-tab Export button) before open():
+        //   targetGenerator: the QObject* generator to render frames from
+        //     (overlayGenerator or profileGenerator). Both implement
+        //     IFrameGenerator; the exporter does the cross-cast internally.
+        //   contentType: a short tag ("dive_computer" / "dive_profile")
+        //     appended to the export filename/directory so exports of
+        //     different overlays for the same dive don't collide.
+        property var targetGenerator: overlayGenerator
+        property string contentType: "dive_computer"
 
         // Use implicitHeight instead of fixed height to adapt to content
         implicitHeight: contentColumn.implicitHeight + 140 // Add padding for dialog margins
@@ -594,24 +828,27 @@ ApplicationWindow {
                 console.log("Export dialog accepted - this should only print once");
                 // Get the video file path (if any) for unique export naming
                 let videoFile = timelineView.videoPath !== "" ? mainWindow.urlToLocalFile(timelineView.videoPath) : ""
+                // Pull dialog-level parameters set by the caller.
+                let target = exportImagesDialog.targetGenerator
+                let contentType = exportImagesDialog.contentType
                 if (exportTypeImages.checked) {
                     // Images export mode
-                    let path = imageExporter.createDefaultExportDir(mainWindow.currentDive, videoFile);
+                    let path = imageExporter.createDefaultExportDir(mainWindow.currentDive, videoFile, contentType);
                     if (path) {
                         imageExporter.exportPath = path;
-                        
+
                         // Check if we have a video and should export only the video portion
                         if (exportVideoRangeOnly.checked && timelineView.videoPath !== "") {
                             // Export only the video range - use the methods
                             let videoStart = timelineView.timeline.getVideoStartTime();
                             let videoEnd = timelineView.timeline.getVideoEndTime();
-                            
+
                             console.log("Exporting video range from", videoStart, "to", videoEnd);
-                            
+
                             imageExporter.exportImageRange(
-                                mainWindow.currentDive, 
-                                overlayGenerator,
-                                videoStart,  
+                                mainWindow.currentDive,
+                                target,
+                                videoStart,
                                 videoEnd
                             );
                         }
@@ -619,14 +856,14 @@ ApplicationWindow {
                         else if (exportRangeOnly.checked) {
                             // Export only the visible range from the timeline
                             imageExporter.exportImageRange(
-                                mainWindow.currentDive, 
-                                overlayGenerator,
-                                timelineView.visibleStartTime,  
+                                mainWindow.currentDive,
+                                target,
+                                timelineView.visibleStartTime,
                                 timelineView.visibleEndTime
                             );
                         } else {
                             // Export the full dive
-                            imageExporter.exportImages(mainWindow.currentDive, overlayGenerator);
+                            imageExporter.exportImages(mainWindow.currentDive, target);
                         }
                     } else {
                         messageDialog.title = qsTr("Export Error");
@@ -635,7 +872,7 @@ ApplicationWindow {
                     }
                 } else {
                     // Video export mode
-                    let outputFile = videoExporter.createDefaultExportFile(mainWindow.currentDive, videoFile);
+                    let outputFile = videoExporter.createDefaultExportFile(mainWindow.currentDive, videoFile, contentType);
                     if (outputFile) {
                         // Just pass the file path directly, don't manipulate it further
                         videoExporter.frameRate = videoFrameRateSpinBox.value;
@@ -672,7 +909,7 @@ ApplicationWindow {
                         }
                         
                         console.log("Exporting video from", startTime, "to", endTime);
-                        videoExporter.exportVideo(mainWindow.currentDive, overlayGenerator, startTime, endTime);
+                        videoExporter.exportVideo(mainWindow.currentDive, target, startTime, endTime);
                     } else {
                         messageDialog.title = qsTr("Export Error");
                         messageDialog.message = qsTr("Failed to create export file");

--- a/src/ui/timeline.cpp
+++ b/src/ui/timeline.cpp
@@ -1,4 +1,6 @@
 #include "include/ui/timeline.h"
+#include "include/generators/overlay_image_provider.h"
+#include "include/generators/profile_image_provider.h"
 #include <QVariantList>
 #include <QVariantMap>
 #include <cmath>
@@ -57,10 +59,14 @@ void Timeline::setCurrentTime(double time)
             m_currentTime = time;
             ensureTimeIsVisible(time);
 
-            // Update the image provider with the new time
+            // Update the image providers with the new time
             extern OverlayImageProvider* g_imageProvider;
             if (g_imageProvider) {
                 g_imageProvider->setCurrentTime(time);
+            }
+            extern ProfileImageProvider* g_profileImageProvider;
+            if (g_profileImageProvider) {
+                g_profileImageProvider->setCurrentTime(time);
             }
 
             emit currentTimeChanged();


### PR DESCRIPTION
- Three-tab UI (Dive Computer Overlay / Dive Profile / Video Preview placeholder) with a global Timeline shared across tabs
- IFrameGenerator interface + beginExport/endExport hooks, implemented by both OverlayGenerator and ProfileGenerator
- ProfileRenderer (depth curve + indicator with halo + scale pulse), ProfileGenerator, ProfileImageProvider, ProfileEditor.qml
- Updated config for persistence of the dive profile related settings.
- Two-phase pulse design: wall-clock phase for live preview (animates while idle), timestamp-derived phase for export (deterministic per frame)
- Double-buffered preview Image for flicker-free animation
- Exporters take QObject* and dynamic_cast to IFrameGenerator — works for both generators transparently
- Filename suffix _dive_computer / _dive_profile threaded through both exporters to help differentiate the generated overlays.
- Context-sensitive toolbar Export button that adapts label and target generator to the active tab

Fixes #3