### PR TITLE
feat: Add mean depth as a new overlay data point

### DIFF
--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -25,6 +25,7 @@ enum class CellType {
     PO2Cell3,         // CCR oxygen sensor 3
     CompositePO2,     // CCR composite PO2
     CNS,              // CNS oxygen toxicity (percent)
+    MeanDepth,        // Average depth of the dive (static, reported by the dive computer)
     Unknown
 };
 

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -32,6 +32,7 @@ class Config : public QObject
     Q_PROPERTY(bool showPressure READ showPressure WRITE setShowPressure NOTIFY showPressureChanged)
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
     Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
+    Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
     Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
     // CCR settings
@@ -110,6 +111,8 @@ public:
 
     bool showCNS() const;
     void setShowCNS(bool show);
+    bool showMeanDepth() const;
+    void setShowMeanDepth(bool show);
 
     Units::UnitSystem unitSystem() const;
     void setUnitSystem(Units::UnitSystem system);
@@ -228,6 +231,7 @@ signals:
     void showPressureChanged();
     void showTimeChanged();
     void showCNSChanged();
+    void showMeanDepthChanged();
     void unitSystemChanged();
     void frameRateChanged();
     void templateDirectoryChanged();
@@ -287,6 +291,7 @@ private:
     bool m_showPressure;
     bool m_showTime;
     bool m_showCNS;
+    bool m_showMeanDepth;
     Units::UnitSystem m_unitSystem;
     double m_frameRate;
     QString m_templateDirectory;

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -100,6 +100,7 @@ class DiveData : public QObject
     Q_PROPERTY(QDateTime startTime READ startTime WRITE setStartTime NOTIFY startTimeChanged)
     Q_PROPERTY(int durationSeconds READ durationSeconds NOTIFY durationChanged)
     Q_PROPERTY(double maxDepth READ maxDepth NOTIFY dataChanged)
+    Q_PROPERTY(double meanDepth READ meanDepth NOTIFY dataChanged)
     Q_PROPERTY(double minTemperature READ minTemperature NOTIFY dataChanged)
     Q_PROPERTY(QString location READ location WRITE setLocation NOTIFY locationChanged)
     Q_PROPERTY(int cylinderCount READ cylinderCount NOTIFY dataChanged)
@@ -123,6 +124,7 @@ public:
     QDateTime startTime() const { return m_startTime; }
     int durationSeconds() const;
     double maxDepth() const;
+    double meanDepth() const;
     double minTemperature() const;
     QString location() const { return m_location; }
     int diveNumber() const { return m_diveNumber; }
@@ -135,6 +137,7 @@ public:
     void setStartTime(const QDateTime &time);
     void setLocation(const QString &location);
     void setDiveNumber(int number);
+    void setMeanDepth(double depth);
     void setDiveSiteName(const QString &siteName);
     void setDiveSiteId(const QString &siteId);
     void setDiveMode(DiveMode mode);
@@ -183,6 +186,7 @@ private:
     QDateTime m_startTime;
     QString m_location;
     int m_diveNumber;
+    double m_meanDepth = -1.0; // parsed from the log; < 0 means "not provided", fall back to computing from samples
     QString m_diveSiteName;
     QString m_diveSiteId;
     DiveMode m_diveMode = UnknownMode;

--- a/include/core/format_parsers/uddf_parser.h
+++ b/include/core/format_parsers/uddf_parser.h
@@ -42,6 +42,7 @@ private:
 
     DiveData *parseDiveElement(QXmlStreamReader &xml);
     void parseInformationBeforeDive(QXmlStreamReader &xml, DiveData *dive);
+    void parseInformationAfterDive(QXmlStreamReader &xml, DiveData *dive);
     void parseTankData(QXmlStreamReader &xml, DiveData *dive);
     void parseSamples(QXmlStreamReader &xml, DiveData *dive);
     void parseWaypoint(QXmlStreamReader &xml,

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -31,6 +31,7 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(bool showPressure READ showPressure WRITE setShowPressure NOTIFY showPressureChanged)
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
     Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
+    Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
     
     // CCR properties
     Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
@@ -66,6 +67,7 @@ public:
     bool showPressure() const { return m_showPressure; }
     bool showTime() const { return m_showTime; }
     bool showCNS() const { return m_showCNS; }
+    bool showMeanDepth() const { return m_showMeanDepth; }
 
     // CCR getters
     bool showPO2Cell1() const { return m_showPO2Cell1; }
@@ -96,6 +98,7 @@ public:
     void setShowPressure(bool show);
     void setShowTime(bool show);
     void setShowCNS(bool show);
+    void setShowMeanDepth(bool show);
 
     // CCR setters
     void setShowPO2Cell1(bool show);
@@ -173,6 +176,7 @@ signals:
     void showPressureChanged();
     void showTimeChanged();
     void showCNSChanged();
+    void showMeanDepthChanged();
 
     // CCR signals
     void showPO2Cell1Changed();
@@ -213,6 +217,7 @@ private:
     bool m_showPressure;
     bool m_showTime;
     bool m_showCNS;
+    bool m_showMeanDepth;
 
     // CCR settings
     bool m_showPO2Cell1;

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -167,6 +167,7 @@ QString CellData::cellTypeToString(CellType type)
         case CellType::PO2Cell3: return "PO2Cell3";
         case CellType::CompositePO2: return "CompositePO2";
         case CellType::CNS: return "CNS";
+        case CellType::MeanDepth: return "MeanDepth";
         default: return "Unknown";
     }
 }
@@ -184,6 +185,7 @@ CellType CellData::cellTypeFromString(const QString& str)
     if (str == "PO2Cell3") return CellType::PO2Cell3;
     if (str == "CompositePO2") return CellType::CompositePO2;
     if (str == "CNS") return CellType::CNS;
+    if (str == "MeanDepth") return CellType::MeanDepth;
     return CellType::Unknown;
 }
 

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -30,6 +30,7 @@ Config::Config(QObject *parent)
     , m_showPressure(true)
     , m_showTime(true)
     , m_showCNS(false)
+    , m_showMeanDepth(false)
     , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
     , m_showPO2Cell1(false)
@@ -220,6 +221,19 @@ void Config::setShowCNS(bool show)
     if (m_showCNS != show) {
         m_showCNS = show;
         emit showCNSChanged();
+    }
+}
+
+bool Config::showMeanDepth() const
+{
+    return m_showMeanDepth;
+}
+
+void Config::setShowMeanDepth(bool show)
+{
+    if (m_showMeanDepth != show) {
+        m_showMeanDepth = show;
+        emit showMeanDepthChanged();
     }
 }
 
@@ -556,6 +570,7 @@ void Config::loadConfig()
     m_showPressure = m_settings.value("overlay/showPressure", true).toBool();
     m_showTime = m_settings.value("overlay/showTime", true).toBool();
     m_showCNS = m_settings.value("overlay/showCNS", false).toBool();
+    m_showMeanDepth = m_settings.value("overlay/showMeanDepth", false).toBool();
 
     // Load CCR settings
     m_showPO2Cell1 = m_settings.value("overlay/showPO2Cell1", false).toBool();
@@ -703,6 +718,7 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showPressure", m_showPressure);
     m_settings.setValue("overlay/showTime", m_showTime);
     m_settings.setValue("overlay/showCNS", m_showCNS);
+    m_settings.setValue("overlay/showMeanDepth", m_showMeanDepth);
 
     // Save CCR settings
     m_settings.setValue("overlay/showPO2Cell1", m_showPO2Cell1);

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -90,6 +90,44 @@ double DiveData::maxDepth() const
     return max;
 }
 
+double DiveData::meanDepth() const
+{
+    // Prefer the value reported by the dive computer / log file
+    if (m_meanDepth >= 0.0) {
+        return m_meanDepth;
+    }
+
+    if (m_dataPoints.isEmpty()) {
+        return 0.0;
+    }
+
+    // Fall back to a time-weighted average of the depth samples (trapezoidal)
+    double weightedSum = 0.0;
+    double totalTime = 0.0;
+    for (int i = 1; i < m_dataPoints.size(); ++i) {
+        double dt = m_dataPoints[i].timestamp - m_dataPoints[i - 1].timestamp;
+        if (dt <= 0.0) {
+            continue;
+        }
+        weightedSum += dt * (m_dataPoints[i].depth + m_dataPoints[i - 1].depth) / 2.0;
+        totalTime += dt;
+    }
+
+    if (totalTime <= 0.0) {
+        return m_dataPoints.first().depth;
+    }
+
+    return weightedSum / totalTime;
+}
+
+void DiveData::setMeanDepth(double depth)
+{
+    if (m_meanDepth != depth) {
+        m_meanDepth = depth;
+        emit dataChanged();
+    }
+}
+
 double DiveData::minTemperature() const
 {
     if (m_dataPoints.isEmpty()) {

--- a/src/core/format_parsers/subsurface_parser.cpp
+++ b/src/core/format_parsers/subsurface_parser.cpp
@@ -377,6 +377,21 @@ void SubsurfaceParser::parseDiveComputerElement(QXmlStreamReader &xml, DiveData 
                 if (sampleCount % 10 == 0) {
                     qDebug() << "Parsed" << sampleCount << "samples";
                 }
+            } else if (elementName == "depth") {
+                QXmlStreamAttributes attrs = xml.attributes();
+                if (attrs.hasAttribute("mean")) {
+                    QString meanStr = attrs.value("mean").toString();
+                    QRegularExpression depthRe("(\\d+\\.?\\d*)\\s+m");
+                    QRegularExpressionMatch match = depthRe.match(meanStr);
+
+                    if (match.hasMatch()) {
+                        dive->setMeanDepth(match.captured(1).toDouble());
+                    }
+                }
+                while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("depth"))) {
+                    xml.readNext();
+                    if (xml.atEnd()) break;
+                }
             } else if (elementName == "temperature") {
                 QXmlStreamAttributes attrs = xml.attributes();
                 if (attrs.hasAttribute("water")) {

--- a/src/core/format_parsers/uddf_parser.cpp
+++ b/src/core/format_parsers/uddf_parser.cpp
@@ -339,8 +339,10 @@ DiveData *UDDFParser::parseDiveElement(QXmlStreamReader &xml)
             parseTankData(xml, dive);
         } else if (name == QStringLiteral("samples")) {
             parseSamples(xml, dive);
+        } else if (name == QStringLiteral("informationafterdive")) {
+            parseInformationAfterDive(xml, dive);
         } else {
-            // Skip everything else — informationafterdive, applieddivedurationformula, etc.
+            // Skip everything else — applieddivedurationformula, etc.
             xml.skipCurrentElement();
         }
     }
@@ -388,6 +390,30 @@ DiveData *UDDFParser::parseDiveElement(QXmlStreamReader &xml)
              << "cylinders:" << dive->cylinderCount()
              << "diveMode:" << dive->diveMode();
     return dive;
+}
+
+void UDDFParser::parseInformationAfterDive(QXmlStreamReader &xml, DiveData *dive)
+{
+    while (!xml.atEnd()) {
+        xml.readNext();
+        if (xml.tokenType() == QXmlStreamReader::EndElement
+            && xml.name() == QStringLiteral("informationafterdive")) {
+            break;
+        }
+        if (xml.tokenType() != QXmlStreamReader::StartElement) {
+            continue;
+        }
+
+        const auto name = xml.name();
+        if (name == QStringLiteral("averagedepth")) {
+            const double avg = parse_utils::parseLocaleDouble(xml.readElementText());
+            if (!std::isnan(avg) && avg >= 0.0) {
+                dive->setMeanDepth(avg);
+            }
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
 }
 
 void UDDFParser::parseInformationBeforeDive(QXmlStreamReader &xml, DiveData *dive)

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -24,6 +24,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_showPressure(true)
     , m_showTime(true)
     , m_showCNS(false)
+    , m_showMeanDepth(false)
     , m_showPO2Cell1(false)
     , m_showPO2Cell2(false)
     , m_showPO2Cell3(false)
@@ -47,6 +48,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     m_showPressure = config->showPressure();
     m_showTime = config->showTime();
     m_showCNS = config->showCNS();
+    m_showMeanDepth = config->showMeanDepth();
     m_showPO2Cell1 = config->showPO2Cell1();
     m_showPO2Cell2 = config->showPO2Cell2();
     m_showPO2Cell3 = config->showPO2Cell3();
@@ -230,6 +232,15 @@ void OverlayGenerator::setShowCNS(bool show)
         m_showCNS = show;
         // Note: Cell regeneration is handled by QML with dive data
         emit showCNSChanged();
+    }
+}
+
+void OverlayGenerator::setShowMeanDepth(bool show)
+{
+    if (m_showMeanDepth != show) {
+        m_showMeanDepth = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showMeanDepthChanged();
     }
 }
 
@@ -599,6 +610,7 @@ void OverlayGenerator::setCellTypeVisible(const QString& cellId, bool visible)
         {"ndl", Unabara::CellType::NDL},
         {"tts", Unabara::CellType::TTS},
         {"cns", Unabara::CellType::CNS},
+        {"mean_depth", Unabara::CellType::MeanDepth},
         {"po2_cell1", Unabara::CellType::PO2Cell1},
         {"po2_cell2", Unabara::CellType::PO2Cell2},
         {"po2_cell3", Unabara::CellType::PO2Cell3},
@@ -744,6 +756,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_showNDL = false;
     m_showPressure = false;
     m_showCNS = false;
+    m_showMeanDepth = false;
     m_showPO2Cell1 = false;
     m_showPO2Cell2 = false;
     m_showPO2Cell3 = false;
@@ -763,6 +776,8 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
             m_showPressure = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::CNS) {
             m_showCNS = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::MeanDepth) {
+            m_showMeanDepth = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell1) {
             m_showPO2Cell1 = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell2) {
@@ -783,6 +798,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     emit showNDLChanged();
     emit showPressureChanged();
     emit showCNSChanged();
+    emit showMeanDepthChanged();
     emit showPO2Cell1Changed();
     emit showPO2Cell2Changed();
     emit showPO2Cell3Changed();
@@ -882,6 +898,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
     if (m_showNDL) numSections++;  // NDL/TTS share the same section
     if (m_showTime) numSections++;
     if (m_showCNS) numSections++;
+    if (m_showMeanDepth) numSections++;
 
     // Tank sections (multi-tank uses grid, gets multiple sections)
     if (m_showPressure) {
@@ -1027,6 +1044,17 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         cell.setFont(m_font, false);
         cell.setTextColor(m_textColor, false);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::CNS, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    if (m_showMeanDepth) {
+        Unabara::CellData cell("mean_depth", Unabara::CellType::MeanDepth);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::MeanDepth, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
         currentSection++;
@@ -1306,6 +1334,14 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
             ? QString("%1%").arg(qRound(dataPoint.cns))
             : "---";
         return format("CNS", value);
+    }
+
+    case Unabara::CellType::MeanDepth: {
+        // Static per-dive value (reported by the dive computer or computed from samples)
+        QString value = dive
+            ? Units::formatDepthValue(dive->meanDepth(), unitSystem)
+            : "---";
+        return format("AVG", value);
     }
 
     default:
@@ -1654,6 +1690,10 @@ QSizeF OverlayGenerator::calculateCellSize(Unabara::CellType cellType, const QFo
             case Unabara::CellType::CNS:
                 header = tr("CNS");
                 value = "99%";           // Typical CNS toxicity percentage
+                break;
+            case Unabara::CellType::MeanDepth:
+                header = tr("AVG");
+                value = "99.9 m";        // Typical mean depth
                 break;
             default:
                 header = "UNKNOWN";

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -390,6 +390,14 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         return format("CNS", value);
     }
 
+    case Unabara::CellType::MeanDepth: {
+        // Static per-dive value (reported by the dive computer or computed from samples)
+        QString value = m_dive
+            ? Units::formatDepthValue(m_dive->meanDepth(), unitSystem)
+            : "---";
+        return format("AVG", value);
+    }
+
     default:
         return "Unknown";
     }

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -320,6 +320,10 @@ Item {
                     root.generator.setCellTypeVisible("cns", root.generator.showCNS)
                     previewContainer.updateCellModel()
                 }
+                function onShowMeanDepthChanged() {
+                    root.generator.setCellTypeVisible("mean_depth", root.generator.showMeanDepth)
+                    previewContainer.updateCellModel()
+                }
                 function onShowPO2Cell1Changed() {
                     root.generator.setCellTypeVisible("po2_cell1", root.generator.showPO2Cell1)
                     previewContainer.updateCellModel()
@@ -805,6 +809,17 @@ Item {
                     onCheckedChanged: {
                         if (generator && generator.showCNS !== checked) {
                             generator.showCNS = checked
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: showMeanDepthCheckbox
+                    text: qsTr("Show Mean Depth")
+                    checked: generator ? generator.showMeanDepth : false
+                    onCheckedChanged: {
+                        if (generator && generator.showMeanDepth !== checked) {
+                            generator.showMeanDepth = checked
                         }
                     }
                 }

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -10,7 +10,7 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). |
+| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). |
 | `CCR_Halcyon_Benoit_cleaned.ssrf` | CCR dive — sensor1/2/3 still populate. |
 | `test_multidive.ssrf` | Multiple dives — picker shows them all; opening any one renders correctly. |
 | `OC_ScubaproG2_Benoit.ssrf` | Open-circuit, multi-tank pressures present. `diveMode` resolves to `OpenCircuit`. |
@@ -19,8 +19,8 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2026-02-28-Monastery_Beach.uddf` | Same dive as the SSRF version above (CCR, dive #143). ~40.5 m max depth; 3 cylinders with begin/end pressure (Pa→bar conversion correct). Per-sample tank pressure / `<measuredpo2>` absent — Subsurface UDDF export limitation; cells just stay blank. Comma-decimal `<depth>` values (e.g. `2,1`) parse as 2.1. |
-| `Shearwater.uddf` | Loads; depth/temperature populated; comma decimals parsed. CNS appears late in the dive (`<cns>` elements near the end): 65% → 70% at the last sample, `---` before the first report. |
+| `2026-02-28-Monastery_Beach.uddf` | Same dive as the SSRF version above (CCR, dive #143). ~40.5 m max depth; 3 cylinders with begin/end pressure (Pa→bar conversion correct). Per-sample tank pressure / `<measuredpo2>` absent — Subsurface UDDF export limitation; cells just stay blank. Comma-decimal `<depth>` values (e.g. `2,1`) parse as 2.1. Mean depth (AVG cell) shows 19.8 m (from `<averagedepth>19.832`). |
+| `Shearwater.uddf` | Loads; depth/temperature populated; comma decimals parsed. CNS appears late in the dive (`<cns>` elements near the end): 65% → 70% at the last sample, `---` before the first report. Mean depth (AVG cell) shows 22.5 m (from `<averagedepth>22.465`). |
 | `Garmin.uddf` | Loads from a different exporter; verifies UDDF dialect handling. |
 
 ## Format detection
@@ -43,5 +43,6 @@ Run this before merging any change to the dive log parser. Each row below is a s
 | Per-sample tank pressure | bar | Pa → bar (via `<tankpressure>` when exporter provides it) |
 | Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) |
 | Per-sample CNS | `cns='NN%'` attribute | `<cns>` percent element (65.0 = 65 %) |
+| Mean depth (static, AVG cell) | `<depth mean>` in `<divecomputer>` | `<averagedepth>` in `<informationafterdive>` (fallback: time-weighted average of samples) |
 | Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index |
 | Dive mode | inferred from CCR cues | `<divemode kind>` or inferred |


### PR DESCRIPTION
Adds an AVG cell showing the dive's mean depth, a static per-dive value
reported by the dive computer:

- SSRF: parse the previously ignored <depth mean='...'/> element inside
  <divecomputer>
- UDDF: parse <averagedepth> from the previously skipped
  <informationafterdive> block (locale-aware, handles comma decimals)
- DiveData: new meanDepth property; falls back to a time-weighted
  average of the depth samples when the log has no reported value
- New CellType::MeanDepth wired through template save/load, Config
  persistence (overlay/showMeanDepth), default cell layout, both render
  paths (C++ generator and QML cell model), and a "Show Mean Depth"
  checkbox in the overlay editor
- Document expected values in tests/SMOKE_TEST.md

Fixes #45