### PR TITLE
feat: Improve the dive profile

### DIFF
--- a/include/core/config.h
+++ b/include/core/config.h
@@ -55,6 +55,15 @@ class Config : public QObject
     Q_PROPERTY(int profilePulsePeriodMs READ profilePulsePeriodMs WRITE setProfilePulsePeriodMs NOTIFY profilePulsePeriodMsChanged)
     Q_PROPERTY(int profileOutputWidth READ profileOutputWidth WRITE setProfileOutputWidth NOTIFY profileOutputWidthChanged)
     Q_PROPERTY(int profileOutputHeight READ profileOutputHeight WRITE setProfileOutputHeight NOTIFY profileOutputHeightChanged)
+    Q_PROPERTY(QColor profileDecoZoneColor READ profileDecoZoneColor WRITE setProfileDecoZoneColor NOTIFY profileDecoZoneColorChanged)
+    Q_PROPERTY(double profileDecoZoneOpacity READ profileDecoZoneOpacity WRITE setProfileDecoZoneOpacity NOTIFY profileDecoZoneOpacityChanged)
+    Q_PROPERTY(bool profileGridEnabled READ profileGridEnabled WRITE setProfileGridEnabled NOTIFY profileGridEnabledChanged)
+    Q_PROPERTY(int profileGridDepthInterval READ profileGridDepthInterval WRITE setProfileGridDepthInterval NOTIFY profileGridDepthIntervalChanged)
+    Q_PROPERTY(int profileGridTimeInterval READ profileGridTimeInterval WRITE setProfileGridTimeInterval NOTIFY profileGridTimeIntervalChanged)
+    Q_PROPERTY(QColor profileGridColor READ profileGridColor WRITE setProfileGridColor NOTIFY profileGridColorChanged)
+    Q_PROPERTY(double profileGridOpacity READ profileGridOpacity WRITE setProfileGridOpacity NOTIFY profileGridOpacityChanged)
+    Q_PROPERTY(int profileGridLineWidth READ profileGridLineWidth WRITE setProfileGridLineWidth NOTIFY profileGridLineWidthChanged)
+    Q_PROPERTY(bool profileGridShowLabels READ profileGridShowLabels WRITE setProfileGridShowLabels NOTIFY profileGridShowLabelsChanged)
 
 public:
     static Config* instance();
@@ -150,6 +159,33 @@ public:
     int profileOutputHeight() const;
     void setProfileOutputHeight(int h);
 
+    QColor profileDecoZoneColor() const;
+    void setProfileDecoZoneColor(const QColor& color);
+
+    double profileDecoZoneOpacity() const;
+    void setProfileDecoZoneOpacity(double opacity);
+
+    bool profileGridEnabled() const;
+    void setProfileGridEnabled(bool enabled);
+
+    int profileGridDepthInterval() const;
+    void setProfileGridDepthInterval(int interval);
+
+    int profileGridTimeInterval() const;
+    void setProfileGridTimeInterval(int seconds);
+
+    QColor profileGridColor() const;
+    void setProfileGridColor(const QColor& color);
+
+    double profileGridOpacity() const;
+    void setProfileGridOpacity(double opacity);
+
+    int profileGridLineWidth() const;
+    void setProfileGridLineWidth(int width);
+
+    bool profileGridShowLabels() const;
+    void setProfileGridShowLabels(bool show);
+
     // Save configuration to disk
     void saveConfig();
 
@@ -194,6 +230,15 @@ signals:
     void profilePulsePeriodMsChanged();
     void profileOutputWidthChanged();
     void profileOutputHeightChanged();
+    void profileDecoZoneColorChanged();
+    void profileDecoZoneOpacityChanged();
+    void profileGridEnabledChanged();
+    void profileGridDepthIntervalChanged();
+    void profileGridTimeIntervalChanged();
+    void profileGridColorChanged();
+    void profileGridOpacityChanged();
+    void profileGridLineWidthChanged();
+    void profileGridShowLabelsChanged();
 
 private:
     explicit Config(QObject *parent = nullptr);
@@ -238,6 +283,15 @@ private:
     int m_profilePulsePeriodMs;
     int m_profileOutputWidth;
     int m_profileOutputHeight;
+    QColor m_profileDecoZoneColor;
+    double m_profileDecoZoneOpacity;
+    bool m_profileGridEnabled;
+    int m_profileGridDepthInterval;
+    int m_profileGridTimeInterval;
+    QColor m_profileGridColor;
+    double m_profileGridOpacity;
+    int m_profileGridLineWidth;
+    bool m_profileGridShowLabels;
 
     // Camera pairings: maps camera name -> calibration constant (seconds)
     QMap<QString, double> m_cameraPairings;

--- a/include/generators/profile_gen.h
+++ b/include/generators/profile_gen.h
@@ -28,6 +28,15 @@ class ProfileGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(int pulsePeriodMs READ pulsePeriodMs WRITE setPulsePeriodMs NOTIFY pulsePeriodMsChanged)
     Q_PROPERTY(int outputWidth READ outputWidth WRITE setOutputWidth NOTIFY outputWidthChanged)
     Q_PROPERTY(int outputHeight READ outputHeight WRITE setOutputHeight NOTIFY outputHeightChanged)
+    Q_PROPERTY(QColor decoZoneColor READ decoZoneColor WRITE setDecoZoneColor NOTIFY decoZoneColorChanged)
+    Q_PROPERTY(double decoZoneOpacity READ decoZoneOpacity WRITE setDecoZoneOpacity NOTIFY decoZoneOpacityChanged)
+    Q_PROPERTY(bool gridEnabled READ gridEnabled WRITE setGridEnabled NOTIFY gridEnabledChanged)
+    Q_PROPERTY(int gridDepthInterval READ gridDepthInterval WRITE setGridDepthInterval NOTIFY gridDepthIntervalChanged)
+    Q_PROPERTY(int gridTimeInterval READ gridTimeInterval WRITE setGridTimeInterval NOTIFY gridTimeIntervalChanged)
+    Q_PROPERTY(QColor gridColor READ gridColor WRITE setGridColor NOTIFY gridColorChanged)
+    Q_PROPERTY(double gridOpacity READ gridOpacity WRITE setGridOpacity NOTIFY gridOpacityChanged)
+    Q_PROPERTY(int gridLineWidth READ gridLineWidth WRITE setGridLineWidth NOTIFY gridLineWidthChanged)
+    Q_PROPERTY(bool gridShowLabels READ gridShowLabels WRITE setGridShowLabels NOTIFY gridShowLabelsChanged)
 
 public:
     enum IndicatorMode {
@@ -47,6 +56,15 @@ public:
     int pulsePeriodMs() const { return m_pulsePeriodMs; }
     int outputWidth() const { return m_outputWidth; }
     int outputHeight() const { return m_outputHeight; }
+    QColor decoZoneColor() const { return m_decoZoneColor; }
+    double decoZoneOpacity() const { return m_decoZoneOpacity; }
+    bool gridEnabled() const { return m_gridEnabled; }
+    int gridDepthInterval() const { return m_gridDepthInterval; }
+    int gridTimeInterval() const { return m_gridTimeInterval; }
+    QColor gridColor() const { return m_gridColor; }
+    double gridOpacity() const { return m_gridOpacity; }
+    int gridLineWidth() const { return m_gridLineWidth; }
+    bool gridShowLabels() const { return m_gridShowLabels; }
 
     void setBackgroundColor(const QColor& c);
     void setBackgroundOpacity(double o);
@@ -57,6 +75,15 @@ public:
     void setPulsePeriodMs(int ms);
     void setOutputWidth(int w);
     void setOutputHeight(int h);
+    void setDecoZoneColor(const QColor& c);
+    void setDecoZoneOpacity(double o);
+    void setGridEnabled(bool enabled);
+    void setGridDepthInterval(int interval);
+    void setGridTimeInterval(int seconds);
+    void setGridColor(const QColor& c);
+    void setGridOpacity(double o);
+    void setGridLineWidth(int width);
+    void setGridShowLabels(bool show);
 
     // IFrameGenerator — for exports, pulse phase is timestamp-derived so each
     // frame in a sequence has a deterministic pulse state.
@@ -76,6 +103,15 @@ signals:
     void pulsePeriodMsChanged();
     void outputWidthChanged();
     void outputHeightChanged();
+    void decoZoneColorChanged();
+    void decoZoneOpacityChanged();
+    void gridEnabledChanged();
+    void gridDepthIntervalChanged();
+    void gridTimeIntervalChanged();
+    void gridColorChanged();
+    void gridOpacityChanged();
+    void gridLineWidthChanged();
+    void gridShowLabelsChanged();
 
 private:
     QColor m_backgroundColor;
@@ -87,6 +123,15 @@ private:
     int m_pulsePeriodMs;
     int m_outputWidth;
     int m_outputHeight;
+    QColor m_decoZoneColor;
+    double m_decoZoneOpacity;
+    bool m_gridEnabled;
+    int m_gridDepthInterval;
+    int m_gridTimeInterval;
+    QColor m_gridColor;
+    double m_gridOpacity;
+    int m_gridLineWidth;
+    bool m_gridShowLabels;
 };
 
 #endif // PROFILE_GEN_H

--- a/include/generators/profile_renderer.h
+++ b/include/generators/profile_renderer.h
@@ -5,6 +5,8 @@
 #include <QPainter>
 #include <QRectF>
 
+#include "include/core/units.h"
+
 class DiveData;
 
 /**
@@ -29,6 +31,33 @@ void drawBackground(QPainter& p, const QRectF& rect, const QColor& bg, double op
 // or a zero max depth.
 void drawDepthCurve(QPainter& p, const QRectF& rect, DiveData* dive,
                     const QColor& color, double lineWidth = 2.0);
+
+// Grid styling. `depthIntervalMeters` is in meters regardless of unitSystem;
+// the UI is responsible for converting the user-entered value (which may be in
+// feet) into meters before populating this struct. Labels are formatted using
+// `unitSystem`.
+struct GridOptions {
+    double depthIntervalMeters;
+    int timeIntervalSec;
+    QColor color;
+    double opacity;
+    double lineWidth;
+    bool showLabels;
+    Units::UnitSystem unitSystem;
+};
+
+// Draw a reference grid over `rect`: horizontal lines at multiples of
+// `depthIntervalMeters` (labeled in the user's unit) and vertical lines at
+// multiples of `timeIntervalSec` (labeled as mm:ss). No-op if intervals are
+// non-positive or the dive is empty.
+void drawGrid(QPainter& p, const QRectF& rect, DiveData* dive, const GridOptions& opts);
+
+// Fill the decompression-ceiling region: for each consecutive run of samples
+// where ceiling > 0, fill a polygon from the surface (y=0) down to the ceiling
+// depth at each timestamp. No-op when opacity is 0 or no samples have a
+// non-zero ceiling.
+void drawDecoZone(QPainter& p, const QRectF& rect, DiveData* dive,
+                  const QColor& color, double opacity);
 
 // Draw a filled indicator dot at the (time, depth) interpolated for currentTimeSec.
 // When `pulsing` is true, the dot's radius is modulated by `pulsePhase01` (0..1

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -44,6 +44,15 @@ Config::Config(QObject *parent)
     , m_profilePulsePeriodMs(2000)
     , m_profileOutputWidth(1920)
     , m_profileOutputHeight(400)
+    , m_profileDecoZoneColor(QColor(255, 0, 0))
+    , m_profileDecoZoneOpacity(0.35)
+    , m_profileGridEnabled(false)
+    , m_profileGridDepthInterval(10)
+    , m_profileGridTimeInterval(600)
+    , m_profileGridColor(QColor(180, 180, 180))
+    , m_profileGridOpacity(0.5)
+    , m_profileGridLineWidth(1)
+    , m_profileGridShowLabels(true)
 {
     // Load settings from disk
     loadConfig();
@@ -400,6 +409,92 @@ void Config::setProfileOutputHeight(int h)
     }
 }
 
+QColor Config::profileDecoZoneColor() const { return m_profileDecoZoneColor; }
+void Config::setProfileDecoZoneColor(const QColor& color)
+{
+    if (m_profileDecoZoneColor != color) {
+        m_profileDecoZoneColor = color;
+        emit profileDecoZoneColorChanged();
+    }
+}
+
+double Config::profileDecoZoneOpacity() const { return m_profileDecoZoneOpacity; }
+void Config::setProfileDecoZoneOpacity(double opacity)
+{
+    opacity = qBound(0.0, opacity, 1.0);
+    if (qAbs(m_profileDecoZoneOpacity - opacity) > 0.001) {
+        m_profileDecoZoneOpacity = opacity;
+        emit profileDecoZoneOpacityChanged();
+    }
+}
+
+bool Config::profileGridEnabled() const { return m_profileGridEnabled; }
+void Config::setProfileGridEnabled(bool enabled)
+{
+    if (m_profileGridEnabled != enabled) {
+        m_profileGridEnabled = enabled;
+        emit profileGridEnabledChanged();
+    }
+}
+
+int Config::profileGridDepthInterval() const { return m_profileGridDepthInterval; }
+void Config::setProfileGridDepthInterval(int interval)
+{
+    interval = qMax(1, interval);
+    if (m_profileGridDepthInterval != interval) {
+        m_profileGridDepthInterval = interval;
+        emit profileGridDepthIntervalChanged();
+    }
+}
+
+int Config::profileGridTimeInterval() const { return m_profileGridTimeInterval; }
+void Config::setProfileGridTimeInterval(int seconds)
+{
+    seconds = qMax(1, seconds);
+    if (m_profileGridTimeInterval != seconds) {
+        m_profileGridTimeInterval = seconds;
+        emit profileGridTimeIntervalChanged();
+    }
+}
+
+QColor Config::profileGridColor() const { return m_profileGridColor; }
+void Config::setProfileGridColor(const QColor& color)
+{
+    if (m_profileGridColor != color) {
+        m_profileGridColor = color;
+        emit profileGridColorChanged();
+    }
+}
+
+double Config::profileGridOpacity() const { return m_profileGridOpacity; }
+void Config::setProfileGridOpacity(double opacity)
+{
+    opacity = qBound(0.0, opacity, 1.0);
+    if (qAbs(m_profileGridOpacity - opacity) > 0.001) {
+        m_profileGridOpacity = opacity;
+        emit profileGridOpacityChanged();
+    }
+}
+
+int Config::profileGridLineWidth() const { return m_profileGridLineWidth; }
+void Config::setProfileGridLineWidth(int width)
+{
+    width = qMax(1, width);
+    if (m_profileGridLineWidth != width) {
+        m_profileGridLineWidth = width;
+        emit profileGridLineWidthChanged();
+    }
+}
+
+bool Config::profileGridShowLabels() const { return m_profileGridShowLabels; }
+void Config::setProfileGridShowLabels(bool show)
+{
+    if (m_profileGridShowLabels != show) {
+        m_profileGridShowLabels = show;
+        emit profileGridShowLabelsChanged();
+    }
+}
+
 void Config::loadConfig()
 {
     // Load general settings
@@ -487,6 +582,25 @@ void Config::loadConfig()
     m_profilePulsePeriodMs = m_settings.value("profile/pulsePeriodMs", 2000).toInt();
     m_profileOutputWidth = m_settings.value("profile/outputWidth", 1920).toInt();
     m_profileOutputHeight = m_settings.value("profile/outputHeight", 400).toInt();
+    {
+        const int dR = m_settings.value("profile/decoZoneColorR", 255).toInt();
+        const int dG = m_settings.value("profile/decoZoneColorG", 0).toInt();
+        const int dB = m_settings.value("profile/decoZoneColorB", 0).toInt();
+        m_profileDecoZoneColor = QColor(dR, dG, dB);
+    }
+    m_profileDecoZoneOpacity = m_settings.value("profile/decoZoneOpacity", 0.35).toDouble();
+    m_profileGridEnabled = m_settings.value("profile/gridEnabled", false).toBool();
+    m_profileGridDepthInterval = m_settings.value("profile/gridDepthInterval", 10).toInt();
+    m_profileGridTimeInterval = m_settings.value("profile/gridTimeInterval", 600).toInt();
+    {
+        const int gR = m_settings.value("profile/gridColorR", 180).toInt();
+        const int gG = m_settings.value("profile/gridColorG", 180).toInt();
+        const int gB = m_settings.value("profile/gridColorB", 180).toInt();
+        m_profileGridColor = QColor(gR, gG, gB);
+    }
+    m_profileGridOpacity = m_settings.value("profile/gridOpacity", 0.5).toDouble();
+    m_profileGridLineWidth = m_settings.value("profile/gridLineWidth", 1).toInt();
+    m_profileGridShowLabels = m_settings.value("profile/gridShowLabels", true).toBool();
 
     // Load camera pairings from JSON
     m_cameraPairings.clear();
@@ -571,6 +685,19 @@ void Config::saveConfig()
     m_settings.setValue("profile/pulsePeriodMs", m_profilePulsePeriodMs);
     m_settings.setValue("profile/outputWidth", m_profileOutputWidth);
     m_settings.setValue("profile/outputHeight", m_profileOutputHeight);
+    m_settings.setValue("profile/decoZoneColorR", m_profileDecoZoneColor.red());
+    m_settings.setValue("profile/decoZoneColorG", m_profileDecoZoneColor.green());
+    m_settings.setValue("profile/decoZoneColorB", m_profileDecoZoneColor.blue());
+    m_settings.setValue("profile/decoZoneOpacity", m_profileDecoZoneOpacity);
+    m_settings.setValue("profile/gridEnabled", m_profileGridEnabled);
+    m_settings.setValue("profile/gridDepthInterval", m_profileGridDepthInterval);
+    m_settings.setValue("profile/gridTimeInterval", m_profileGridTimeInterval);
+    m_settings.setValue("profile/gridColorR", m_profileGridColor.red());
+    m_settings.setValue("profile/gridColorG", m_profileGridColor.green());
+    m_settings.setValue("profile/gridColorB", m_profileGridColor.blue());
+    m_settings.setValue("profile/gridOpacity", m_profileGridOpacity);
+    m_settings.setValue("profile/gridLineWidth", m_profileGridLineWidth);
+    m_settings.setValue("profile/gridShowLabels", m_profileGridShowLabels);
 
     // Save camera pairings as compact JSON
     QJsonArray pairingsArray;

--- a/src/generators/profile_gen.cpp
+++ b/src/generators/profile_gen.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include "include/core/config.h"
+#include "include/core/units.h"
 #include "include/generators/profile_renderer.h"
 
 ProfileGenerator::ProfileGenerator(QObject* parent)
@@ -21,6 +22,15 @@ ProfileGenerator::ProfileGenerator(QObject* parent)
     m_pulsePeriodMs     = cfg->profilePulsePeriodMs();
     m_outputWidth       = cfg->profileOutputWidth();
     m_outputHeight      = cfg->profileOutputHeight();
+    m_decoZoneColor     = cfg->profileDecoZoneColor();
+    m_decoZoneOpacity   = cfg->profileDecoZoneOpacity();
+    m_gridEnabled       = cfg->profileGridEnabled();
+    m_gridDepthInterval = cfg->profileGridDepthInterval();
+    m_gridTimeInterval  = cfg->profileGridTimeInterval();
+    m_gridColor         = cfg->profileGridColor();
+    m_gridOpacity       = cfg->profileGridOpacity();
+    m_gridLineWidth     = cfg->profileGridLineWidth();
+    m_gridShowLabels    = cfg->profileGridShowLabels();
 
     // Stay in sync with Config — settings changes flowing in from anywhere
     // (e.g. another window, future preferences dialog) propagate to here.
@@ -59,6 +69,48 @@ ProfileGenerator::ProfileGenerator(QObject* parent)
     connect(cfg, &Config::profileOutputHeightChanged, this, [this]() {
         m_outputHeight = Config::instance()->profileOutputHeight();
         emit outputHeightChanged();
+    });
+    connect(cfg, &Config::profileDecoZoneColorChanged, this, [this]() {
+        m_decoZoneColor = Config::instance()->profileDecoZoneColor();
+        emit decoZoneColorChanged();
+    });
+    connect(cfg, &Config::profileDecoZoneOpacityChanged, this, [this]() {
+        m_decoZoneOpacity = Config::instance()->profileDecoZoneOpacity();
+        emit decoZoneOpacityChanged();
+    });
+    connect(cfg, &Config::profileGridEnabledChanged, this, [this]() {
+        m_gridEnabled = Config::instance()->profileGridEnabled();
+        emit gridEnabledChanged();
+    });
+    connect(cfg, &Config::profileGridDepthIntervalChanged, this, [this]() {
+        m_gridDepthInterval = Config::instance()->profileGridDepthInterval();
+        emit gridDepthIntervalChanged();
+    });
+    connect(cfg, &Config::profileGridTimeIntervalChanged, this, [this]() {
+        m_gridTimeInterval = Config::instance()->profileGridTimeInterval();
+        emit gridTimeIntervalChanged();
+    });
+    connect(cfg, &Config::profileGridColorChanged, this, [this]() {
+        m_gridColor = Config::instance()->profileGridColor();
+        emit gridColorChanged();
+    });
+    connect(cfg, &Config::profileGridOpacityChanged, this, [this]() {
+        m_gridOpacity = Config::instance()->profileGridOpacity();
+        emit gridOpacityChanged();
+    });
+    connect(cfg, &Config::profileGridLineWidthChanged, this, [this]() {
+        m_gridLineWidth = Config::instance()->profileGridLineWidth();
+        emit gridLineWidthChanged();
+    });
+    connect(cfg, &Config::profileGridShowLabelsChanged, this, [this]() {
+        m_gridShowLabels = Config::instance()->profileGridShowLabels();
+        emit gridShowLabelsChanged();
+    });
+
+    // Repaint when the user's unit setting changes — depth-interval labels and
+    // line positions are unit-dependent.
+    connect(cfg, &Config::unitSystemChanged, this, [this]() {
+        if (m_gridEnabled) emit gridDepthIntervalChanged();
     });
 }
 
@@ -148,6 +200,92 @@ void ProfileGenerator::setOutputHeight(int h)
     }
 }
 
+void ProfileGenerator::setDecoZoneColor(const QColor& c)
+{
+    if (m_decoZoneColor != c) {
+        m_decoZoneColor = c;
+        Config::instance()->setProfileDecoZoneColor(c);
+        emit decoZoneColorChanged();
+    }
+}
+
+void ProfileGenerator::setDecoZoneOpacity(double o)
+{
+    o = qBound(0.0, o, 1.0);
+    if (qAbs(m_decoZoneOpacity - o) > 0.001) {
+        m_decoZoneOpacity = o;
+        Config::instance()->setProfileDecoZoneOpacity(o);
+        emit decoZoneOpacityChanged();
+    }
+}
+
+void ProfileGenerator::setGridEnabled(bool enabled)
+{
+    if (m_gridEnabled != enabled) {
+        m_gridEnabled = enabled;
+        Config::instance()->setProfileGridEnabled(enabled);
+        emit gridEnabledChanged();
+    }
+}
+
+void ProfileGenerator::setGridDepthInterval(int interval)
+{
+    interval = qMax(1, interval);
+    if (m_gridDepthInterval != interval) {
+        m_gridDepthInterval = interval;
+        Config::instance()->setProfileGridDepthInterval(interval);
+        emit gridDepthIntervalChanged();
+    }
+}
+
+void ProfileGenerator::setGridTimeInterval(int seconds)
+{
+    seconds = qMax(1, seconds);
+    if (m_gridTimeInterval != seconds) {
+        m_gridTimeInterval = seconds;
+        Config::instance()->setProfileGridTimeInterval(seconds);
+        emit gridTimeIntervalChanged();
+    }
+}
+
+void ProfileGenerator::setGridColor(const QColor& c)
+{
+    if (m_gridColor != c) {
+        m_gridColor = c;
+        Config::instance()->setProfileGridColor(c);
+        emit gridColorChanged();
+    }
+}
+
+void ProfileGenerator::setGridOpacity(double o)
+{
+    o = qBound(0.0, o, 1.0);
+    if (qAbs(m_gridOpacity - o) > 0.001) {
+        m_gridOpacity = o;
+        Config::instance()->setProfileGridOpacity(o);
+        emit gridOpacityChanged();
+    }
+}
+
+void ProfileGenerator::setGridLineWidth(int width)
+{
+    width = qMax(1, width);
+    if (m_gridLineWidth != width) {
+        m_gridLineWidth = width;
+        Config::instance()->setProfileGridLineWidth(width);
+        emit gridLineWidthChanged();
+    }
+}
+
+void ProfileGenerator::setGridShowLabels(bool show)
+{
+    if (m_gridShowLabels != show) {
+        m_gridShowLabels = show;
+        Config::instance()->setProfileGridShowLabels(show);
+        emit gridShowLabelsChanged();
+    }
+}
+
 QImage ProfileGenerator::generate(DiveData* dive, double timePoint)
 {
     // Export path: pulse phase is deterministic from the dive-time so a
@@ -170,6 +308,23 @@ QImage ProfileGenerator::renderFrame(DiveData* dive, double timePoint, double pu
     const QRectF rect(0, 0, m_outputWidth, m_outputHeight);
 
     ProfileRenderer::drawBackground(painter, rect, m_backgroundColor, m_backgroundOpacity);
+    if (m_gridEnabled) {
+        ProfileRenderer::GridOptions g;
+        const Units::UnitSystem unitSystem = Config::instance()->unitSystem();
+        // depth interval is entered in the user's unit; convert to meters.
+        const double intervalMeters = (unitSystem == Units::UnitSystem::Imperial)
+            ? Units::feetToMeters(static_cast<double>(m_gridDepthInterval))
+            : static_cast<double>(m_gridDepthInterval);
+        g.depthIntervalMeters = intervalMeters;
+        g.timeIntervalSec = m_gridTimeInterval;
+        g.color = m_gridColor;
+        g.opacity = m_gridOpacity;
+        g.lineWidth = static_cast<double>(m_gridLineWidth);
+        g.showLabels = m_gridShowLabels;
+        g.unitSystem = unitSystem;
+        ProfileRenderer::drawGrid(painter, rect, dive, g);
+    }
+    ProfileRenderer::drawDecoZone(painter, rect, dive, m_decoZoneColor, m_decoZoneOpacity);
     ProfileRenderer::drawDepthCurve(painter, rect, dive, m_curveColor);
     ProfileRenderer::drawIndicator(painter, rect, dive, timePoint, m_indicatorColor,
                                    static_cast<double>(m_indicatorRadius),

--- a/src/generators/profile_renderer.cpp
+++ b/src/generators/profile_renderer.cpp
@@ -1,7 +1,10 @@
 #include "include/generators/profile_renderer.h"
 #include "include/core/dive_data.h"
+#include "include/core/units.h"
 
+#include <QFontMetricsF>
 #include <QPainterPath>
+#include <QString>
 #include <QtMath>
 
 #include <algorithm>
@@ -92,6 +95,154 @@ void drawDepthCurve(QPainter& p, const QRectF& rect, DiveData* dive,
     p.setPen(pen);
     p.setBrush(Qt::NoBrush);
     p.drawPath(path);
+    p.restore();
+}
+
+void drawGrid(QPainter& p, const QRectF& rect, DiveData* dive, const GridOptions& opts)
+{
+    if (!dive || opts.opacity <= 0.0
+        || opts.depthIntervalMeters <= 0.0 || opts.timeIntervalSec <= 0) {
+        return;
+    }
+    const double depthMax = depthAxisMax(dive);
+    const double tMax = timeAxisMax(dive);
+    if (depthMax <= 0.0 || tMax <= 0.0) {
+        return;
+    }
+
+    QColor lineColor = opts.color;
+    lineColor.setAlphaF(std::clamp(opts.opacity, 0.0, 1.0)
+                        * (opts.color.alphaF() > 0 ? opts.color.alphaF() : 1.0));
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, false); // crisp 1-px lines
+
+    QPen pen(lineColor);
+    pen.setWidthF(opts.lineWidth);
+    pen.setCapStyle(Qt::FlatCap);
+    p.setPen(pen);
+
+    // Horizontal lines (depth axis). Iterate in meters; convert label using the
+    // user's unit system.
+    for (double dm = opts.depthIntervalMeters; dm <= depthMax; dm += opts.depthIntervalMeters) {
+        const double y = rect.top() + (dm / depthMax) * rect.height();
+        p.drawLine(QPointF(rect.left(), y), QPointF(rect.right(), y));
+    }
+
+    // Vertical lines (time axis).
+    for (double t = opts.timeIntervalSec; t <= tMax; t += opts.timeIntervalSec) {
+        const double x = rect.left() + (t / tMax) * rect.width();
+        p.drawLine(QPointF(x, rect.top()), QPointF(x, rect.bottom()));
+    }
+
+    if (opts.showLabels) {
+        // Labels share the grid color but at full opacity (so they remain
+        // readable when the grid lines are faint).
+        QColor labelColor = opts.color;
+        labelColor.setAlphaF(1.0);
+        p.setPen(labelColor);
+
+        QFont labelFont = p.font();
+        // Scale the label font with the image height so labels stay readable
+        // on a 4K profile without being huge on a small one.
+        const int px = std::max(10, static_cast<int>(rect.height() * 0.04));
+        labelFont.setPixelSize(px);
+        p.setFont(labelFont);
+
+        const QFontMetricsF fm(labelFont);
+
+        // Depth labels — left-anchored just inside the rect, offset above the line.
+        for (double dm = opts.depthIntervalMeters; dm <= depthMax; dm += opts.depthIntervalMeters) {
+            const double y = rect.top() + (dm / depthMax) * rect.height();
+            const QString text = Units::formatDepthValue(dm, opts.unitSystem);
+            p.drawText(QPointF(rect.left() + 4, y - 2), text);
+        }
+
+        // Time labels — top-anchored just inside the rect, mm:ss format.
+        for (double t = opts.timeIntervalSec; t <= tMax; t += opts.timeIntervalSec) {
+            const double x = rect.left() + (t / tMax) * rect.width();
+            const int totalSec = static_cast<int>(t);
+            const int mm = totalSec / 60;
+            const int ss = totalSec % 60;
+            const QString text = QString::asprintf("%d:%02d", mm, ss);
+            p.drawText(QPointF(x + 4, rect.top() + fm.ascent() + 2), text);
+        }
+    }
+
+    p.restore();
+}
+
+void drawDecoZone(QPainter& p, const QRectF& rect, DiveData* dive,
+                  const QColor& color, double opacity)
+{
+    if (!dive || opacity <= 0.0) {
+        return;
+    }
+    const auto& points = dive->allDataPoints();
+    if (points.size() < 2) {
+        return;
+    }
+    const double depthMax = depthAxisMax(dive);
+    const double tMax = timeAxisMax(dive);
+    if (depthMax <= 0.0 || tMax <= 0.0) {
+        return;
+    }
+
+    QColor fill = color;
+    fill.setAlphaF(std::clamp(opacity, 0.0, 1.0) * (color.alphaF() > 0 ? color.alphaF() : 1.0));
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setPen(Qt::NoPen);
+    p.setBrush(fill);
+
+    // Walk the samples and emit one filled polygon per consecutive run where
+    // ceiling > 0. Polygon shape: top edge along y=0 (surface), bottom edge
+    // follows the ceiling depth.
+    QPainterPath path;
+    bool inRun = false;
+    QList<QPointF> ceilingPts;   // bottom edge of the current polygon
+    double runStartT = 0.0;
+    double runEndT = 0.0;
+
+    auto flushRun = [&]() {
+        if (ceilingPts.size() < 1) {
+            return;
+        }
+        QPainterPath poly;
+        const QPointF topLeft = samplePoint(rect, runStartT, 0.0, tMax, depthMax);
+        poly.moveTo(topLeft);
+        for (const QPointF& pt : ceilingPts) {
+            poly.lineTo(pt);
+        }
+        const QPointF topRight = samplePoint(rect, runEndT, 0.0, tMax, depthMax);
+        poly.lineTo(topRight);
+        poly.closeSubpath();
+        path.addPath(poly);
+    };
+
+    for (const DiveDataPoint& pt : points) {
+        if (pt.ceiling > 0.0) {
+            if (!inRun) {
+                inRun = true;
+                ceilingPts.clear();
+                runStartT = pt.timestamp;
+            }
+            ceilingPts.append(samplePoint(rect, pt.timestamp, pt.ceiling, tMax, depthMax));
+            runEndT = pt.timestamp;
+        } else if (inRun) {
+            flushRun();
+            inRun = false;
+            ceilingPts.clear();
+        }
+    }
+    if (inRun) {
+        flushRun();
+    }
+
+    if (!path.isEmpty()) {
+        p.drawPath(path);
+    }
     p.restore();
 }
 

--- a/src/ui/qml/ProfileEditor.qml
+++ b/src/ui/qml/ProfileEditor.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Dialogs
+import Unabara.Core 1.0
 import Unabara.Generators 1.0
 
 Item {
@@ -94,6 +95,53 @@ Item {
                         colorDialog.selectedColor = root.generator ? root.generator.curveColor : "purple"
                         colorDialog.open()
                     }
+                }
+            }
+        }
+
+        GroupBox {
+            title: qsTr("Deco Zone")
+            Layout.fillWidth: true
+
+            GridLayout {
+                anchors.fill: parent
+                columns: 3
+                rowSpacing: 8
+                columnSpacing: 8
+
+                Label { text: qsTr("Color:") }
+                Button {
+                    id: decoColorButton
+                    Layout.fillWidth: true
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.generator ? root.generator.decoZoneColor : "red"
+                        border.color: palette.mid
+                        border.width: 1
+                    }
+                    onClicked: {
+                        root.colorTarget = "deco"
+                        colorDialog.selectedColor = root.generator ? root.generator.decoZoneColor : "red"
+                        colorDialog.open()
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                Label { text: qsTr("Opacity:") }
+                Slider {
+                    id: decoOpacitySlider
+                    Layout.fillWidth: true
+                    from: 0.0
+                    to: 1.0
+                    value: root.generator ? root.generator.decoZoneOpacity : 0.35
+                    onMoved: {
+                        if (root.generator) root.generator.decoZoneOpacity = value
+                    }
+                }
+                Label {
+                    text: decoOpacitySlider.value.toFixed(2)
+                    Layout.preferredWidth: 40
                 }
             }
         }
@@ -206,6 +254,143 @@ Item {
             }
         }
 
+        GroupBox {
+            title: qsTr("Grid")
+            Layout.fillWidth: true
+
+            GridLayout {
+                anchors.fill: parent
+                columns: 3
+                rowSpacing: 8
+                columnSpacing: 8
+
+                CheckBox {
+                    id: gridEnabledCheck
+                    text: qsTr("Enable grid")
+                    Layout.columnSpan: 3
+                    checked: root.generator ? root.generator.gridEnabled : false
+                    onToggled: {
+                        if (root.generator) root.generator.gridEnabled = checked
+                    }
+                }
+
+                Label {
+                    text: qsTr("Depth interval:")
+                    enabled: gridEnabledCheck.checked
+                }
+                SpinBox {
+                    id: gridDepthIntervalSpin
+                    Layout.fillWidth: true
+                    from: 1
+                    to: 200
+                    enabled: gridEnabledCheck.checked
+                    value: root.generator ? root.generator.gridDepthInterval : 10
+                    onValueModified: {
+                        if (root.generator) root.generator.gridDepthInterval = value
+                    }
+                }
+                Label {
+                    text: (config && config.unitSystem === Units.Metric) ? qsTr("m") : qsTr("ft")
+                    Layout.preferredWidth: 40
+                    enabled: gridEnabledCheck.checked
+                }
+
+                Label {
+                    text: qsTr("Time interval:")
+                    enabled: gridEnabledCheck.checked
+                }
+                SpinBox {
+                    id: gridTimeIntervalSpin
+                    Layout.fillWidth: true
+                    from: 30
+                    to: 7200
+                    stepSize: 60
+                    enabled: gridEnabledCheck.checked
+                    value: root.generator ? root.generator.gridTimeInterval : 600
+                    onValueModified: {
+                        if (root.generator) root.generator.gridTimeInterval = value
+                    }
+                }
+                Label {
+                    text: qsTr("sec")
+                    Layout.preferredWidth: 40
+                    enabled: gridEnabledCheck.checked
+                }
+
+                Label {
+                    text: qsTr("Color:")
+                    enabled: gridEnabledCheck.checked
+                }
+                Button {
+                    id: gridColorButton
+                    Layout.fillWidth: true
+                    enabled: gridEnabledCheck.checked
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.generator ? root.generator.gridColor : "#b4b4b4"
+                        border.color: palette.mid
+                        border.width: 1
+                    }
+                    onClicked: {
+                        root.colorTarget = "grid"
+                        colorDialog.selectedColor = root.generator ? root.generator.gridColor : "#b4b4b4"
+                        colorDialog.open()
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                Label {
+                    text: qsTr("Opacity:")
+                    enabled: gridEnabledCheck.checked
+                }
+                Slider {
+                    id: gridOpacitySlider
+                    Layout.fillWidth: true
+                    from: 0.0
+                    to: 1.0
+                    enabled: gridEnabledCheck.checked
+                    value: root.generator ? root.generator.gridOpacity : 0.5
+                    onMoved: {
+                        if (root.generator) root.generator.gridOpacity = value
+                    }
+                }
+                Label {
+                    text: gridOpacitySlider.value.toFixed(2)
+                    Layout.preferredWidth: 40
+                    enabled: gridEnabledCheck.checked
+                }
+
+                Label {
+                    text: qsTr("Line width (px):")
+                    enabled: gridEnabledCheck.checked
+                }
+                SpinBox {
+                    id: gridLineWidthSpin
+                    Layout.fillWidth: true
+                    from: 1
+                    to: 8
+                    enabled: gridEnabledCheck.checked
+                    value: root.generator ? root.generator.gridLineWidth : 1
+                    onValueModified: {
+                        if (root.generator) root.generator.gridLineWidth = value
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                CheckBox {
+                    id: gridShowLabelsCheck
+                    text: qsTr("Show axis labels")
+                    Layout.columnSpan: 3
+                    enabled: gridEnabledCheck.checked
+                    checked: root.generator ? root.generator.gridShowLabels : true
+                    onToggled: {
+                        if (root.generator) root.generator.gridShowLabels = checked
+                    }
+                }
+            }
+        }
+
         Item { Layout.fillHeight: true }
     }
 
@@ -218,6 +403,8 @@ Item {
             case "background": root.generator.backgroundColor = selectedColor; break
             case "curve":      root.generator.curveColor = selectedColor; break
             case "indicator":  root.generator.indicatorColor = selectedColor; break
+            case "deco":       root.generator.decoZoneColor = selectedColor; break
+            case "grid":       root.generator.gridColor = selectedColor; break
             }
         }
     }

--- a/src/ui/qml/TimelineView.qml
+++ b/src/ui/qml/TimelineView.qml
@@ -233,15 +233,62 @@ Item {
                         ctx.fillText(d + "m", 2, y - 2);
                     }
                     
+                    // Draw deco zone: filled polygons from surface (y=0) down to
+                    // the ceiling at each timestamp, for each consecutive run of
+                    // samples where ceiling > 0. Reads color/opacity from the
+                    // shared profile config so the timeline and the profile
+                    // graphic visually match.
+                    if (typeof config !== "undefined" && config) {
+                        var decoOpacity = config.profileDecoZoneOpacity;
+                        if (decoOpacity > 0) {
+                            var decoColor = config.profileDecoZoneColor;
+                            ctx.fillStyle = "rgba(" + decoColor.r * 255 + "," +
+                                                       decoColor.g * 255 + "," +
+                                                       decoColor.b * 255 + "," +
+                                                       decoOpacity + ")";
+                            var inRun = false;
+                            var runStartX = 0;
+                            for (var j = 0; j < timelineData.length; j++) {
+                                var dp = timelineData[j];
+                                var dx = ((dp.timestamp - timeline.startTime) / timeRange) * width;
+                                if (dp.ceiling > 0) {
+                                    if (!inRun) {
+                                        ctx.beginPath();
+                                        ctx.moveTo(dx, 0);
+                                        runStartX = dx;
+                                        inRun = true;
+                                    }
+                                    var dy = (dp.ceiling / maxDepth) * height;
+                                    ctx.lineTo(dx, dy);
+                                } else if (inRun) {
+                                    // Close: walk back along y=0 to runStartX
+                                    var prevDp = timelineData[j - 1];
+                                    var prevX = ((prevDp.timestamp - timeline.startTime) / timeRange) * width;
+                                    ctx.lineTo(prevX, 0);
+                                    ctx.closePath();
+                                    ctx.fill();
+                                    inRun = false;
+                                }
+                            }
+                            if (inRun) {
+                                var lastDp = timelineData[timelineData.length - 1];
+                                var lastX = ((lastDp.timestamp - timeline.startTime) / timeRange) * width;
+                                ctx.lineTo(lastX, 0);
+                                ctx.closePath();
+                                ctx.fill();
+                            }
+                        }
+                    }
+
                     // Draw depth profile
                     ctx.beginPath();
                     ctx.moveTo(0, 0);
-                    
+
                     for (var i = 0; i < timelineData.length; i++) {
                         var point = timelineData[i];
                         var x = ((point.timestamp - timeline.startTime) / timeRange) * width;
                         var y = (point.depth / maxDepth) * height;
-                        
+
                         if (i === 0) {
                             ctx.moveTo(x, y);
                         } else {
@@ -361,6 +408,14 @@ Item {
                     function onCanvasBackgroundChanged() { depthCanvas.requestPaint() }
                     function onCanvasGridColorChanged() { depthCanvas.requestPaint() }
                     function onCanvasTextColorChanged() { depthCanvas.requestPaint() }
+                }
+
+                // Repaint when deco zone styling changes in the profile editor.
+                Connections {
+                    target: typeof config !== "undefined" ? config : null
+                    ignoreUnknownSignals: true
+                    function onProfileDecoZoneColorChanged() { depthCanvas.requestPaint() }
+                    function onProfileDecoZoneOpacityChanged() { depthCanvas.requestPaint() }
                 }
                 
                 function updateTimelineData() {

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -609,6 +609,15 @@ ApplicationWindow {
                                         function onPulsePeriodMsChanged()     { profilePreviewImage.updatePreview() }
                                         function onOutputWidthChanged()       { profilePreviewImage.updatePreview() }
                                         function onOutputHeightChanged()      { profilePreviewImage.updatePreview() }
+                                        function onDecoZoneColorChanged()     { profilePreviewImage.updatePreview() }
+                                        function onDecoZoneOpacityChanged()   { profilePreviewImage.updatePreview() }
+                                        function onGridEnabledChanged()       { profilePreviewImage.updatePreview() }
+                                        function onGridDepthIntervalChanged() { profilePreviewImage.updatePreview() }
+                                        function onGridTimeIntervalChanged()  { profilePreviewImage.updatePreview() }
+                                        function onGridColorChanged()         { profilePreviewImage.updatePreview() }
+                                        function onGridOpacityChanged()       { profilePreviewImage.updatePreview() }
+                                        function onGridLineWidthChanged()     { profilePreviewImage.updatePreview() }
+                                        function onGridShowLabelsChanged()    { profilePreviewImage.updatePreview() }
                                     }
 
                                     Connections {


### PR DESCRIPTION
- Add the visualization of the deco zone.
- Add the customization options for the rendering of the deco zone.
- Add the possibility to add an optional grid to the Dive Profile.
- Add the customization options for the rendering of the Dive Profile's grid.
- The grid respects the metric/imperial setting of the dive computer overlay.

Fixes #34