### PR TITLE
feat: Add CNS oxygen toxicity as a new overlay data point

### DIFF
--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -24,6 +24,7 @@ enum class CellType {
     PO2Cell2,         // CCR oxygen sensor 2
     PO2Cell3,         // CCR oxygen sensor 3
     CompositePO2,     // CCR composite PO2
+    CNS,              // CNS oxygen toxicity (percent)
     Unknown
 };
 

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -31,6 +31,7 @@ class Config : public QObject
     Q_PROPERTY(bool showNDL READ showNDL WRITE setShowNDL NOTIFY showNDLChanged)
     Q_PROPERTY(bool showPressure READ showPressure WRITE setShowPressure NOTIFY showPressureChanged)
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
+    Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
     Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
     // CCR settings
@@ -106,7 +107,10 @@ public:
     
     bool showTime() const;
     void setShowTime(bool show);
-    
+
+    bool showCNS() const;
+    void setShowCNS(bool show);
+
     Units::UnitSystem unitSystem() const;
     void setUnitSystem(Units::UnitSystem system);
     
@@ -223,6 +227,7 @@ signals:
     void showNDLChanged();
     void showPressureChanged();
     void showTimeChanged();
+    void showCNSChanged();
     void unitSystemChanged();
     void frameRateChanged();
     void templateDirectoryChanged();
@@ -281,6 +286,7 @@ private:
     bool m_showNDL;
     bool m_showPressure;
     bool m_showTime;
+    bool m_showCNS;
     Units::UnitSystem m_unitSystem;
     double m_frameRate;
     QString m_templateDirectory;

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -18,14 +18,15 @@ struct DiveDataPoint {
     double ceiling;             // Decompression ceiling in meters
     double o2percent;           // O2 percentage
     double tts;                 // Time To Surface in minutes
+    double cns;                 // CNS oxygen toxicity in percent (-1 = no data)
     QVector<double> po2Sensors; // PO2 sensor values in bar (for CCR dives)
-    
+
     // Constructor with default values
-    DiveDataPoint(double time = 0.0, double d = 0.0, double temp = 0.0, 
-                  double n = 0.0, double ceil = 0.0, 
+    DiveDataPoint(double time = 0.0, double d = 0.0, double temp = 0.0,
+                  double n = 0.0, double ceil = 0.0,
                   double o2 = 21.0, double t = 0.0)
         : timestamp(time), depth(d), temperature(temp),
-          ndl(n), ceiling(ceil), o2percent(o2), tts(t) {}
+          ndl(n), ceiling(ceil), o2percent(o2), tts(t), cns(-1.0) {}
           
     // Get the pressure for a specific tank (returns 0 if tank doesn't exist)
     Q_INVOKABLE double getPressure(int tankIndex = 0) const {

--- a/include/core/format_parsers/subsurface_parser.h
+++ b/include/core/format_parsers/subsurface_parser.h
@@ -37,6 +37,7 @@ private:
                             double &lastTemperature,
                             double &lastNDL,
                             double &lastTTS,
+                            double &lastCNS,
                             QMap<int, double> &lastPressures,
                             QMap<int, double> &lastPO2Sensors);
     void parseCylinderElement(QXmlStreamReader &xml, DiveData *dive);

--- a/include/core/format_parsers/uddf_parser.h
+++ b/include/core/format_parsers/uddf_parser.h
@@ -50,6 +50,7 @@ private:
                        double &lastNDL,
                        double &lastTTS,
                        double &lastCeiling,
+                       double &lastCNS,
                        QMap<int, double> &lastPressures,
                        QMap<int, double> &lastPO2Sensors,
                        QMap<QString, int> &po2SensorRefToIndex);

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -30,6 +30,7 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(bool showNDL READ showNDL WRITE setShowNDL NOTIFY showNDLChanged)
     Q_PROPERTY(bool showPressure READ showPressure WRITE setShowPressure NOTIFY showPressureChanged)
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
+    Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
     
     // CCR properties
     Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
@@ -64,7 +65,8 @@ public:
     bool showNDL() const { return m_showNDL; }
     bool showPressure() const { return m_showPressure; }
     bool showTime() const { return m_showTime; }
-    
+    bool showCNS() const { return m_showCNS; }
+
     // CCR getters
     bool showPO2Cell1() const { return m_showPO2Cell1; }
     bool showPO2Cell2() const { return m_showPO2Cell2; }
@@ -93,7 +95,8 @@ public:
     void setShowNDL(bool show);
     void setShowPressure(bool show);
     void setShowTime(bool show);
-    
+    void setShowCNS(bool show);
+
     // CCR setters
     void setShowPO2Cell1(bool show);
     void setShowPO2Cell2(bool show);
@@ -124,6 +127,7 @@ public:
     Q_INVOKABLE void setCellShowLabel(const QString& cellId, bool show);
     Q_INVOKABLE bool getCellShowLabel(const QString& cellId) const;
     Q_INVOKABLE void setCellVisible(const QString& cellId, bool visible);
+    Q_INVOKABLE void setCellTypeVisible(const QString& cellId, bool visible);
     Q_INVOKABLE void resetCellFont(const QString& cellId);
     Q_INVOKABLE void resetCellColor(const QString& cellId);
     Q_INVOKABLE void resetCellShowLabel(const QString& cellId);
@@ -168,7 +172,8 @@ signals:
     void showNDLChanged();
     void showPressureChanged();
     void showTimeChanged();
-    
+    void showCNSChanged();
+
     // CCR signals
     void showPO2Cell1Changed();
     void showPO2Cell2Changed();
@@ -207,7 +212,8 @@ private:
     bool m_showNDL;
     bool m_showPressure;
     bool m_showTime;
-    
+    bool m_showCNS;
+
     // CCR settings
     bool m_showPO2Cell1;
     bool m_showPO2Cell2;

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -166,6 +166,7 @@ QString CellData::cellTypeToString(CellType type)
         case CellType::PO2Cell2: return "PO2Cell2";
         case CellType::PO2Cell3: return "PO2Cell3";
         case CellType::CompositePO2: return "CompositePO2";
+        case CellType::CNS: return "CNS";
         default: return "Unknown";
     }
 }
@@ -182,6 +183,7 @@ CellType CellData::cellTypeFromString(const QString& str)
     if (str == "PO2Cell2") return CellType::PO2Cell2;
     if (str == "PO2Cell3") return CellType::PO2Cell3;
     if (str == "CompositePO2") return CellType::CompositePO2;
+    if (str == "CNS") return CellType::CNS;
     return CellType::Unknown;
 }
 

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -29,6 +29,7 @@ Config::Config(QObject *parent)
     , m_showNDL(true)
     , m_showPressure(true)
     , m_showTime(true)
+    , m_showCNS(false)
     , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
     , m_showPO2Cell1(false)
@@ -206,6 +207,19 @@ void Config::setShowTime(bool show)
     if (m_showTime != show) {
         m_showTime = show;
         emit showTimeChanged();
+    }
+}
+
+bool Config::showCNS() const
+{
+    return m_showCNS;
+}
+
+void Config::setShowCNS(bool show)
+{
+    if (m_showCNS != show) {
+        m_showCNS = show;
+        emit showCNSChanged();
     }
 }
 
@@ -541,7 +555,8 @@ void Config::loadConfig()
     m_showNDL = m_settings.value("overlay/showNDL", true).toBool();
     m_showPressure = m_settings.value("overlay/showPressure", true).toBool();
     m_showTime = m_settings.value("overlay/showTime", true).toBool();
-    
+    m_showCNS = m_settings.value("overlay/showCNS", false).toBool();
+
     // Load CCR settings
     m_showPO2Cell1 = m_settings.value("overlay/showPO2Cell1", false).toBool();
     m_showPO2Cell2 = m_settings.value("overlay/showPO2Cell2", false).toBool();
@@ -687,7 +702,8 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showNDL", m_showNDL);
     m_settings.setValue("overlay/showPressure", m_showPressure);
     m_settings.setValue("overlay/showTime", m_showTime);
-    
+    m_settings.setValue("overlay/showCNS", m_showCNS);
+
     // Save CCR settings
     m_settings.setValue("overlay/showPO2Cell1", m_showPO2Cell1);
     m_settings.setValue("overlay/showPO2Cell2", m_showPO2Cell2);

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -209,6 +209,13 @@ DiveDataPoint DiveData::dataAtTime(double time) const
     result.o2percent = prev.o2percent + factor * (next.o2percent - prev.o2percent);
     result.tts = prev.tts + factor * (next.tts - prev.tts);
 
+    // CNS: only interpolate between two valid values (-1 means no data).
+    // Across a no-data boundary, keep the surrounding sample's state instead
+    // of blending with the -1 sentinel.
+    result.cns = (prev.cns < 0.0 || next.cns < 0.0)
+        ? (factor >= 1.0 ? next.cns : prev.cns)
+        : prev.cns + factor * (next.cns - prev.cns);
+
     // Do NOT interpolate ceiling - use the value from the previous point
     // Ceiling is a state that persists until changed
     result.ceiling = prev.ceiling;

--- a/src/core/format_parsers/subsurface_parser.cpp
+++ b/src/core/format_parsers/subsurface_parser.cpp
@@ -349,6 +349,7 @@ void SubsurfaceParser::parseDiveComputerElement(QXmlStreamReader &xml, DiveData 
     double lastTemperature = 0.0;
     double lastNDL = 0.0;
     double lastTTS = 0.0;
+    double lastCNS = -1.0;
 
     QMap<int, double> lastPressures;
     QMap<int, double> lastPO2Sensors;
@@ -370,7 +371,7 @@ void SubsurfaceParser::parseDiveComputerElement(QXmlStreamReader &xml, DiveData 
             QString elementName = xml.name().toString();
 
             if (elementName == "sample") {
-                parseSampleElement(xml, dive, lastTemperature, lastNDL, lastTTS, lastPressures, lastPO2Sensors);
+                parseSampleElement(xml, dive, lastTemperature, lastNDL, lastTTS, lastCNS, lastPressures, lastPO2Sensors);
                 sampleCount++;
 
                 if (sampleCount % 10 == 0) {
@@ -442,6 +443,7 @@ void SubsurfaceParser::parseSampleElement(QXmlStreamReader &xml,
                                           double &lastTemperature,
                                           double &lastNDL,
                                           double &lastTTS,
+                                          double &lastCNS,
                                           QMap<int, double> &lastPressures,
                                           QMap<int, double> &lastPO2Sensors)
 {
@@ -662,6 +664,30 @@ void SubsurfaceParser::parseSampleElement(QXmlStreamReader &xml,
     } else {
         if (lastNDL >= 0.0) {
             point.ndl = lastNDL;
+        }
+    }
+
+    if (attrs.hasAttribute("cns")) {
+        QString cnsStr = attrs.value("cns").toString();
+        QRegularExpression cnsRe("(\\d+\\.?\\d*)\\s*%");
+        QRegularExpressionMatch match = cnsRe.match(cnsStr);
+
+        if (match.hasMatch()) {
+            point.cns = match.captured(1).toDouble();
+            lastCNS = point.cns;
+            hasData = true;
+        } else {
+            bool ok;
+            double cns = cnsStr.toDouble(&ok);
+            if (ok) {
+                point.cns = cns;
+                lastCNS = cns;
+                hasData = true;
+            }
+        }
+    } else {
+        if (lastCNS >= 0.0) {
+            point.cns = lastCNS;
         }
     }
 

--- a/src/core/format_parsers/uddf_parser.cpp
+++ b/src/core/format_parsers/uddf_parser.cpp
@@ -500,12 +500,13 @@ void UDDFParser::parseSamples(QXmlStreamReader &xml, DiveData *dive)
 {
     // UDDF waypoints record changes only — values not present in a waypoint
     // should be inherited from the previous one. We carry forward temperature,
-    // NDL, TTS, ceiling, per-tank pressure, and per-sensor PO2 across
+    // NDL, TTS, ceiling, CNS, per-tank pressure, and per-sensor PO2 across
     // waypoints, mirroring the SSRF parser's logic.
     double lastTemperature = 0.0;
     double lastNDL = 0.0;
     double lastTTS = 0.0;
     double lastCeiling = 0.0;
+    double lastCNS = -1.0;
     QMap<int, double> lastPressures;
     QMap<int, double> lastPO2Sensors;
     // Maps a <measuredpo2 ref="..."> identifier to its stable sensor index.
@@ -540,7 +541,7 @@ void UDDFParser::parseSamples(QXmlStreamReader &xml, DiveData *dive)
         if (xml.tokenType() == QXmlStreamReader::StartElement
             && xml.name() == QStringLiteral("waypoint")) {
             parseWaypoint(xml, dive, lastTemperature, lastNDL, lastTTS, lastCeiling,
-                          lastPressures, lastPO2Sensors, po2SensorRefToIndex);
+                          lastCNS, lastPressures, lastPO2Sensors, po2SensorRefToIndex);
         }
     }
 }
@@ -551,6 +552,7 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
                                double &lastNDL,
                                double &lastTTS,
                                double &lastCeiling,
+                               double &lastCNS,
                                QMap<int, double> &lastPressures,
                                QMap<int, double> &lastPO2Sensors,
                                QMap<QString, int> &po2SensorRefToIndex)
@@ -652,6 +654,13 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
                 sensorsSetThisWaypoint.insert(sensorIndex);
                 m_currentDiveCcrSeen = true;
             }
+        } else if (name == QStringLiteral("cns")) {
+            // <cns> is the CNS toxicity as a percent value (e.g. 65.0 = 65 %).
+            const double cns = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(cns) && cns >= 0.0) {
+                point.cns = cns;
+                lastCNS = cns;
+            }
         } else if (name == QStringLiteral("nodecotime")) {
             // <nodecotime> is in seconds; DiveDataPoint::ndl is in minutes.
             const double seconds = parse_utils::parseLocaleDouble(xml.readElementText());
@@ -738,6 +747,11 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
             point.tts = lastTTS;
         }
         point.ceiling = lastCeiling;
+    }
+
+    // Carry CNS forward when this waypoint did not report it.
+    if (point.cns < 0.0 && lastCNS >= 0.0) {
+        point.cns = lastCNS;
     }
 
     // Apply pending gas switches now that the timestamp is final.

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -23,6 +23,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_showNDL(true)
     , m_showPressure(true)
     , m_showTime(true)
+    , m_showCNS(false)
     , m_showPO2Cell1(false)
     , m_showPO2Cell2(false)
     , m_showPO2Cell3(false)
@@ -45,6 +46,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     m_showNDL = config->showNDL();
     m_showPressure = config->showPressure();
     m_showTime = config->showTime();
+    m_showCNS = config->showCNS();
     m_showPO2Cell1 = config->showPO2Cell1();
     m_showPO2Cell2 = config->showPO2Cell2();
     m_showPO2Cell3 = config->showPO2Cell3();
@@ -219,6 +221,15 @@ void OverlayGenerator::setShowNDL(bool show)
         m_showNDL = show;
         // Note: Cell regeneration is handled by QML with dive data
         emit showNDLChanged();
+    }
+}
+
+void OverlayGenerator::setShowCNS(bool show)
+{
+    if (m_showCNS != show) {
+        m_showCNS = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showCNSChanged();
     }
 }
 
@@ -564,6 +575,57 @@ void OverlayGenerator::setCellVisible(const QString& cellId, bool visible)
     }
 }
 
+void OverlayGenerator::setCellTypeVisible(const QString& cellId, bool visible)
+{
+    Unabara::CellData* cell = getCellData(cellId);
+    if (cell) {
+        cell->setVisible(visible);
+        emit cellLayoutChanged();
+        return;
+    }
+
+    if (!visible) {
+        // Nothing to hide
+        return;
+    }
+
+    // The template has no cell for this data type — create a default one
+    // (mirrors setPressureCellsVisible). Pressure cells have their own method
+    // because they depend on the dive's tank count.
+    static const QMap<QString, Unabara::CellType> idToType = {
+        {"depth", Unabara::CellType::Depth},
+        {"temperature", Unabara::CellType::Temperature},
+        {"time", Unabara::CellType::Time},
+        {"ndl", Unabara::CellType::NDL},
+        {"tts", Unabara::CellType::TTS},
+        {"cns", Unabara::CellType::CNS},
+        {"po2_cell1", Unabara::CellType::PO2Cell1},
+        {"po2_cell2", Unabara::CellType::PO2Cell2},
+        {"po2_cell3", Unabara::CellType::PO2Cell3},
+        {"composite_po2", Unabara::CellType::CompositePO2},
+    };
+    if (!idToType.contains(cellId)) {
+        qWarning() << "setCellTypeVisible: Unknown cell id:" << cellId;
+        return;
+    }
+
+    QImage templateImage(m_templatePath);
+    QSizeF templateSize = templateImage.isNull()
+        ? QSizeF(640, 120)
+        : QSizeF(templateImage.width(), templateImage.height());
+
+    Unabara::CellData newCell(cellId, idToType.value(cellId));
+    newCell.setPosition(QPointF(0.5, 0.5));
+    newCell.setFont(m_font, false);
+    newCell.setTextColor(m_textColor, false);
+    newCell.setCalculatedSize(calculateCellSize(newCell.cellType(), m_font, templateSize));
+    newCell.setVisible(true);
+    m_cells.append(newCell);
+
+    emit cellsChanged();
+    emit cellLayoutChanged();
+}
+
 void OverlayGenerator::adjustTankCellVisibility(DiveData* dive)
 {
     if (!dive || dive->cylinderCount() == 0) {
@@ -681,6 +743,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_showTime = false;
     m_showNDL = false;
     m_showPressure = false;
+    m_showCNS = false;
     m_showPO2Cell1 = false;
     m_showPO2Cell2 = false;
     m_showPO2Cell3 = false;
@@ -698,6 +761,8 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
             m_showNDL = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::Pressure) {
             m_showPressure = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::CNS) {
+            m_showCNS = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell1) {
             m_showPO2Cell1 = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell2) {
@@ -717,6 +782,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     emit showTimeChanged();
     emit showNDLChanged();
     emit showPressureChanged();
+    emit showCNSChanged();
     emit showPO2Cell1Changed();
     emit showPO2Cell2Changed();
     emit showPO2Cell3Changed();
@@ -815,6 +881,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
     if (m_showTemperature) numSections++;
     if (m_showNDL) numSections++;  // NDL/TTS share the same section
     if (m_showTime) numSections++;
+    if (m_showCNS) numSections++;
 
     // Tank sections (multi-tank uses grid, gets multiple sections)
     if (m_showPressure) {
@@ -949,6 +1016,17 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         cell.setFont(m_font, false);
         cell.setTextColor(m_textColor, false);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Time, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    if (m_showCNS) {
+        Unabara::CellData cell("cns", Unabara::CellType::CNS);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::CNS, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
         currentSection++;
@@ -1221,6 +1299,13 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
             ? QString("%1").arg(compositePO2, 0, 'f', 2)
             : "---";
         return format("PO2", value);
+    }
+
+    case Unabara::CellType::CNS: {
+        QString value = (dataPoint.cns >= 0)
+            ? QString("%1%").arg(qRound(dataPoint.cns))
+            : "---";
+        return format("CNS", value);
     }
 
     default:
@@ -1565,6 +1650,10 @@ QSizeF OverlayGenerator::calculateCellSize(Unabara::CellType cellType, const QFo
             case Unabara::CellType::CompositePO2:
                 header = tr("PPO2");
                 value = "1.29 bar";      // Typical composite PO2
+                break;
+            case Unabara::CellType::CNS:
+                header = tr("CNS");
+                value = "99%";           // Typical CNS toxicity percentage
                 break;
             default:
                 header = "UNKNOWN";

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -380,6 +380,16 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         return format("PO2", value);
     }
 
+    case Unabara::CellType::CNS: {
+        QString value;
+        if (dataPoint.cns >= 0) {
+            value = QString("%1%").arg(qRound(dataPoint.cns));
+        } else {
+            value = "---";
+        }
+        return format("CNS", value);
+    }
+
     default:
         return "Unknown";
     }

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -293,17 +293,19 @@ Item {
                     previewContainer.updateCellModel()
                 }
 
-                // Toggle cell visibility without destroying the layout
+                // Toggle cell visibility without destroying the layout.
+                // setCellTypeVisible creates a default cell when the current
+                // template has none for that data type.
                 function onShowDepthChanged() {
-                    root.generator.setCellVisible("depth", root.generator.showDepth)
+                    root.generator.setCellTypeVisible("depth", root.generator.showDepth)
                     previewContainer.updateCellModel()
                 }
                 function onShowTemperatureChanged() {
-                    root.generator.setCellVisible("temperature", root.generator.showTemperature)
+                    root.generator.setCellTypeVisible("temperature", root.generator.showTemperature)
                     previewContainer.updateCellModel()
                 }
                 function onShowNDLChanged() {
-                    root.generator.setCellVisible("ndl", root.generator.showNDL)
+                    root.generator.setCellTypeVisible("ndl", root.generator.showNDL)
                     previewContainer.updateCellModel()
                 }
                 function onShowPressureChanged() {
@@ -311,23 +313,27 @@ Item {
                     previewContainer.updateCellModel()
                 }
                 function onShowTimeChanged() {
-                    root.generator.setCellVisible("time", root.generator.showTime)
+                    root.generator.setCellTypeVisible("time", root.generator.showTime)
+                    previewContainer.updateCellModel()
+                }
+                function onShowCNSChanged() {
+                    root.generator.setCellTypeVisible("cns", root.generator.showCNS)
                     previewContainer.updateCellModel()
                 }
                 function onShowPO2Cell1Changed() {
-                    root.generator.setCellVisible("po2_cell1", root.generator.showPO2Cell1)
+                    root.generator.setCellTypeVisible("po2_cell1", root.generator.showPO2Cell1)
                     previewContainer.updateCellModel()
                 }
                 function onShowPO2Cell2Changed() {
-                    root.generator.setCellVisible("po2_cell2", root.generator.showPO2Cell2)
+                    root.generator.setCellTypeVisible("po2_cell2", root.generator.showPO2Cell2)
                     previewContainer.updateCellModel()
                 }
                 function onShowPO2Cell3Changed() {
-                    root.generator.setCellVisible("po2_cell3", root.generator.showPO2Cell3)
+                    root.generator.setCellTypeVisible("po2_cell3", root.generator.showPO2Cell3)
                     previewContainer.updateCellModel()
                 }
                 function onShowCompositePO2Changed() {
-                    root.generator.setCellVisible("composite_po2", root.generator.showCompositePO2)
+                    root.generator.setCellTypeVisible("composite_po2", root.generator.showCompositePO2)
                     previewContainer.updateCellModel()
                 }
             }
@@ -788,6 +794,17 @@ Item {
                     onCheckedChanged: {
                         if (generator && generator.showPressure !== checked) {
                             generator.showPressure = checked
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: showCNSCheckbox
+                    text: qsTr("Show CNS")
+                    checked: generator ? generator.showCNS : false
+                    onCheckedChanged: {
+                        if (generator && generator.showCNS !== checked) {
+                            generator.showCNS = checked
                         }
                     }
                 }

--- a/src/ui/qml/TimelineView.qml
+++ b/src/ui/qml/TimelineView.qml
@@ -586,6 +586,11 @@ Item {
                         } else {
                             infoText += "NDL: " + Math.round(dataPoint.ndl) + "min  ";
                         }
+
+                        // Add CNS if the dive computer reported it
+                        if (dataPoint.cns >= 0) {
+                            infoText += "CNS: " + Math.round(dataPoint.cns) + "%  ";
+                        }
                         
                         // Add tank pressures
                         var tankCount = dataPoint.tankCount;

--- a/src/ui/timeline.cpp
+++ b/src/ui/timeline.cpp
@@ -292,7 +292,8 @@ QVariantMap Timeline::getCurrentDataPoint() const
         result["ceiling"] = point.ceiling;
         result["o2percent"] = point.o2percent;
         result["tts"] = point.tts;
-        
+        result["cns"] = point.cns;
+
         // Add tank count
         result["tankCount"] = point.tankCount();
         

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -10,7 +10,7 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. |
+| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). |
 | `CCR_Halcyon_Benoit_cleaned.ssrf` | CCR dive — sensor1/2/3 still populate. |
 | `test_multidive.ssrf` | Multiple dives — picker shows them all; opening any one renders correctly. |
 | `OC_ScubaproG2_Benoit.ssrf` | Open-circuit, multi-tank pressures present. `diveMode` resolves to `OpenCircuit`. |
@@ -20,7 +20,7 @@ Run this before merging any change to the dive log parser. Each row below is a s
 | File | Expected |
 |---|---|
 | `2026-02-28-Monastery_Beach.uddf` | Same dive as the SSRF version above (CCR, dive #143). ~40.5 m max depth; 3 cylinders with begin/end pressure (Pa→bar conversion correct). Per-sample tank pressure / `<measuredpo2>` absent — Subsurface UDDF export limitation; cells just stay blank. Comma-decimal `<depth>` values (e.g. `2,1`) parse as 2.1. |
-| `Shearwater.uddf` | Loads; depth/temperature populated; comma decimals parsed. |
+| `Shearwater.uddf` | Loads; depth/temperature populated; comma decimals parsed. CNS appears late in the dive (`<cns>` elements near the end): 65% → 70% at the last sample, `---` before the first report. |
 | `Garmin.uddf` | Loads from a different exporter; verifies UDDF dialect handling. |
 
 ## Format detection
@@ -42,5 +42,6 @@ Run this before merging any change to the dive log parser. Each row below is a s
 | Per-sample temperature | Celsius | Kelvin → Celsius |
 | Per-sample tank pressure | bar | Pa → bar (via `<tankpressure>` when exporter provides it) |
 | Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) |
+| Per-sample CNS | `cns='NN%'` attribute | `<cns>` percent element (65.0 = 65 %) |
 | Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index |
 | Dive mode | inferred from CCR cues | `<divemode kind>` or inferred |


### PR DESCRIPTION
Parse the CNS percentage from both supported log formats:
- SSRF: `cns='14%'` sample attribute (percent string)
- UDDF: `<cns>65.0</cns>` waypoint child (percent as real number)

Both parsers carry the last known value forward across samples that omit
it, mirroring the NDL/TTS handling. CNS is stored as a double with a
-1 "no data" sentinel: dives without CNS display "---" instead of a
misleading 0%, and interpolation never blends real values with the
sentinel. Display rounds to an integer with a "%" suffix (e.g. "14%").

New CNS cell type wired through the full pipeline: template save/load,
C++ and QML renderers (kept in sync), cell size estimation, "Show CNS"
display option (off by default, persisted in config), and the timeline
hover readout.

Also add OverlayGenerator::setCellTypeVisible(), which creates a default
cell when the active template has none for that data type. All
non-pressure display toggles (depth, temperature, NDL, time, CNS, PO2)
now use it, fixing the long-standing issue where enabling a data type
missing from the template silently did nothing.

Document CNS expectations in the parser smoke test checklist.


Fixes #43