### PR TITLE
feat: add an edit history with undo/redo capabilities.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(PROJECT_SOURCES
     src/ui/timeline.cpp
     src/ui/cell_model.cpp
     src/generators/overlay_gen.cpp
+    src/generators/template_undo_stack.cpp
     src/generators/overlay_image_provider.cpp
     src/generators/profile_renderer.cpp
     src/generators/profile_gen.cpp
@@ -74,6 +75,7 @@ set(PROJECT_HEADERS
     include/ui/timeline.h
     include/ui/cell_model.h
     include/generators/overlay_gen.h
+    include/generators/template_undo_stack.h
     include/generators/overlay_image_provider.h
     include/generators/i_frame_generator.h
     include/generators/profile_renderer.h

--- a/include/generators/template_undo_stack.h
+++ b/include/generators/template_undo_stack.h
@@ -1,0 +1,70 @@
+#ifndef TEMPLATE_UNDO_STACK_H
+#define TEMPLATE_UNDO_STACK_H
+
+#include <QObject>
+#include <QList>
+#include <QTimer>
+#include "include/core/overlay_template.h"
+
+class OverlayGenerator;
+
+// Snapshot-based undo/redo for the template editor.
+//
+// The OverlayGenerator already round-trips all template content through
+// exportTemplate()/loadTemplate(), so an undo history is just a stack of
+// OverlayTemplate snapshots. This class listens to the generator's
+// content-change signals and, after a short debounce, records the *previous*
+// state. Debouncing coalesces continuous edits (opacity slider, font-size
+// spinbox) into a single undo entry per gesture.
+//
+// Invariant: m_baseline equals the current generator state whenever the
+// coalesce timer is not pending.
+class TemplateUndoStack : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool canUndo READ canUndo NOTIFY canUndoChanged)
+    Q_PROPERTY(bool canRedo READ canRedo NOTIFY canRedoChanged)
+
+public:
+    explicit TemplateUndoStack(OverlayGenerator* generator, QObject* parent = nullptr);
+
+    bool canUndo() const { return !m_undoStack.isEmpty(); }
+    bool canRedo() const { return !m_redoStack.isEmpty(); }
+
+    // Connect a generator content-change signal to the debounced recorder.
+    // Called once per tracked signal from main.cpp.
+    void trackSignal(const char* signal);
+
+public slots:
+    void undo();
+    void redo();
+
+    // Commit any pending change immediately (used internally before undo/redo).
+    void flush();
+
+    // Drop all history and re-baseline to the current state. Used at history
+    // boundaries (template file load, dive import) so undo never crosses them.
+    void resetHistory();
+
+signals:
+    void canUndoChanged();
+    void canRedoChanged();
+
+private slots:
+    void onGeneratorChanged();
+    void commit();
+
+private:
+    OverlayGenerator* m_generator;
+    QList<Unabara::OverlayTemplate> m_undoStack;
+    QList<Unabara::OverlayTemplate> m_redoStack;
+    Unabara::OverlayTemplate m_baseline;
+    QTimer m_coalesceTimer;
+    bool m_restoring = false;
+
+    static constexpr int kMaxDepth = 50;
+    static constexpr int kCoalesceMs = 300;
+};
+
+#endif // TEMPLATE_UNDO_STACK_H

--- a/src/generators/template_undo_stack.cpp
+++ b/src/generators/template_undo_stack.cpp
@@ -1,0 +1,142 @@
+#include "include/generators/template_undo_stack.h"
+#include "include/generators/overlay_gen.h"
+
+TemplateUndoStack::TemplateUndoStack(OverlayGenerator* generator, QObject* parent)
+    : QObject(parent)
+    , m_generator(generator)
+{
+    m_coalesceTimer.setSingleShot(true);
+    m_coalesceTimer.setInterval(kCoalesceMs);
+    connect(&m_coalesceTimer, &QTimer::timeout, this, &TemplateUndoStack::commit);
+
+    // Baseline the current generator state. Tracked signals are connected by
+    // main.cpp via trackSignal() after construction, so nothing fires here.
+    if (m_generator)
+        m_baseline = m_generator->exportTemplate();
+}
+
+void TemplateUndoStack::trackSignal(const char* signal)
+{
+    if (m_generator)
+        connect(m_generator, signal, this, SLOT(onGeneratorChanged()));
+}
+
+void TemplateUndoStack::onGeneratorChanged()
+{
+    // Ignore signals emitted by our own loadTemplate() during undo/redo.
+    if (m_restoring)
+        return;
+    // Coalesce rapid changes into a single entry; (re)start the debounce.
+    m_coalesceTimer.start();
+}
+
+void TemplateUndoStack::commit()
+{
+    if (!m_generator)
+        return;
+
+    m_coalesceTimer.stop();
+
+    const bool hadRedo = !m_redoStack.isEmpty();
+    const bool wasEmpty = m_undoStack.isEmpty();
+
+    // Record the prior state and clear any redo branch — a new edit invalidates
+    // the redo history.
+    m_undoStack.append(m_baseline);
+    m_redoStack.clear();
+    m_baseline = m_generator->exportTemplate();
+
+    // Bound memory: drop the oldest entries beyond the cap.
+    while (m_undoStack.size() > kMaxDepth)
+        m_undoStack.removeFirst();
+
+    if (wasEmpty)
+        emit canUndoChanged();
+    if (hadRedo)
+        emit canRedoChanged();
+}
+
+void TemplateUndoStack::flush()
+{
+    if (m_coalesceTimer.isActive())
+        commit();
+}
+
+void TemplateUndoStack::undo()
+{
+    if (!m_generator)
+        return;
+
+    // Commit any in-progress edit so it becomes the first thing we undo.
+    flush();
+
+    if (m_undoStack.isEmpty())
+        return;
+
+    const bool redoWasEmpty = m_redoStack.isEmpty();
+
+    const Unabara::OverlayTemplate current = m_generator->exportTemplate();
+    const Unabara::OverlayTemplate prev = m_undoStack.takeLast();
+    m_redoStack.append(current);
+
+    m_restoring = true;
+    m_generator->loadTemplate(prev);
+    m_restoring = false;
+
+    m_baseline = prev;
+
+    if (m_undoStack.isEmpty())
+        emit canUndoChanged();
+    if (redoWasEmpty)
+        emit canRedoChanged();
+}
+
+void TemplateUndoStack::redo()
+{
+    if (!m_generator)
+        return;
+
+    // A pending edit must win over the redo branch, so commit it first; that
+    // clears the redo stack and redo() below becomes a no-op (correct).
+    flush();
+
+    if (m_redoStack.isEmpty())
+        return;
+
+    const bool undoWasEmpty = m_undoStack.isEmpty();
+
+    const Unabara::OverlayTemplate current = m_generator->exportTemplate();
+    const Unabara::OverlayTemplate next = m_redoStack.takeLast();
+    m_undoStack.append(current);
+
+    m_restoring = true;
+    m_generator->loadTemplate(next);
+    m_restoring = false;
+
+    m_baseline = next;
+
+    if (m_redoStack.isEmpty())
+        emit canRedoChanged();
+    if (undoWasEmpty)
+        emit canUndoChanged();
+}
+
+void TemplateUndoStack::resetHistory()
+{
+    if (!m_generator)
+        return;
+
+    m_coalesceTimer.stop();
+
+    const bool hadUndo = !m_undoStack.isEmpty();
+    const bool hadRedo = !m_redoStack.isEmpty();
+
+    m_undoStack.clear();
+    m_redoStack.clear();
+    m_baseline = m_generator->exportTemplate();
+
+    if (hadUndo)
+        emit canUndoChanged();
+    if (hadRedo)
+        emit canRedoChanged();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "include/ui/timeline.h"
 #include "include/ui/cell_model.h"
 #include "include/generators/overlay_gen.h"
+#include "include/generators/template_undo_stack.h"
 #include "include/export/image_export.h"
 #include "include/export/video_export.h"
 #include "include/generators/overlay_image_provider.h"
@@ -71,6 +72,11 @@ int main(int argc, char *argv[])
     OverlayGenerator* overlayGenerator = new OverlayGenerator();
     OverlayImageProvider* imageProvider = new OverlayImageProvider(overlayGenerator);
 
+    // Undo/redo for the template editor. Constructed after the generator (which
+    // loads its active template during construction) so it baselines a valid
+    // state; tracked signals are connected below.
+    TemplateUndoStack* undoManager = new TemplateUndoStack(overlayGenerator);
+
     // Register the image provider
     engine.addImageProvider("overlay", imageProvider);
 
@@ -113,6 +119,34 @@ int main(int argc, char *argv[])
     QObject::connect(overlayGenerator, &OverlayGenerator::cellLayoutChanged,        invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showCellBackgroundsChanged, invalidateOverlay);
     QObject::connect(Config::instance(), &Config::unitSystemChanged,                invalidateOverlay);
+
+    // Undo/redo: record a snapshot when template *content* changes. This tracks
+    // only the signals that map to what exportTemplate() serializes — not the
+    // full invalidate set above, which also fires on editor-only / display state
+    // (showCellBackgrounds, unit system, show* toggles whose real cell mutation
+    // already arrives via cellsChanged/cellLayoutChanged) and would otherwise
+    // produce no-op undo entries.
+    undoManager->trackSignal(SIGNAL(cellsChanged()));
+    undoManager->trackSignal(SIGNAL(cellLayoutChanged()));
+    undoManager->trackSignal(SIGNAL(fontChanged()));
+    undoManager->trackSignal(SIGNAL(textColorChanged()));
+    undoManager->trackSignal(SIGNAL(backgroundOpacityChanged()));
+    undoManager->trackSignal(SIGNAL(templateChanged()));
+    undoManager->trackSignal(SIGNAL(showLabelChanged()));
+
+    // History boundaries: a template file load (combobox / Load button) and a
+    // dive import both reset undo history so it never crosses them. templateLoaded
+    // fires from loadTemplateFromFile but NOT from loadTemplate(), so an undo
+    // restore never triggers this.
+    QObject::connect(overlayGenerator, &OverlayGenerator::templateLoaded,
+                     undoManager, &TemplateUndoStack::resetHistory);
+    // Queued: a dive change triggers synchronous QML cell-layout regeneration
+    // (adjustTankCellVisibility, etc.) that emits cellsChanged. Running the reset
+    // at the end of the event-loop turn lets it cancel the coalesce timer that
+    // regeneration started, so the import itself produces no undo entry.
+    QObject::connect(&mainWindow, &MainWindow::currentDiveChanged,
+                     undoManager, &TemplateUndoStack::resetHistory,
+                     Qt::QueuedConnection);
 
     QObject::connect(profileGenerator, &ProfileGenerator::backgroundColorChanged,    invalidateProfile);
     QObject::connect(profileGenerator, &ProfileGenerator::backgroundOpacityChanged,  invalidateProfile);
@@ -159,6 +193,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("mainWindow", &mainWindow);
     engine.rootContext()->setContextProperty("logParser", &logParser);
     engine.rootContext()->setContextProperty("overlayGenerator", overlayGenerator);
+    engine.rootContext()->setContextProperty("undoManager", undoManager);
     engine.rootContext()->setContextProperty("profileGenerator", profileGenerator);
     engine.rootContext()->setContextProperty("config", Config::instance());
 

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -20,6 +20,20 @@ ApplicationWindow {
     // UTC seconds since epoch from video file metadata; -1 if unavailable
     property double videoCreationTime: -1
 
+    // Template-editor undo/redo. Ctrl+Z / Ctrl+Y (plus Ctrl+Shift+Z for redo on
+    // platforms that prefer it). StandardKey resolves the platform-native binding.
+    Shortcut {
+        sequence: StandardKey.Undo
+        onActivated: undoManager.undo()
+    }
+    Shortcut {
+        // Explicit chords (not StandardKey.Redo) to honor the requested Ctrl+Y
+        // while avoiding a duplicate-binding warning, since StandardKey.Redo
+        // already resolves to Ctrl+Y / Ctrl+Shift+Z on Linux.
+        sequences: ["Ctrl+Y", "Ctrl+Shift+Z"]
+        onActivated: undoManager.redo()
+    }
+
     // Models and objects
     ImageExporter {
         id: imageExporter
@@ -303,7 +317,27 @@ ApplicationWindow {
                 onClicked: overlayEditorPanel.visible = !overlayEditorPanel.visible
             }
 
-            
+            ToolButton {
+                text: qsTr("Edit")
+                icon.name: "edit-undo"
+                onClicked: editMenu.open()
+
+                Menu {
+                    id: editMenu
+                    MenuItem {
+                        text: qsTr("Undo")
+                        enabled: undoManager.canUndo
+                        onTriggered: undoManager.undo()
+                    }
+                    MenuItem {
+                        text: qsTr("Redo")
+                        enabled: undoManager.canRedo
+                        onTriggered: undoManager.redo()
+                    }
+                }
+            }
+
+
             Item { Layout.fillWidth: true }
             
             Label {

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -20,17 +20,14 @@ ApplicationWindow {
     // UTC seconds since epoch from video file metadata; -1 if unavailable
     property double videoCreationTime: -1
 
-    // Template-editor undo/redo. Ctrl+Z / Ctrl+Y (plus Ctrl+Shift+Z for redo on
-    // platforms that prefer it). StandardKey resolves the platform-native binding.
+    // Template-editor undo/redo.
+    // StandardKey resolves the platform-native binding.
     Shortcut {
-        sequence: StandardKey.Undo
+        sequences: [StandardKey.Undo]
         onActivated: undoManager.undo()
     }
     Shortcut {
-        // Explicit chords (not StandardKey.Redo) to honor the requested Ctrl+Y
-        // while avoiding a duplicate-binding warning, since StandardKey.Redo
-        // already resolves to Ctrl+Y / Ctrl+Shift+Z on Linux.
-        sequences: ["Ctrl+Y", "Ctrl+Shift+Z"]
+        sequences: [StandardKey.Redo]
         onActivated: undoManager.redo()
     }
 


### PR DESCRIPTION
This PR add a new undo stack to manage undo/redo capabilities in the template editor.


Fixes #22