### PR TITLE
feat: Add max depth as a new overlay data point.

### DIFF
--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -26,6 +26,7 @@ enum class CellType {
     CompositePO2,     // CCR composite PO2
     CNS,              // CNS oxygen toxicity (percent)
     MeanDepth,        // Average depth of the dive (static, reported by the dive computer)
+    MaxDepth,         // Maximum depth reached so far (running max, like the DC's MAX field)
     Unknown
 };
 

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -33,6 +33,7 @@ class Config : public QObject
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
     Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
     Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
+    Q_PROPERTY(bool showMaxDepth READ showMaxDepth WRITE setShowMaxDepth NOTIFY showMaxDepthChanged)
     Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
     // CCR settings
@@ -113,6 +114,8 @@ public:
     void setShowCNS(bool show);
     bool showMeanDepth() const;
     void setShowMeanDepth(bool show);
+    bool showMaxDepth() const;
+    void setShowMaxDepth(bool show);
 
     Units::UnitSystem unitSystem() const;
     void setUnitSystem(Units::UnitSystem system);
@@ -232,6 +235,7 @@ signals:
     void showTimeChanged();
     void showCNSChanged();
     void showMeanDepthChanged();
+    void showMaxDepthChanged();
     void unitSystemChanged();
     void frameRateChanged();
     void templateDirectoryChanged();
@@ -292,6 +296,7 @@ private:
     bool m_showTime;
     bool m_showCNS;
     bool m_showMeanDepth;
+    bool m_showMaxDepth;
     Units::UnitSystem m_unitSystem;
     double m_frameRate;
     QString m_templateDirectory;

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -124,6 +124,7 @@ public:
     QDateTime startTime() const { return m_startTime; }
     int durationSeconds() const;
     double maxDepth() const;
+    Q_INVOKABLE double maxDepthUntil(double time) const;
     double meanDepth() const;
     double minTemperature() const;
     QString location() const { return m_location; }

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -32,7 +32,8 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(bool showTime READ showTime WRITE setShowTime NOTIFY showTimeChanged)
     Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
     Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
-    
+    Q_PROPERTY(bool showMaxDepth READ showMaxDepth WRITE setShowMaxDepth NOTIFY showMaxDepthChanged)
+
     // CCR properties
     Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
     Q_PROPERTY(bool showPO2Cell2 READ showPO2Cell2 WRITE setShowPO2Cell2 NOTIFY showPO2Cell2Changed)
@@ -68,6 +69,7 @@ public:
     bool showTime() const { return m_showTime; }
     bool showCNS() const { return m_showCNS; }
     bool showMeanDepth() const { return m_showMeanDepth; }
+    bool showMaxDepth() const { return m_showMaxDepth; }
 
     // CCR getters
     bool showPO2Cell1() const { return m_showPO2Cell1; }
@@ -99,6 +101,7 @@ public:
     void setShowTime(bool show);
     void setShowCNS(bool show);
     void setShowMeanDepth(bool show);
+    void setShowMaxDepth(bool show);
 
     // CCR setters
     void setShowPO2Cell1(bool show);
@@ -177,6 +180,7 @@ signals:
     void showTimeChanged();
     void showCNSChanged();
     void showMeanDepthChanged();
+    void showMaxDepthChanged();
 
     // CCR signals
     void showPO2Cell1Changed();
@@ -218,6 +222,7 @@ private:
     bool m_showTime;
     bool m_showCNS;
     bool m_showMeanDepth;
+    bool m_showMaxDepth;
 
     // CCR settings
     bool m_showPO2Cell1;

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -168,6 +168,7 @@ QString CellData::cellTypeToString(CellType type)
         case CellType::CompositePO2: return "CompositePO2";
         case CellType::CNS: return "CNS";
         case CellType::MeanDepth: return "MeanDepth";
+        case CellType::MaxDepth: return "MaxDepth";
         default: return "Unknown";
     }
 }
@@ -186,6 +187,7 @@ CellType CellData::cellTypeFromString(const QString& str)
     if (str == "CompositePO2") return CellType::CompositePO2;
     if (str == "CNS") return CellType::CNS;
     if (str == "MeanDepth") return CellType::MeanDepth;
+    if (str == "MaxDepth") return CellType::MaxDepth;
     return CellType::Unknown;
 }
 

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -31,6 +31,7 @@ Config::Config(QObject *parent)
     , m_showTime(true)
     , m_showCNS(false)
     , m_showMeanDepth(false)
+    , m_showMaxDepth(false)
     , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
     , m_showPO2Cell1(false)
@@ -234,6 +235,19 @@ void Config::setShowMeanDepth(bool show)
     if (m_showMeanDepth != show) {
         m_showMeanDepth = show;
         emit showMeanDepthChanged();
+    }
+}
+
+bool Config::showMaxDepth() const
+{
+    return m_showMaxDepth;
+}
+
+void Config::setShowMaxDepth(bool show)
+{
+    if (m_showMaxDepth != show) {
+        m_showMaxDepth = show;
+        emit showMaxDepthChanged();
     }
 }
 
@@ -571,6 +585,7 @@ void Config::loadConfig()
     m_showTime = m_settings.value("overlay/showTime", true).toBool();
     m_showCNS = m_settings.value("overlay/showCNS", false).toBool();
     m_showMeanDepth = m_settings.value("overlay/showMeanDepth", false).toBool();
+    m_showMaxDepth = m_settings.value("overlay/showMaxDepth", false).toBool();
 
     // Load CCR settings
     m_showPO2Cell1 = m_settings.value("overlay/showPO2Cell1", false).toBool();
@@ -719,6 +734,7 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showTime", m_showTime);
     m_settings.setValue("overlay/showCNS", m_showCNS);
     m_settings.setValue("overlay/showMeanDepth", m_showMeanDepth);
+    m_settings.setValue("overlay/showMaxDepth", m_showMaxDepth);
 
     // Save CCR settings
     m_settings.setValue("overlay/showPO2Cell1", m_showPO2Cell1);

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -90,6 +90,37 @@ double DiveData::maxDepth() const
     return max;
 }
 
+double DiveData::maxDepthUntil(double time) const
+{
+    // Running maximum: the deepest point reached up to 'time', like the MAX
+    // field on a dive computer display during the dive.
+    double max = 0.0;
+    for (int i = 0; i < m_dataPoints.size(); ++i) {
+        const DiveDataPoint &point = m_dataPoints[i];
+        if (point.timestamp > time) {
+            // 'time' falls inside the previous segment — include the
+            // interpolated depth so a descent between samples still registers
+            if (i > 0) {
+                const DiveDataPoint &prev = m_dataPoints[i - 1];
+                double dt = point.timestamp - prev.timestamp;
+                if (dt > 0.0 && time > prev.timestamp) {
+                    double factor = (time - prev.timestamp) / dt;
+                    double depth = prev.depth + factor * (point.depth - prev.depth);
+                    if (depth > max) {
+                        max = depth;
+                    }
+                }
+            }
+            break;
+        }
+        if (point.depth > max) {
+            max = point.depth;
+        }
+    }
+
+    return max;
+}
+
 double DiveData::meanDepth() const
 {
     // Prefer the value reported by the dive computer / log file

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -25,6 +25,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_showTime(true)
     , m_showCNS(false)
     , m_showMeanDepth(false)
+    , m_showMaxDepth(false)
     , m_showPO2Cell1(false)
     , m_showPO2Cell2(false)
     , m_showPO2Cell3(false)
@@ -49,6 +50,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     m_showTime = config->showTime();
     m_showCNS = config->showCNS();
     m_showMeanDepth = config->showMeanDepth();
+    m_showMaxDepth = config->showMaxDepth();
     m_showPO2Cell1 = config->showPO2Cell1();
     m_showPO2Cell2 = config->showPO2Cell2();
     m_showPO2Cell3 = config->showPO2Cell3();
@@ -241,6 +243,15 @@ void OverlayGenerator::setShowMeanDepth(bool show)
         m_showMeanDepth = show;
         // Note: Cell regeneration is handled by QML with dive data
         emit showMeanDepthChanged();
+    }
+}
+
+void OverlayGenerator::setShowMaxDepth(bool show)
+{
+    if (m_showMaxDepth != show) {
+        m_showMaxDepth = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showMaxDepthChanged();
     }
 }
 
@@ -611,6 +622,7 @@ void OverlayGenerator::setCellTypeVisible(const QString& cellId, bool visible)
         {"tts", Unabara::CellType::TTS},
         {"cns", Unabara::CellType::CNS},
         {"mean_depth", Unabara::CellType::MeanDepth},
+        {"max_depth", Unabara::CellType::MaxDepth},
         {"po2_cell1", Unabara::CellType::PO2Cell1},
         {"po2_cell2", Unabara::CellType::PO2Cell2},
         {"po2_cell3", Unabara::CellType::PO2Cell3},
@@ -757,6 +769,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_showPressure = false;
     m_showCNS = false;
     m_showMeanDepth = false;
+    m_showMaxDepth = false;
     m_showPO2Cell1 = false;
     m_showPO2Cell2 = false;
     m_showPO2Cell3 = false;
@@ -778,6 +791,8 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
             m_showCNS = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::MeanDepth) {
             m_showMeanDepth = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::MaxDepth) {
+            m_showMaxDepth = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell1) {
             m_showPO2Cell1 = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell2) {
@@ -799,6 +814,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     emit showPressureChanged();
     emit showCNSChanged();
     emit showMeanDepthChanged();
+    emit showMaxDepthChanged();
     emit showPO2Cell1Changed();
     emit showPO2Cell2Changed();
     emit showPO2Cell3Changed();
@@ -899,6 +915,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
     if (m_showTime) numSections++;
     if (m_showCNS) numSections++;
     if (m_showMeanDepth) numSections++;
+    if (m_showMaxDepth) numSections++;
 
     // Tank sections (multi-tank uses grid, gets multiple sections)
     if (m_showPressure) {
@@ -1055,6 +1072,17 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         cell.setFont(m_font, false);
         cell.setTextColor(m_textColor, false);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::MeanDepth, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    if (m_showMaxDepth) {
+        Unabara::CellData cell("max_depth", Unabara::CellType::MaxDepth);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::MaxDepth, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
         currentSection++;
@@ -1342,6 +1370,14 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
             ? Units::formatDepthValue(dive->meanDepth(), unitSystem)
             : "---";
         return format("AVG", value);
+    }
+
+    case Unabara::CellType::MaxDepth: {
+        // Running max: deepest point reached up to the current time
+        QString value = dive
+            ? Units::formatDepthValue(dive->maxDepthUntil(dataPoint.timestamp), unitSystem)
+            : "---";
+        return format("MAX", value);
     }
 
     default:
@@ -1694,6 +1730,10 @@ QSizeF OverlayGenerator::calculateCellSize(Unabara::CellType cellType, const QFo
             case Unabara::CellType::MeanDepth:
                 header = tr("AVG");
                 value = "99.9 m";        // Typical mean depth
+                break;
+            case Unabara::CellType::MaxDepth:
+                header = tr("MAX");
+                value = "99.9 m";        // Typical max depth
                 break;
             default:
                 header = "UNKNOWN";

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -398,6 +398,14 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         return format("AVG", value);
     }
 
+    case Unabara::CellType::MaxDepth: {
+        // Running max: deepest point reached up to the current time
+        QString value = m_dive
+            ? Units::formatDepthValue(m_dive->maxDepthUntil(dataPoint.timestamp), unitSystem)
+            : "---";
+        return format("MAX", value);
+    }
+
     default:
         return "Unknown";
     }

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -324,6 +324,10 @@ Item {
                     root.generator.setCellTypeVisible("mean_depth", root.generator.showMeanDepth)
                     previewContainer.updateCellModel()
                 }
+                function onShowMaxDepthChanged() {
+                    root.generator.setCellTypeVisible("max_depth", root.generator.showMaxDepth)
+                    previewContainer.updateCellModel()
+                }
                 function onShowPO2Cell1Changed() {
                     root.generator.setCellTypeVisible("po2_cell1", root.generator.showPO2Cell1)
                     previewContainer.updateCellModel()
@@ -820,6 +824,17 @@ Item {
                     onCheckedChanged: {
                         if (generator && generator.showMeanDepth !== checked) {
                             generator.showMeanDepth = checked
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: showMaxDepthCheckbox
+                    text: qsTr("Show Max Depth")
+                    checked: generator ? generator.showMaxDepth : false
+                    onCheckedChanged: {
+                        if (generator && generator.showMaxDepth !== checked) {
+                            generator.showMaxDepth = checked
                         }
                     }
                 }

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -10,7 +10,7 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). |
+| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). Max depth (MAX cell) is a running max: 9.6 m at 12:35 (current depth 8.7 m), pinned at 40.6 m from the deepest point to the end. |
 | `CCR_Halcyon_Benoit_cleaned.ssrf` | CCR dive — sensor1/2/3 still populate. |
 | `test_multidive.ssrf` | Multiple dives — picker shows them all; opening any one renders correctly. |
 | `OC_ScubaproG2_Benoit.ssrf` | Open-circuit, multi-tank pressures present. `diveMode` resolves to `OpenCircuit`. |
@@ -44,5 +44,6 @@ Run this before merging any change to the dive log parser. Each row below is a s
 | Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) |
 | Per-sample CNS | `cns='NN%'` attribute | `<cns>` percent element (65.0 = 65 %) |
 | Mean depth (static, AVG cell) | `<depth mean>` in `<divecomputer>` | `<averagedepth>` in `<informationafterdive>` (fallback: time-weighted average of samples) |
+| Max depth (running, MAX cell) | computed from samples (no parsing) — deepest point reached up to the current time | same |
 | Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index |
 | Dive mode | inferred from CCR cues | `<divemode kind>` or inferred |


### PR DESCRIPTION
Adds a MAX cell showing the maximum depth reached so far at the
current dive time, computed as a running max over the depth samples
(with interpolation on the boundary segment). This matches what the
dive computer's MAX field displays during the dive, rather than
spoiling the dive's final max depth from the start of the video.

No parser changes needed: the running max converges to the logged
value at the end of the dive, so the static SSRF/UDDF tags would be
redundant with the samples.

Fixes #44