### PR TITLE
Video Preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(PROJECT_SOURCES
     src/generators/profile_renderer.cpp
     src/generators/profile_gen.cpp
     src/generators/profile_image_provider.cpp
+    src/generators/frame_cache.cpp
     src/export/image_export.cpp
     src/core/update_checker.cpp
     src/export/video_export.cpp
@@ -68,6 +69,7 @@ set(PROJECT_HEADERS
     include/core/units.h
     include/core/cell_data.h
     include/core/overlay_template.h
+    include/core/video_overlay_layout.h
     include/ui/main_window.h
     include/ui/timeline.h
     include/ui/cell_model.h
@@ -77,6 +79,7 @@ set(PROJECT_HEADERS
     include/generators/profile_renderer.h
     include/generators/profile_gen.h
     include/generators/profile_image_provider.h
+    include/generators/frame_cache.h
     include/export/image_export.h
     include/core/update_checker.h
     include/export/video_export.h

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -7,8 +7,11 @@
 #include <QFont>
 #include <QColor>
 #include <QMap>
+#include <QHash>
 #include <QStringList>
+#include <QVariantMap>
 #include "include/core/units.h"
+#include "include/core/video_overlay_layout.h"
 
 class Config : public QObject
 {
@@ -195,6 +198,15 @@ public:
     Q_INVOKABLE void removeCameraPairing(const QString &name);
     Q_INVOKABLE double cameraCalibrationConstant(const QString &name) const;
 
+    // Per-video overlay layout persistence. Returns the saved layout for
+    // `videoPath`, falling back to the last-used layout if none is saved
+    // (so a fresh video inherits the user's most recent placement).
+    Q_INVOKABLE QVariantMap videoOverlayLayout(const QString &videoPath) const;
+    // Saves the layout for `videoPath` AND replaces the last-used layout
+    // so the next opened video without a saved layout inherits it.
+    Q_INVOKABLE void setVideoOverlayLayout(const QString &videoPath,
+                                           const QVariantMap &layout);
+
 signals:
     void lastImportPathChanged();
     void lastExportPathChanged();
@@ -219,6 +231,8 @@ signals:
     void showCompositePO2Changed();
 
     void cameraPairingsChanged();
+
+    void videoOverlayLayoutChanged(const QString &videoPath);
 
     // Profile signals
     void profileBackgroundColorChanged();
@@ -295,6 +309,11 @@ private:
 
     // Camera pairings: maps camera name -> calibration constant (seconds)
     QMap<QString, double> m_cameraPairings;
+
+    // Per-video overlay layouts, keyed by absolute video path.
+    QHash<QString, VideoOverlayLayout> m_videoOverlayLayouts;
+    // Layout to seed a new video that has no saved entry yet.
+    VideoOverlayLayout m_lastUsedVideoOverlayLayout;
 
     // Load configuration from disk
     void loadConfig();

--- a/include/core/video_overlay_layout.h
+++ b/include/core/video_overlay_layout.h
@@ -1,0 +1,64 @@
+#ifndef VIDEO_OVERLAY_LAYOUT_H
+#define VIDEO_OVERLAY_LAYOUT_H
+
+#include <QMetaType>
+#include <QRectF>
+#include <QVariantMap>
+
+// Placement of one overlay on top of the video frame. Coordinates are
+// normalized to [0..1] of the video frame so the same layout survives
+// resolution changes and is reusable for both the live preview and any
+// future burn-in compositing pass.
+struct OverlayPlacement {
+    bool visible = true;
+    QRectF normalizedRect; // x, y, w, h ∈ [0..1]
+
+    QVariantMap toVariantMap() const {
+        QVariantMap m;
+        m.insert(QStringLiteral("visible"), visible);
+        m.insert(QStringLiteral("x"), normalizedRect.x());
+        m.insert(QStringLiteral("y"), normalizedRect.y());
+        m.insert(QStringLiteral("w"), normalizedRect.width());
+        m.insert(QStringLiteral("h"), normalizedRect.height());
+        return m;
+    }
+
+    static OverlayPlacement fromVariantMap(const QVariantMap& m) {
+        OverlayPlacement p;
+        p.visible = m.value(QStringLiteral("visible"), true).toBool();
+        p.normalizedRect = QRectF(
+            m.value(QStringLiteral("x"), 0.0).toDouble(),
+            m.value(QStringLiteral("y"), 0.0).toDouble(),
+            m.value(QStringLiteral("w"), 0.3).toDouble(),
+            m.value(QStringLiteral("h"), 0.3).toDouble());
+        return p;
+    }
+};
+
+struct VideoOverlayLayout {
+    OverlayPlacement diveComputer{ true, QRectF(0.02, 0.55, 0.30, 0.40) };
+    OverlayPlacement diveProfile { true, QRectF(0.30, 0.78, 0.68, 0.20) };
+
+    QVariantMap toVariantMap() const {
+        QVariantMap m;
+        m.insert(QStringLiteral("diveComputer"), diveComputer.toVariantMap());
+        m.insert(QStringLiteral("diveProfile"),  diveProfile.toVariantMap());
+        return m;
+    }
+
+    static VideoOverlayLayout fromVariantMap(const QVariantMap& m) {
+        VideoOverlayLayout l;
+        if (m.contains(QStringLiteral("diveComputer")))
+            l.diveComputer = OverlayPlacement::fromVariantMap(
+                m.value(QStringLiteral("diveComputer")).toMap());
+        if (m.contains(QStringLiteral("diveProfile")))
+            l.diveProfile = OverlayPlacement::fromVariantMap(
+                m.value(QStringLiteral("diveProfile")).toMap());
+        return l;
+    }
+};
+
+Q_DECLARE_METATYPE(OverlayPlacement)
+Q_DECLARE_METATYPE(VideoOverlayLayout)
+
+#endif // VIDEO_OVERLAY_LAYOUT_H

--- a/include/generators/frame_cache.h
+++ b/include/generators/frame_cache.h
@@ -1,0 +1,46 @@
+#ifndef FRAME_CACHE_H
+#define FRAME_CACHE_H
+
+#include <QImage>
+#include <QHash>
+#include <QList>
+
+class DiveData;
+class IFrameGenerator;
+
+// Time-bucketed image cache wrapping an IFrameGenerator. Quantizes the
+// requested dive-time into buckets so consecutive requests at slightly
+// different times collapse into one render — the natural "low FPS" cadence
+// for live preview compositing on a video player.
+//
+// Invalidated by bumping an epoch; the epoch is part of the cache key, so
+// stale entries are simply dropped on the next lookup. Callers wire all
+// generator/Config *Changed() signals to invalidate().
+class FrameCache
+{
+public:
+    FrameCache(IFrameGenerator* gen,
+               double bucketSeconds = 0.5,
+               int maxEntries = 64);
+
+    // Returns the rendered frame for `dive` at `timePoint` (seconds), reusing
+    // a cached result when the bucket+epoch+dive triple matches. Returns
+    // QImage() if generator or dive is null.
+    QImage frameAt(DiveData* dive, double timePoint);
+
+    // Drops every cached entry — call when any config that affects the
+    // generator's output changes.
+    void invalidate();
+
+private:
+    struct Key { quint64 packed; DiveData* dive; };
+    struct Entry { quint64 packed; DiveData* dive; QImage image; };
+
+    IFrameGenerator* m_gen;
+    double m_bucketSeconds;
+    int m_maxEntries;
+    quint64 m_epoch;
+    QList<Entry> m_entries; // simple LRU; small N so linear scan is fine
+};
+
+#endif // FRAME_CACHE_H

--- a/include/generators/overlay_image_provider.h
+++ b/include/generators/overlay_image_provider.h
@@ -5,6 +5,8 @@
 #include "include/core/dive_data.h"
 #include "include/generators/overlay_gen.h"
 
+class FrameCache;
+
 // Forward declare the class first
 class OverlayImageProvider;
 
@@ -21,11 +23,16 @@ public:
     
     void setCurrentDive(DiveData* dive);
     void setCurrentTime(double time);
-    
+
+    // Optional cache used for "at/<seconds>/<tick>" requests from the video
+    // preview compositor. Provider does not take ownership.
+    void setFrameCache(FrameCache* cache) { m_frameCache = cache; }
+
 private:
     OverlayGenerator* m_generator;
     DiveData* m_currentDive;
     double m_currentTime;
+    FrameCache* m_frameCache = nullptr;
 };
 
 #endif // OVERLAY_IMAGE_PROVIDER_H

--- a/include/generators/profile_image_provider.h
+++ b/include/generators/profile_image_provider.h
@@ -6,6 +6,7 @@
 #include "include/core/dive_data.h"
 #include "include/generators/profile_gen.h"
 
+class FrameCache;
 class ProfileImageProvider;
 
 // Global pointer mirroring g_imageProvider so Timeline (or anything else)
@@ -22,10 +23,15 @@ public:
     void setCurrentDive(DiveData* dive);
     void setCurrentTime(double time);
 
+    // Optional cache used for "at/<seconds>/<tick>" requests from the video
+    // preview compositor. Provider does not take ownership.
+    void setFrameCache(FrameCache* cache) { m_frameCache = cache; }
+
 private:
     ProfileGenerator* m_generator;
     DiveData* m_currentDive;
     double m_currentTime;
+    FrameCache* m_frameCache = nullptr;
 };
 
 #endif // PROFILE_IMAGE_PROVIDER_H

--- a/resources.qrc
+++ b/resources.qrc
@@ -8,6 +8,7 @@
         <file alias="OverlayCell.qml">src/ui/qml/OverlayCell.qml</file>
         <file alias="ProfileEditor.qml">src/ui/qml/ProfileEditor.qml</file>
         <file alias="VideoSyncPlayer.qml">src/ui/qml/VideoSyncPlayer.qml</file>
+        <file alias="VideoOverlayItem.qml">src/ui/qml/VideoOverlayItem.qml</file>
         <file>resources/styles/style.qss</file>
         <file alias="templates/OC_Rec_NoTanks_Ocean.utp">resources/templates/OC_Rec_NoTanks_Ocean.utp</file>
         <file alias="templates/OC_Rec_NoTanks_Titanium.utp">resources/templates/OC_Rec_NoTanks_Titanium.utp</file>

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -602,6 +602,32 @@ void Config::loadConfig()
     m_profileGridLineWidth = m_settings.value("profile/gridLineWidth", 1).toInt();
     m_profileGridShowLabels = m_settings.value("profile/gridShowLabels", true).toBool();
 
+    // Load per-video overlay layouts
+    {
+        m_videoOverlayLayouts.clear();
+        const QString json = m_settings.value("video/overlayLayouts", "{}").toString();
+        QJsonParseError err;
+        const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &err);
+        if (err.error == QJsonParseError::NoError && doc.isObject()) {
+            const QJsonObject root = doc.object();
+            for (auto it = root.constBegin(); it != root.constEnd(); ++it) {
+                const QString path = it.key();
+                if (it.value().isObject()) {
+                    QVariantMap m = it.value().toObject().toVariantMap();
+                    m_videoOverlayLayouts.insert(path, VideoOverlayLayout::fromVariantMap(m));
+                }
+            }
+        }
+        const QString lastJson = m_settings.value("video/lastOverlayLayout", "").toString();
+        if (!lastJson.isEmpty()) {
+            const QJsonDocument lastDoc = QJsonDocument::fromJson(lastJson.toUtf8());
+            if (lastDoc.isObject()) {
+                m_lastUsedVideoOverlayLayout = VideoOverlayLayout::fromVariantMap(
+                    lastDoc.object().toVariantMap());
+            }
+        }
+    }
+
     // Load camera pairings from JSON
     m_cameraPairings.clear();
     QString pairingsJson = m_settings.value("video/cameraPairings", "[]").toString();
@@ -699,6 +725,21 @@ void Config::saveConfig()
     m_settings.setValue("profile/gridLineWidth", m_profileGridLineWidth);
     m_settings.setValue("profile/gridShowLabels", m_profileGridShowLabels);
 
+    // Save per-video overlay layouts
+    {
+        QJsonObject root;
+        for (auto it = m_videoOverlayLayouts.constBegin();
+             it != m_videoOverlayLayouts.constEnd(); ++it) {
+            root.insert(it.key(), QJsonObject::fromVariantMap(it.value().toVariantMap()));
+        }
+        m_settings.setValue("video/overlayLayouts",
+                            QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact)));
+        const QJsonObject lastObj =
+            QJsonObject::fromVariantMap(m_lastUsedVideoOverlayLayout.toVariantMap());
+        m_settings.setValue("video/lastOverlayLayout",
+                            QString::fromUtf8(QJsonDocument(lastObj).toJson(QJsonDocument::Compact)));
+    }
+
     // Save camera pairings as compact JSON
     QJsonArray pairingsArray;
     for (auto it = m_cameraPairings.constBegin(); it != m_cameraPairings.constEnd(); ++it) {
@@ -742,4 +783,25 @@ void Config::removeCameraPairing(const QString &name)
 double Config::cameraCalibrationConstant(const QString &name) const
 {
     return m_cameraPairings.value(name, qQNaN());
+}
+
+// ---- Per-video overlay layouts -------------------------------------------
+
+QVariantMap Config::videoOverlayLayout(const QString &videoPath) const
+{
+    auto it = m_videoOverlayLayouts.constFind(videoPath);
+    if (it != m_videoOverlayLayouts.constEnd())
+        return it.value().toVariantMap();
+    return m_lastUsedVideoOverlayLayout.toVariantMap();
+}
+
+void Config::setVideoOverlayLayout(const QString &videoPath, const QVariantMap &layout)
+{
+    if (videoPath.isEmpty())
+        return;
+    VideoOverlayLayout parsed = VideoOverlayLayout::fromVariantMap(layout);
+    m_videoOverlayLayouts.insert(videoPath, parsed);
+    m_lastUsedVideoOverlayLayout = parsed;
+    saveConfig();
+    emit videoOverlayLayoutChanged(videoPath);
 }

--- a/src/generators/frame_cache.cpp
+++ b/src/generators/frame_cache.cpp
@@ -1,0 +1,46 @@
+#include "include/generators/frame_cache.h"
+#include "include/generators/i_frame_generator.h"
+
+#include <cmath>
+
+FrameCache::FrameCache(IFrameGenerator* gen, double bucketSeconds, int maxEntries)
+    : m_gen(gen)
+    , m_bucketSeconds(bucketSeconds > 0.0 ? bucketSeconds : 0.5)
+    , m_maxEntries(maxEntries > 1 ? maxEntries : 1)
+    , m_epoch(1)
+{
+}
+
+QImage FrameCache::frameAt(DiveData* dive, double timePoint)
+{
+    if (!m_gen || !dive)
+        return QImage();
+
+    const qint64 bucket = static_cast<qint64>(std::floor(timePoint / m_bucketSeconds));
+    // Pack epoch (high 32) + bucket (low 32, biased to keep negatives well-defined).
+    const quint64 packed = (m_epoch << 32) ^ static_cast<quint64>(bucket);
+
+    for (int i = m_entries.size() - 1; i >= 0; --i) {
+        if (m_entries[i].packed == packed && m_entries[i].dive == dive) {
+            Entry hit = m_entries.takeAt(i);
+            m_entries.append(hit); // bump to MRU
+            return hit.image;
+        }
+    }
+
+    // Miss — render and insert.
+    const double bucketTime = bucket * m_bucketSeconds;
+    QImage img = m_gen->generate(dive, bucketTime);
+
+    m_entries.append({ packed, dive, img });
+    if (m_entries.size() > m_maxEntries)
+        m_entries.removeFirst();
+
+    return img;
+}
+
+void FrameCache::invalidate()
+{
+    ++m_epoch;
+    m_entries.clear();
+}

--- a/src/generators/overlay_image_provider.cpp
+++ b/src/generators/overlay_image_provider.cpp
@@ -1,4 +1,5 @@
 #include "include/generators/overlay_image_provider.h"
+#include "include/generators/frame_cache.h"
 #include <QDebug>
 
 OverlayImageProvider::OverlayImageProvider(OverlayGenerator* generator)
@@ -31,7 +32,25 @@ QImage OverlayImageProvider::requestImage(const QString &id, QSize *size, const 
     bool prevShowCellBg = m_generator->showCellBackgrounds();
     m_generator->setShowCellBackgrounds(false);
 
-    if (id.startsWith("preview/")) {
+    if (id.startsWith("at/")) {
+        // "at/<seconds>/<tick>" — explicit dive-time request from the video
+        // preview compositor. Routed through the frame cache when one is
+        // attached so repeated bucket-equal requests collapse to one render.
+        const QString tail = id.mid(3);
+        const int slash = tail.indexOf('/');
+        const QString secsStr = slash >= 0 ? tail.left(slash) : tail;
+        bool ok = false;
+        const double timePoint = secsStr.toDouble(&ok);
+        if (ok) {
+            if (m_frameCache) {
+                result = m_frameCache->frameAt(m_currentDive, timePoint);
+            } else {
+                result = m_generator->generateOverlay(m_currentDive, timePoint);
+            }
+        } else {
+            result = m_generator->generateOverlay(m_currentDive, m_currentTime);
+        }
+    } else if (id.startsWith("preview/")) {
         // For preview images, use the current time
         qDebug() << "OverlayImageProvider: Generating preview at time:" << m_currentTime;
         result = m_generator->generateOverlay(m_currentDive, m_currentTime);

--- a/src/generators/profile_image_provider.cpp
+++ b/src/generators/profile_image_provider.cpp
@@ -1,4 +1,5 @@
 #include "include/generators/profile_image_provider.h"
+#include "include/generators/frame_cache.h"
 
 #include <QDebug>
 
@@ -26,7 +27,25 @@ QImage ProfileImageProvider::requestImage(const QString& id, QSize* size, const 
     }
 
     QImage result;
-    if (id.startsWith("preview/")) {
+    if (id.startsWith("at/")) {
+        // "at/<seconds>/<tick>" — explicit dive-time request from the video
+        // preview compositor. Routed through the frame cache when one is
+        // attached; the indicator sits at the dive position with no pulse.
+        const QString tail = id.mid(3);
+        const int slash = tail.indexOf('/');
+        const QString secsStr = slash >= 0 ? tail.left(slash) : tail;
+        bool ok = false;
+        const double timePoint = secsStr.toDouble(&ok);
+        if (ok) {
+            if (m_frameCache) {
+                result = m_frameCache->frameAt(m_currentDive, timePoint);
+            } else {
+                result = m_generator->generate(m_currentDive, timePoint);
+            }
+        } else {
+            result = m_generator->generate(m_currentDive, m_currentTime);
+        }
+    } else if (id.startsWith("preview/")) {
         // Preview path. The URL may carry an explicit pulse phase so the live
         // preview can animate the indicator on wall-clock time while the dive
         // cursor is idle. URL form: preview/phase=<0..1>/<cachebust>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "include/generators/overlay_image_provider.h"
 #include "include/generators/profile_gen.h"
 #include "include/generators/profile_image_provider.h"
+#include "include/generators/frame_cache.h"
 #include "include/core/config.h"
 #include "include/core/units.h"
 #include "include/core/update_checker.h"
@@ -81,6 +82,57 @@ int main(int argc, char *argv[])
     engine.addImageProvider("profile", profileImageProvider);
     g_profileImageProvider = profileImageProvider;
 
+    // Frame caches for the video-preview compositor. Tighter bound on the
+    // profile cache since profile frames are larger (1920×400 by default).
+    FrameCache* overlayFrameCache = new FrameCache(overlayGenerator, 0.5, 64);
+    FrameCache* profileFrameCache = new FrameCache(profileGenerator, 0.5, 32);
+    imageProvider->setFrameCache(overlayFrameCache);
+    profileImageProvider->setFrameCache(profileFrameCache);
+
+    // Wire every generator and Config signal that could affect rendered output
+    // to cache invalidation. Conservative — invalidating on the wrong signal
+    // costs a single re-render; missing one would show stale frames.
+    auto invalidateOverlay = [overlayFrameCache]() { overlayFrameCache->invalidate(); };
+    auto invalidateProfile = [profileFrameCache]() { profileFrameCache->invalidate(); };
+
+    QObject::connect(overlayGenerator, &OverlayGenerator::fontChanged,              invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::textColorChanged,         invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::templateChanged,          invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showDepthChanged,         invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showTemperatureChanged,   invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showNDLChanged,           invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showPressureChanged,      invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showTimeChanged,          invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::backgroundOpacityChanged, invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showLabelChanged,         invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showPO2Cell1Changed,      invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showPO2Cell2Changed,      invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showPO2Cell3Changed,      invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showCompositePO2Changed,  invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::cellsChanged,             invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::cellLayoutChanged,        invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::showCellBackgroundsChanged, invalidateOverlay);
+    QObject::connect(Config::instance(), &Config::unitSystemChanged,                invalidateOverlay);
+
+    QObject::connect(profileGenerator, &ProfileGenerator::backgroundColorChanged,    invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::backgroundOpacityChanged,  invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::curveColorChanged,         invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::indicatorColorChanged,     invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::indicatorModeChanged,      invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::indicatorRadiusChanged,    invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::pulsePeriodMsChanged,      invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::outputWidthChanged,        invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::outputHeightChanged,       invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::decoZoneColorChanged,      invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::decoZoneOpacityChanged,    invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridEnabledChanged,        invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridDepthIntervalChanged,  invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridTimeIntervalChanged,   invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridColorChanged,          invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridOpacityChanged,        invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridLineWidthChanged,      invalidateProfile);
+    QObject::connect(profileGenerator, &ProfileGenerator::gridShowLabelsChanged,     invalidateProfile);
+
     // Connect the LogParser signals to MainWindow slots
     QObject::connect(&logParser, &LogParser::diveImported,
                      &mainWindow, &MainWindow::onDiveImported);
@@ -89,10 +141,16 @@ int main(int argc, char *argv[])
 
     // Connect signals to update the image providers when the active dive changes
     QObject::connect(&mainWindow, &MainWindow::currentDiveChanged,
-                    [imageProvider, profileImageProvider, &mainWindow]() {
+                    [imageProvider, profileImageProvider, overlayFrameCache,
+                     profileFrameCache, &mainWindow]() {
                         DiveData* dive = mainWindow.currentDive();
                         imageProvider->setCurrentDive(dive);
                         profileImageProvider->setCurrentDive(dive);
+                        // Drop cached frames keyed on the previous dive pointer;
+                        // the pointer might be reused for a fresh DiveData and
+                        // would otherwise return stale images.
+                        overlayFrameCache->invalidate();
+                        profileFrameCache->invalidate();
                     });
     
     qDebug() << "Connected LogParser::diveImported to MainWindow::onDiveImported";

--- a/src/ui/qml/TimelineView.qml
+++ b/src/ui/qml/TimelineView.qml
@@ -21,6 +21,13 @@ Item {
     property color canvasBackground: palette.base
     property color canvasGridColor: palette.mid
     property color canvasTextColor: palette.windowText
+
+    // True while the Video Preview tab is active with a video loaded. In this
+    // mode the red cursor is driven by video playback (cursorTime = videoPos +
+    // videoOffset), so clicking the timeline must NOT seek the cursor — that
+    // would clobber the derived position. Dragging the zone/cursor still adjusts
+    // videoOffset (the sync gesture).
+    property bool videoSyncMode: false
     
     // Reference to C++ Timeline object
     Timeline {
@@ -440,6 +447,9 @@ Item {
                     property int dragThreshold: 3
                     
                     onClicked: function(mouseEvent) {
+                        // In video-sync mode the cursor mirrors the video position;
+                        // a click must not seek it independently.
+                        if (root.videoSyncMode) return;
                         if (!isDraggingVideo) {
                             var timeRange = timeline.endTime - timeline.startTime;
                             var clickTime = timeline.startTime + (mouseEvent.x / parent.width) * timeRange;
@@ -509,7 +519,10 @@ Item {
                                 var endX = ((videoEndTime - timeline.startTime) / timeRange) * width;
                                 
                                 if (mouseEvent.x >= startX && mouseEvent.x <= endX) {
-                                    cursorShape = Qt.PointingHandCursor;
+                                    // In sync mode dragging the zone/cursor adjusts the
+                                    // offset horizontally — signal that with a resize cursor.
+                                    cursorShape = root.videoSyncMode ? Qt.SizeHorCursor
+                                                                     : Qt.PointingHandCursor;
                                 } else {
                                     cursorShape = Qt.ArrowCursor;
                                 }

--- a/src/ui/qml/VideoOverlayItem.qml
+++ b/src/ui/qml/VideoOverlayItem.qml
@@ -1,0 +1,210 @@
+import QtQuick
+import QtQuick.Controls
+
+// Draggable / resizable overlay container that anchors itself to its parent
+// using normalized [0..1] coordinates. The same `normalizedRect` flows into
+// any future burn-in pass without further conversion.
+Item {
+    id: root
+
+    // -- Inputs ----------------------------------------------------------
+    property string imageSourceBase: "image://overlay/at/"
+    property real diveTime: 0
+    property int refreshTick: 0
+    property bool placementVisible: true
+    // x,y,w,h all in [0..1] of parent.
+    property rect normalizedRect: Qt.rect(0.02, 0.55, 0.30, 0.40)
+    property bool editable: true
+    property real minNormSize: 0.05
+    property color accentColor: "#ff3030"
+    property int borderWidth: 3
+    property int handleSize: 12
+
+    // -- Outputs ---------------------------------------------------------
+    // Fired after a drag or resize gesture completes (mouse released).
+    signal layoutCommitted()
+
+    visible: placementVisible
+
+    // Pixel placement derived from normalized rect against parent.
+    x: parent ? Math.round(normalizedRect.x * parent.width) : 0
+    y: parent ? Math.round(normalizedRect.y * parent.height) : 0
+    width:  parent ? Math.round(normalizedRect.width  * parent.width)  : 0
+    height: parent ? Math.round(normalizedRect.height * parent.height) : 0
+
+    // The rendered overlay image. Fits inside the item's bounds without
+    // distortion so user-chosen aspect doesn't squish the dive computer.
+    Image {
+        id: overlayImage
+        anchors.fill: parent
+        fillMode: Image.PreserveAspectFit
+        smooth: true
+        asynchronous: true
+        // Disable QML's URL cache: we have a content-addressed cache behind
+        // the image provider, and URLs change per refresh tick anyway.
+        cache: false
+        source: root.diveTime >= 0
+                ? root.imageSourceBase + root.diveTime.toFixed(2) + "/" + root.refreshTick
+                : ""
+    }
+
+    // Editor chrome — border + handles + move indicator. Only visible when
+    // the parent has flagged this overlay as editable.
+    Rectangle {
+        id: border
+        anchors.fill: parent
+        color: "transparent"
+        border.color: root.accentColor
+        border.width: root.borderWidth
+        visible: root.editable
+    }
+
+    // ---- Helpers -------------------------------------------------------
+    function _clampRect(x, y, w, h) {
+        w = Math.max(root.minNormSize, Math.min(1.0, w))
+        h = Math.max(root.minNormSize, Math.min(1.0, h))
+        x = Math.max(0.0, Math.min(1.0 - w, x))
+        y = Math.max(0.0, Math.min(1.0 - h, y))
+        return Qt.rect(x, y, w, h)
+    }
+
+    function _applyNormalized(x, y, w, h) {
+        root.normalizedRect = _clampRect(x, y, w, h)
+    }
+
+    // ---- Center drag (move) -------------------------------------------
+    MouseArea {
+        id: moveArea
+        anchors.fill: parent
+        anchors.margins: root.handleSize * 1.5
+        enabled: root.editable
+        cursorShape: Qt.SizeAllCursor
+        property real pressNormX: 0
+        property real pressNormY: 0
+        property real pressMouseSceneX: 0
+        property real pressMouseSceneY: 0
+
+        onPressed: (mouse) => {
+            pressNormX = root.normalizedRect.x
+            pressNormY = root.normalizedRect.y
+            const sp = mapToItem(root.parent, mouse.x, mouse.y)
+            pressMouseSceneX = sp.x
+            pressMouseSceneY = sp.y
+        }
+
+        onPositionChanged: (mouse) => {
+            if (!pressed || !root.parent) return
+            const sp = mapToItem(root.parent, mouse.x, mouse.y)
+            const dx = (sp.x - pressMouseSceneX) / root.parent.width
+            const dy = (sp.y - pressMouseSceneY) / root.parent.height
+            _applyNormalized(pressNormX + dx, pressNormY + dy,
+                             root.normalizedRect.width, root.normalizedRect.height)
+        }
+
+        onReleased: root.layoutCommitted()
+    }
+
+    // Center move indicator — a small "+" / four-arrow chip the user can see
+    // and grab when the overlay image fills the entire frame.
+    Rectangle {
+        anchors.centerIn: parent
+        width: root.handleSize * 2
+        height: root.handleSize * 2
+        radius: width / 2
+        color: Qt.rgba(0, 0, 0, 0.45)
+        border.color: root.accentColor
+        border.width: 2
+        visible: root.editable
+        Text {
+            anchors.centerIn: parent
+            text: "✥" // four-arrow-ish glyph; falls back gracefully
+            color: root.accentColor
+            font.pixelSize: parent.height * 0.7
+        }
+    }
+
+    // ---- Resize handles -----------------------------------------------
+    // One generic handle component reused for all 8 positions. `corner`
+    // identifies which edges/corners the drag affects.
+    component Handle : Rectangle {
+        id: handle
+        width: root.handleSize
+        height: root.handleSize
+        color: root.accentColor
+        border.color: "white"
+        border.width: 1
+        visible: root.editable
+        property string corner // "tl","t","tr","r","br","b","bl","l"
+
+        property real pressRectX: 0
+        property real pressRectY: 0
+        property real pressRectW: 0
+        property real pressRectH: 0
+        property real pressSceneX: 0
+        property real pressSceneY: 0
+
+        MouseArea {
+            anchors.fill: parent
+            enabled: root.editable
+            cursorShape: {
+                switch (handle.corner) {
+                case "tl": case "br": return Qt.SizeFDiagCursor
+                case "tr": case "bl": return Qt.SizeBDiagCursor
+                case "t":  case "b":  return Qt.SizeVerCursor
+                case "l":  case "r":  return Qt.SizeHorCursor
+                }
+                return Qt.ArrowCursor
+            }
+
+            onPressed: (mouse) => {
+                handle.pressRectX = root.normalizedRect.x
+                handle.pressRectY = root.normalizedRect.y
+                handle.pressRectW = root.normalizedRect.width
+                handle.pressRectH = root.normalizedRect.height
+                const sp = mapToItem(root.parent, mouse.x, mouse.y)
+                handle.pressSceneX = sp.x
+                handle.pressSceneY = sp.y
+            }
+
+            onPositionChanged: (mouse) => {
+                if (!pressed || !root.parent) return
+                const sp = mapToItem(root.parent, mouse.x, mouse.y)
+                const dxN = (sp.x - handle.pressSceneX) / root.parent.width
+                const dyN = (sp.y - handle.pressSceneY) / root.parent.height
+
+                let nx = handle.pressRectX
+                let ny = handle.pressRectY
+                let nw = handle.pressRectW
+                let nh = handle.pressRectH
+
+                const c = handle.corner
+                if (c === "tl" || c === "l" || c === "bl") {
+                    nx = handle.pressRectX + dxN
+                    nw = handle.pressRectW - dxN
+                } else if (c === "tr" || c === "r" || c === "br") {
+                    nw = handle.pressRectW + dxN
+                }
+                if (c === "tl" || c === "t" || c === "tr") {
+                    ny = handle.pressRectY + dyN
+                    nh = handle.pressRectH - dyN
+                } else if (c === "bl" || c === "b" || c === "br") {
+                    nh = handle.pressRectH + dyN
+                }
+                root._applyNormalized(nx, ny, nw, nh)
+            }
+
+            onReleased: root.layoutCommitted()
+        }
+    }
+
+    // 4 corners
+    Handle { corner: "tl"; x: -width/2;             y: -height/2 }
+    Handle { corner: "tr"; x: parent.width - width/2; y: -height/2 }
+    Handle { corner: "bl"; x: -width/2;             y: parent.height - height/2 }
+    Handle { corner: "br"; x: parent.width - width/2; y: parent.height - height/2 }
+    // 4 edge midpoints
+    Handle { corner: "t"; x: (parent.width - width)/2;  y: -height/2 }
+    Handle { corner: "b"; x: (parent.width - width)/2;  y: parent.height - height/2 }
+    Handle { corner: "l"; x: -width/2;                  y: (parent.height - height)/2 }
+    Handle { corner: "r"; x: parent.width - width/2;    y: (parent.height - height)/2 }
+}

--- a/src/ui/qml/VideoSyncPlayer.qml
+++ b/src/ui/qml/VideoSyncPlayer.qml
@@ -12,6 +12,27 @@ Item {
     property double videoCreationTime: -1  // UTC seconds since epoch; -1 if unavailable
     property var dive: null                // DiveData object (exposes startTime QDateTime)
 
+    // Seconds to add to MediaPlayer.position to obtain dive-time. Owned by
+    // the Timeline; mirrored here so the in-video overlay items can compute
+    // their dive time without reaching up the tree.
+    property double videoOffset: 0
+
+    // Exposed so other UI (e.g. the Profile tab pulse timer) can gate work
+    // on whether the user is actively watching the video.
+    readonly property bool playing: syncPlayer.playbackState === MediaPlayer.PlayingState
+
+    // Quantized to the same bucket as FrameCache so the Image source URL
+    // doesn't change faster than the cache regenerates frames.
+    readonly property double bucketSeconds: 0.5
+    readonly property double currentDiveTime: {
+        const raw = (syncPlayer.position / 1000.0) + root.videoOffset
+        return Math.floor(raw / bucketSeconds) * bucketSeconds
+    }
+
+    // Bumped whenever a generator setting that affects rendered output
+    // changes, so the Image re-requests with a new URL token while paused.
+    property int refreshTick: 0
+
     property double capturedVideoPosition: -1
     property bool syncPointCaptured: capturedVideoPosition >= 0
     property double parsedDiveSeconds: -1
@@ -29,6 +50,7 @@ Item {
 
     Component.onCompleted: {
         root.profileNames = config.cameraPairingNames()
+        loadOverlayLayoutFromConfig()
     }
 
     onVideoSourceChanged: {
@@ -36,6 +58,83 @@ Item {
         root.capturedVideoPosition = -1
         diveTimeField.text = ""
         root.syncApplied = false
+        loadOverlayLayoutFromConfig()
+    }
+
+    function videoLocalPath() {
+        if (videoSource == "") return ""
+        return mainWindow.urlToLocalFile(videoSource.toString())
+    }
+
+    function loadOverlayLayoutFromConfig() {
+        const path = videoLocalPath()
+        // Even with an empty path, fetch the last-used layout as the default.
+        const layout = config.videoOverlayLayout(path)
+        if (layout.diveComputer) {
+            const dc = layout.diveComputer
+            diveComputerOverlay.normalizedRect = Qt.rect(dc.x, dc.y, dc.w, dc.h)
+            diveComputerOverlay.placementVisible = dc.visible
+        }
+        if (layout.diveProfile) {
+            const dp = layout.diveProfile
+            diveProfileOverlay.normalizedRect = Qt.rect(dp.x, dp.y, dp.w, dp.h)
+            diveProfileOverlay.placementVisible = dp.visible
+        }
+    }
+
+    function saveOverlayLayoutToConfig() {
+        const path = videoLocalPath()
+        if (path === "") return
+        const dc = diveComputerOverlay.normalizedRect
+        const dp = diveProfileOverlay.normalizedRect
+        config.setVideoOverlayLayout(path, {
+            "diveComputer": {
+                "visible": diveComputerOverlay.placementVisible,
+                "x": dc.x, "y": dc.y, "w": dc.width, "h": dc.height
+            },
+            "diveProfile": {
+                "visible": diveProfileOverlay.placementVisible,
+                "x": dp.x, "y": dp.y, "w": dp.width, "h": dp.height
+            }
+        })
+    }
+
+    // Force a re-fetch of both overlay images when any generator setting that
+    // affects rendered output changes — needed while paused, since otherwise
+    // diveTime is static and the Image source URL doesn't change.
+    Connections {
+        target: overlayGenerator
+        function onFontChanged()              { root.refreshTick++ }
+        function onTextColorChanged()         { root.refreshTick++ }
+        function onTemplateChanged()          { root.refreshTick++ }
+        function onShowDepthChanged()         { root.refreshTick++ }
+        function onShowTemperatureChanged()   { root.refreshTick++ }
+        function onShowNDLChanged()           { root.refreshTick++ }
+        function onShowPressureChanged()      { root.refreshTick++ }
+        function onShowTimeChanged()          { root.refreshTick++ }
+        function onBackgroundOpacityChanged() { root.refreshTick++ }
+        function onShowPO2Cell1Changed()      { root.refreshTick++ }
+        function onShowPO2Cell2Changed()      { root.refreshTick++ }
+        function onShowPO2Cell3Changed()      { root.refreshTick++ }
+        function onShowCompositePO2Changed()  { root.refreshTick++ }
+        function onCellsChanged()             { root.refreshTick++ }
+        function onCellLayoutChanged()        { root.refreshTick++ }
+    }
+    Connections {
+        target: profileGenerator
+        function onBackgroundColorChanged()   { root.refreshTick++ }
+        function onBackgroundOpacityChanged() { root.refreshTick++ }
+        function onCurveColorChanged()        { root.refreshTick++ }
+        function onIndicatorColorChanged()    { root.refreshTick++ }
+        function onIndicatorModeChanged()     { root.refreshTick++ }
+        function onIndicatorRadiusChanged()   { root.refreshTick++ }
+        function onOutputWidthChanged()       { root.refreshTick++ }
+        function onOutputHeightChanged()      { root.refreshTick++ }
+        function onDecoZoneColorChanged()     { root.refreshTick++ }
+        function onDecoZoneOpacityChanged()   { root.refreshTick++ }
+        function onGridEnabledChanged()       { root.refreshTick++ }
+        function onGridColorChanged()         { root.refreshTick++ }
+        function onGridOpacityChanged()       { root.refreshTick++ }
     }
 
     function parseDiveTime(text) {
@@ -91,6 +190,30 @@ Item {
                 anchors.fill: parent
             }
 
+            // Live preview overlays. Anchored to the video Rectangle so
+            // their normalized rects map onto the full video area.
+            VideoOverlayItem {
+                id: diveComputerOverlay
+                imageSourceBase: "image://overlay/at/"
+                diveTime: root.currentDiveTime
+                refreshTick: root.refreshTick
+                editable: true
+                visible: placementVisible && root.dive !== null && root.videoSource != ""
+                onLayoutCommitted: root.saveOverlayLayoutToConfig()
+                onPlacementVisibleChanged: root.saveOverlayLayoutToConfig()
+            }
+
+            VideoOverlayItem {
+                id: diveProfileOverlay
+                imageSourceBase: "image://profile/at/"
+                diveTime: root.currentDiveTime
+                refreshTick: root.refreshTick
+                editable: true
+                visible: placementVisible && root.dive !== null && root.videoSource != ""
+                onLayoutCommitted: root.saveOverlayLayoutToConfig()
+                onPlacementVisibleChanged: root.saveOverlayLayoutToConfig()
+            }
+
             Label {
                 anchors.centerIn: parent
                 visible: root.videoSource == ""
@@ -141,6 +264,18 @@ Item {
                           " / " + formatTime(syncPlayer.duration / 1000)
                     color: palette.windowText
                     font.family: "monospace"
+                }
+
+                CheckBox {
+                    text: qsTr("Dive Computer")
+                    checked: diveComputerOverlay.placementVisible
+                    onToggled: diveComputerOverlay.placementVisible = checked
+                }
+
+                CheckBox {
+                    text: qsTr("Profile")
+                    checked: diveProfileOverlay.placementVisible
+                    onToggled: diveProfileOverlay.placementVisible = checked
                 }
             }
         }

--- a/src/ui/qml/VideoSyncPlayer.qml
+++ b/src/ui/qml/VideoSyncPlayer.qml
@@ -9,6 +9,14 @@ Item {
     property url videoSource: ""
     signal syncOffsetComputed(double offset)
 
+    // Emitted to drive the timeline's red cursor to the dive-time of the current
+    // video frame while this tab is active. main.qml routes it to currentTime.
+    signal cursorTimeRequested(double diveTime)
+
+    // True while the Video Preview tab is the active tab. Gates cursor-driving so
+    // we don't move the shared timeline cursor while the user is on another tab.
+    property bool tabActive: false
+
     property double videoCreationTime: -1  // UTC seconds since epoch; -1 if unavailable
     property var dive: null                // DiveData object (exposes startTime QDateTime)
 
@@ -33,17 +41,26 @@ Item {
     // changes, so the Image re-requests with a new URL token while paused.
     property int refreshTick: 0
 
-    property double capturedVideoPosition: -1
-    property bool syncPointCaptured: capturedVideoPosition >= 0
-    property double parsedDiveSeconds: -1
-    property bool inputValid: parsedDiveSeconds >= 0
-    property double previewOffset: (syncPointCaptured && inputValid)
-                                   ? parsedDiveSeconds - capturedVideoPosition
-                                   : 0
-    property bool syncApplied: false
+    // Precise (un-bucketed) dive-time of the current video frame. Drives the red
+    // cursor and the editable "Dive time at this frame" field. The overlay images
+    // use the bucketed currentDiveTime instead so the cache isn't thrashed.
+    readonly property double exactDiveTime: (syncPlayer.position / 1000.0) + root.videoOffset
 
     readonly property bool metadataAvailable: root.videoCreationTime >= 0
     readonly property bool diveAvailable: root.dive !== null
+
+    // Push the red timeline cursor to the current frame's dive-time. No-op unless
+    // this tab is active and a video + dive are loaded.
+    function updateCursor() {
+        if (tabActive && videoSource != "" && root.dive !== null)
+            root.cursorTimeRequested(exactDiveTime)
+    }
+
+    // Re-drive the cursor whenever the frame's dive-time can change: the offset is
+    // adjusted, or the tab becomes active. (Playback position is handled in the
+    // syncPlayer Connections below.)
+    onVideoOffsetChanged: updateCursor()
+    onTabActiveChanged: updateCursor()
 
     // Reactive mirror of config.cameraPairingNames() — updated via onCameraPairingsChanged
     property var profileNames: []
@@ -55,9 +72,6 @@ Item {
 
     onVideoSourceChanged: {
         syncPlayer.source = videoSource
-        root.capturedVideoPosition = -1
-        diveTimeField.text = ""
-        root.syncApplied = false
         loadOverlayLayoutFromConfig()
     }
 
@@ -172,6 +186,7 @@ Item {
         function onPositionChanged() {
             if (!seekSlider.pressed)
                 seekSlider.value = syncPlayer.position
+            root.updateCursor()
         }
     }
 
@@ -317,7 +332,6 @@ Item {
                                 var diveStartSecs = root.dive.startTime.getTime() / 1000.0
                                 var suggested = (root.videoCreationTime - diveStartSecs) + constant
                                 root.syncOffsetComputed(suggested)
-                                root.syncApplied = true
                             }
                         }
                     }
@@ -356,67 +370,62 @@ Item {
                     text: qsTr("Video creation time not available — camera profiles cannot be used or saved for this file.")
                 }
 
-                // ── Manual sync workflow ──────────────────────────────────
+                // ── Graphical sync ────────────────────────────────────────
                 Label {
                     Layout.fillWidth: true
                     wrapMode: Text.WordWrap
-                    text: {
-                        if (root.videoSource == "")
-                            return qsTr("No video loaded.")
-                        if (!root.syncPointCaptured)
-                            return qsTr("Play the video and pause when you can clearly see the dive computer display, then press 'Set Sync Point'.")
-                        if (!root.inputValid)
-                            return qsTr("Video captured at %1. Now enter the dive time shown on your dive computer display.").arg(formatTime(root.capturedVideoPosition))
-                        return qsTr("Ready to apply. The video will be aligned to start %1 seconds into the dive.").arg(root.previewOffset.toFixed(1))
-                    }
+                    text: root.videoSource == ""
+                          ? qsTr("No video loaded.")
+                          : qsTr("Pause when your dive computer is clearly visible, then drag the video band on the timeline (or nudge below) until the overlay's data matches the display on your computer. The red cursor follows the video.")
                 }
 
                 RowLayout {
+                    visible: root.videoSource != ""
                     spacing: 8
 
-                    Button {
-                        text: root.syncPointCaptured ? qsTr("Reset Sync Point") : qsTr("Set Sync Point")
-                        enabled: root.videoSource != ""
-                        onClicked: {
-                            syncPlayer.pause()
-                            root.capturedVideoPosition = syncPlayer.position / 1000.0
-                            diveTimeField.text = ""
-                            diveTimeField.forceActiveFocus()
-                        }
-                    }
-
-                    Label {
-                        visible: root.syncPointCaptured
-                        text: qsTr("Captured at %1").arg(formatTime(root.capturedVideoPosition))
-                    }
-                }
-
-                RowLayout {
-                    visible: root.syncPointCaptured
-                    spacing: 8
-
-                    Label { text: qsTr("Dive time shown on computer:") }
+                    Label { text: qsTr("Dive time at this frame:") }
 
                     TextField {
                         id: diveTimeField
                         placeholderText: qsTr("MM:SS  (e.g. 12:15)")
-                        implicitWidth: 160
-                        onTextChanged: root.parsedDiveSeconds = parseDiveTime(text)
+                        implicitWidth: 120
+                        // Live readout of the current frame's dive-time. Editing
+                        // breaks this binding (user value wins); committing restores
+                        // it. While paused exactDiveTime is static, so typing isn't
+                        // overwritten.
+                        text: formatTime(root.exactDiveTime)
+                        onEditingFinished: {
+                            // Only commit when the user actually changed the value —
+                            // a bare focus-loss must not re-apply the floored readout
+                            // (which would shave the sub-second fraction off the offset).
+                            if (text !== formatTime(root.exactDiveTime)) {
+                                var secs = parseDiveTime(text)
+                                if (secs >= 0)
+                                    root.syncOffsetComputed(secs - syncPlayer.position / 1000.0)
+                            }
+                            // Re-establish the live readout binding.
+                            text = Qt.binding(function() { return formatTime(root.exactDiveTime) })
+                        }
+                    }
+
+                    Label { text: qsTr("Nudge:") }
+
+                    Button {
+                        text: qsTr("-1s")
+                        enabled: root.videoSource != ""
+                        onClicked: root.syncOffsetComputed(root.videoOffset - 1)
                     }
 
                     Button {
-                        text: qsTr("Apply")
-                        enabled: root.syncPointCaptured && root.inputValid
-                        onClicked: {
-                            root.syncOffsetComputed(root.previewOffset)
-                            root.syncApplied = true
-                        }
+                        text: qsTr("+1s")
+                        enabled: root.videoSource != ""
+                        onClicked: root.syncOffsetComputed(root.videoOffset + 1)
                     }
                 }
 
                 // ── Section B: Save Profile ───────────────────────────────
                 ColumnLayout {
-                    visible: root.syncApplied && root.metadataAvailable && root.diveAvailable
+                    visible: root.metadataAvailable && root.diveAvailable && root.videoSource != ""
                     spacing: 4
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: palette.mid }
@@ -446,7 +455,8 @@ Item {
                             onClicked: {
                                 var savedName = cameraNameField.text.trim()
                                 var diveStartSecs = root.dive.startTime.getTime() / 1000.0
-                                var constant = root.previewOffset
+                                // The current live offset is the sync result.
+                                var constant = root.videoOffset
                                                - (root.videoCreationTime - diveStartSecs)
                                 // addOrUpdateCameraPairing emits cameraPairingsChanged
                                 // synchronously, so root.profileNames and profileComboBox.model

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -635,7 +635,13 @@ ApplicationWindow {
                                     Timer {
                                         interval: 80
                                         repeat: true
-                                        running: profileGenerator && profileGenerator.indicatorMode === 1 && mainWindow.hasActiveDive
+                                        // Suppressed while the video preview is playing — the
+                                        // indicator's position is already moving with dive time
+                                        // there, and the wall-clock pulse adds visual noise.
+                                        running: profileGenerator
+                                                 && profileGenerator.indicatorMode === 1
+                                                 && mainWindow.hasActiveDive
+                                                 && !videoSyncPlayer.playing
                                         onTriggered: {
                                             var period = profileGenerator ? profileGenerator.pulsePeriodMs : 2000
                                             if (period < 100) period = 100
@@ -690,6 +696,7 @@ ApplicationWindow {
                         videoSource: window.currentVideoUrl
                         videoCreationTime: window.videoCreationTime
                         dive: mainWindow.currentDive
+                        videoOffset: timelineView.timeline ? timelineView.timeline.videoOffset : 0
 
                         onSyncOffsetComputed: function(offset) {
                             timelineView.timeline.videoOffset = offset

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -623,7 +623,11 @@ ApplicationWindow {
                                     Connections {
                                         target: timelineView.timeline
                                         function onCurrentTimeChanged() {
-                                            profilePreviewImage.updatePreview()
+                                            // currentTime now also moves while the video plays
+                                            // (Video Preview tab). Skip regenerating this hidden
+                                            // tab's preview unless it's the active tab.
+                                            if (contentTabs.currentIndex === 1)
+                                                profilePreviewImage.updatePreview()
                                         }
                                     }
 
@@ -697,9 +701,15 @@ ApplicationWindow {
                         videoCreationTime: window.videoCreationTime
                         dive: mainWindow.currentDive
                         videoOffset: timelineView.timeline ? timelineView.timeline.videoOffset : 0
+                        tabActive: contentTabs.currentIndex === 2
 
                         onSyncOffsetComputed: function(offset) {
                             timelineView.timeline.videoOffset = offset
+                        }
+                        // Inverse of videoOffset: the player drives the red cursor to the
+                        // dive-time of the current video frame while the tab is active.
+                        onCursorTimeRequested: function(t) {
+                            timelineView.timeline.currentTime = t
                         }
                     }
                 } // end StackLayout
@@ -717,9 +727,13 @@ ApplicationWindow {
                 id: timelineView
                 anchors.fill: parent
                 visible: mainWindow.hasActiveDive
-                
+                videoSyncMode: contentTabs.currentIndex === 2 && timeline.videoPath !== ""
+
                 onCurrentTimeChanged: {
-                    if (previewImage.status === Image.Ready) {
+                    // The overlay tab's preview is the only consumer here; skip the
+                    // work when it isn't the active tab (currentTime also moves
+                    // during video playback on the Video Preview tab).
+                    if (contentTabs.currentIndex === 0 && previewImage.status === Image.Ready) {
                         previewImage.updatePreview()
                     }
                 }


### PR DESCRIPTION
This PR adds the preview capability to the Video Preview tab. It allows to:

 1. Visualize both overlays (dive computer and dive profile) with your video.
 2. Adjust the overlays (position, size and geometry). In the future we will be able to export a composited video from here.
 3. Synchronize your footage with the dive timeline and save the profile.

Fixes #36