### PR TITLE
feat: Add current breathing gas as a new overlay data point.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Unabara is a powerful tool for creating telemetry overlays for scuba diving vide
 - **Visual Timeline**: View and navigate your dive data on an interactive timeline.
 - **Video Import**: Import your dive footage and position it against your dive data on the timeline.
 - **Video Preview & Sync**: Play your footage directly in Unabara and align it with your dive graphically — the timeline cursor follows the video, so you can match the overlay to your dive computer frame by frame. Save per-camera sync profiles for repeatable alignment.
-- **Customizable Overlay**: Configure which telemetry data appears in your overlay (depth, temperature, NDL, tank pressure, dive time, and CCR PO₂ cells), with optional per-cell or global labels.
+- **Customizable Overlay**: Configure which telemetry data appears in your overlay (depth, temperature, NDL, tank pressure, dive time, breathing gas, CNS, max/average depth, and CCR PO₂ cells), with optional per-cell or global labels.
 - **Dive Profile Graph**: Generate a customizable depth-over-time dive profile that can be composited as its own overlay.
 - **Template Selection**: Choose from built-in overlay templates or import your own designs.
 - **Undo/Redo**: Full edit history in the template editor — step back and forward through your changes (Ctrl+Z / Ctrl+Y).
@@ -174,7 +174,7 @@ For direct video export functionality, FFmpeg needs to be installed on your syst
 ## Usage
 
 1. Launch Unabara
-2. Import a dive log file (Subsurface XML/SSRF format)
+2. Import a dive log file (Subsurface XML/SSRF or UDDF format)
 3. Optionally import your dive video footage
 4. Adjust the positioning and video sync timing using the timeline
 5. Configure the overlay display options in settings

--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -27,6 +27,7 @@ enum class CellType {
     CNS,              // CNS oxygen toxicity (percent)
     MeanDepth,        // Average depth of the dive (static, reported by the dive computer)
     MaxDepth,         // Maximum depth reached so far (running max, like the DC's MAX field)
+    Gas,              // Currently breathed gas mix (from gas switches)
     Unknown
 };
 

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -34,6 +34,7 @@ class Config : public QObject
     Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
     Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
     Q_PROPERTY(bool showMaxDepth READ showMaxDepth WRITE setShowMaxDepth NOTIFY showMaxDepthChanged)
+    Q_PROPERTY(bool showGas READ showGas WRITE setShowGas NOTIFY showGasChanged)
     Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
     // CCR settings
@@ -116,6 +117,8 @@ public:
     void setShowMeanDepth(bool show);
     bool showMaxDepth() const;
     void setShowMaxDepth(bool show);
+    bool showGas() const;
+    void setShowGas(bool show);
 
     Units::UnitSystem unitSystem() const;
     void setUnitSystem(Units::UnitSystem system);
@@ -236,6 +239,7 @@ signals:
     void showCNSChanged();
     void showMeanDepthChanged();
     void showMaxDepthChanged();
+    void showGasChanged();
     void unitSystemChanged();
     void frameRateChanged();
     void templateDirectoryChanged();
@@ -297,6 +301,7 @@ private:
     bool m_showCNS;
     bool m_showMeanDepth;
     bool m_showMaxDepth;
+    bool m_showGas;
     Units::UnitSystem m_unitSystem;
     double m_frameRate;
     QString m_templateDirectory;

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -88,7 +88,7 @@ struct CylinderInfo {
 };
 
 struct GasSwitch {
-    double timestamp;  // Time in minutes when switch occurred
+    double timestamp;  // Time in seconds when switch occurred
     int cylinderIndex; // Which cylinder was switched to
 };
 
@@ -149,6 +149,7 @@ public:
     const CylinderInfo& cylinderInfo(int index) const;
     QVector<CylinderInfo> cylinders() const { return m_cylinders; }
     bool isCylinderActiveAtTime(int cylinderIndex, double timestamp) const;
+    Q_INVOKABLE int activeCylinderAtTime(double timestamp) const;
     double interpolateCylinderPressure(int cylinderIndex, double timestamp) const;
     double getLastInterpolatedPressure(int cylinderIndex) const;
 

--- a/include/core/units.h
+++ b/include/core/units.h
@@ -43,6 +43,9 @@ public:
     static QString formatDepthValue(double depthMeters, UnitSystem system);
     static QString formatTemperatureValue(double tempCelsius, UnitSystem system);
     static QString formatPressureValue(double pressureBar, UnitSystem system);
+
+    // Gas mix name (unit-agnostic): "Air", "EAN32", "21/35", "O2"
+    static QString formatGasMix(double o2Percent, double hePercent);
 };
 
 #endif // UNITS_H

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -33,6 +33,7 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(bool showCNS READ showCNS WRITE setShowCNS NOTIFY showCNSChanged)
     Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
     Q_PROPERTY(bool showMaxDepth READ showMaxDepth WRITE setShowMaxDepth NOTIFY showMaxDepthChanged)
+    Q_PROPERTY(bool showGas READ showGas WRITE setShowGas NOTIFY showGasChanged)
 
     // CCR properties
     Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
@@ -70,6 +71,7 @@ public:
     bool showCNS() const { return m_showCNS; }
     bool showMeanDepth() const { return m_showMeanDepth; }
     bool showMaxDepth() const { return m_showMaxDepth; }
+    bool showGas() const { return m_showGas; }
 
     // CCR getters
     bool showPO2Cell1() const { return m_showPO2Cell1; }
@@ -102,6 +104,7 @@ public:
     void setShowCNS(bool show);
     void setShowMeanDepth(bool show);
     void setShowMaxDepth(bool show);
+    void setShowGas(bool show);
 
     // CCR setters
     void setShowPO2Cell1(bool show);
@@ -181,6 +184,7 @@ signals:
     void showCNSChanged();
     void showMeanDepthChanged();
     void showMaxDepthChanged();
+    void showGasChanged();
 
     // CCR signals
     void showPO2Cell1Changed();
@@ -223,6 +227,7 @@ private:
     bool m_showCNS;
     bool m_showMeanDepth;
     bool m_showMaxDepth;
+    bool m_showGas;
 
     // CCR settings
     bool m_showPO2Cell1;

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -169,6 +169,7 @@ QString CellData::cellTypeToString(CellType type)
         case CellType::CNS: return "CNS";
         case CellType::MeanDepth: return "MeanDepth";
         case CellType::MaxDepth: return "MaxDepth";
+        case CellType::Gas: return "Gas";
         default: return "Unknown";
     }
 }
@@ -188,6 +189,7 @@ CellType CellData::cellTypeFromString(const QString& str)
     if (str == "CNS") return CellType::CNS;
     if (str == "MeanDepth") return CellType::MeanDepth;
     if (str == "MaxDepth") return CellType::MaxDepth;
+    if (str == "Gas") return CellType::Gas;
     return CellType::Unknown;
 }
 

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -32,6 +32,7 @@ Config::Config(QObject *parent)
     , m_showCNS(false)
     , m_showMeanDepth(false)
     , m_showMaxDepth(false)
+    , m_showGas(false)
     , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
     , m_showPO2Cell1(false)
@@ -248,6 +249,19 @@ void Config::setShowMaxDepth(bool show)
     if (m_showMaxDepth != show) {
         m_showMaxDepth = show;
         emit showMaxDepthChanged();
+    }
+}
+
+bool Config::showGas() const
+{
+    return m_showGas;
+}
+
+void Config::setShowGas(bool show)
+{
+    if (m_showGas != show) {
+        m_showGas = show;
+        emit showGasChanged();
     }
 }
 
@@ -586,6 +600,7 @@ void Config::loadConfig()
     m_showCNS = m_settings.value("overlay/showCNS", false).toBool();
     m_showMeanDepth = m_settings.value("overlay/showMeanDepth", false).toBool();
     m_showMaxDepth = m_settings.value("overlay/showMaxDepth", false).toBool();
+    m_showGas = m_settings.value("overlay/showGas", false).toBool();
 
     // Load CCR settings
     m_showPO2Cell1 = m_settings.value("overlay/showPO2Cell1", false).toBool();
@@ -735,6 +750,7 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showCNS", m_showCNS);
     m_settings.setValue("overlay/showMeanDepth", m_showMeanDepth);
     m_settings.setValue("overlay/showMaxDepth", m_showMaxDepth);
+    m_settings.setValue("overlay/showGas", m_showGas);
 
     // Save CCR settings
     m_settings.setValue("overlay/showPO2Cell1", m_showPO2Cell1);

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -436,19 +436,11 @@ void DiveData::addGasSwitch(double timestamp, int cylinderIndex) {
               });
 }
 
-bool DiveData::isCylinderActiveAtTime(int cylinderIndex, double timestamp) const {
-    if (cylinderIndex < 0 || cylinderIndex >= m_cylinders.size()) {
-        return false;  // Invalid cylinder index
-    }
-    
-    // If we have no gas switches, assume first cylinder is always active
-    if (m_gasSwitches.isEmpty()) {
-        return cylinderIndex == 0;
-    }
-    
-    // Find the active cylinder at this timestamp
+int DiveData::activeCylinderAtTime(double timestamp) const {
+    // First cylinder is breathed from the start; each gas switch at or
+    // before 'timestamp' updates the active cylinder
     int activeCylinder = 0; // Default to first cylinder
-    
+
     for (const GasSwitch &gasSwitch : m_gasSwitches) {
         if (gasSwitch.timestamp <= timestamp) {
             activeCylinder = gasSwitch.cylinderIndex;
@@ -458,8 +450,16 @@ bool DiveData::isCylinderActiveAtTime(int cylinderIndex, double timestamp) const
             break;
         }
     }
-    
-    return (cylinderIndex == activeCylinder);
+
+    return activeCylinder;
+}
+
+bool DiveData::isCylinderActiveAtTime(int cylinderIndex, double timestamp) const {
+    if (cylinderIndex < 0 || cylinderIndex >= m_cylinders.size()) {
+        return false;  // Invalid cylinder index
+    }
+
+    return cylinderIndex == activeCylinderAtTime(timestamp);
 }
 
 double DiveData::interpolateCylinderPressure(int cylinderIndex, double timestamp) const

--- a/src/core/units.cpp
+++ b/src/core/units.cpp
@@ -95,3 +95,21 @@ QString Units::formatPressureValue(double pressureBar, UnitSystem system)
 {
     return formatPressure(pressureBar, system) + " " + pressureUnit(system);
 }
+
+QString Units::formatGasMix(double o2Percent, double hePercent)
+{
+    // Round before comparing so 20.9/21.0 float noise still reads as Air
+    int o2 = qRound(o2Percent);
+    int he = qRound(hePercent);
+
+    if (he > 0) {
+        return QString("%1/%2").arg(o2).arg(he); // Trimix, Subsurface style
+    }
+    if (o2 == 100) {
+        return QStringLiteral("O2");
+    }
+    if (o2 == 21) {
+        return QStringLiteral("Air");
+    }
+    return QString("EAN%1").arg(o2);
+}

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -26,6 +26,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_showCNS(false)
     , m_showMeanDepth(false)
     , m_showMaxDepth(false)
+    , m_showGas(false)
     , m_showPO2Cell1(false)
     , m_showPO2Cell2(false)
     , m_showPO2Cell3(false)
@@ -51,6 +52,7 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     m_showCNS = config->showCNS();
     m_showMeanDepth = config->showMeanDepth();
     m_showMaxDepth = config->showMaxDepth();
+    m_showGas = config->showGas();
     m_showPO2Cell1 = config->showPO2Cell1();
     m_showPO2Cell2 = config->showPO2Cell2();
     m_showPO2Cell3 = config->showPO2Cell3();
@@ -252,6 +254,15 @@ void OverlayGenerator::setShowMaxDepth(bool show)
         m_showMaxDepth = show;
         // Note: Cell regeneration is handled by QML with dive data
         emit showMaxDepthChanged();
+    }
+}
+
+void OverlayGenerator::setShowGas(bool show)
+{
+    if (m_showGas != show) {
+        m_showGas = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showGasChanged();
     }
 }
 
@@ -623,6 +634,7 @@ void OverlayGenerator::setCellTypeVisible(const QString& cellId, bool visible)
         {"cns", Unabara::CellType::CNS},
         {"mean_depth", Unabara::CellType::MeanDepth},
         {"max_depth", Unabara::CellType::MaxDepth},
+        {"gas", Unabara::CellType::Gas},
         {"po2_cell1", Unabara::CellType::PO2Cell1},
         {"po2_cell2", Unabara::CellType::PO2Cell2},
         {"po2_cell3", Unabara::CellType::PO2Cell3},
@@ -770,6 +782,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_showCNS = false;
     m_showMeanDepth = false;
     m_showMaxDepth = false;
+    m_showGas = false;
     m_showPO2Cell1 = false;
     m_showPO2Cell2 = false;
     m_showPO2Cell3 = false;
@@ -793,6 +806,8 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
             m_showMeanDepth = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::MaxDepth) {
             m_showMaxDepth = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::Gas) {
+            m_showGas = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell1) {
             m_showPO2Cell1 = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell2) {
@@ -815,6 +830,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     emit showCNSChanged();
     emit showMeanDepthChanged();
     emit showMaxDepthChanged();
+    emit showGasChanged();
     emit showPO2Cell1Changed();
     emit showPO2Cell2Changed();
     emit showPO2Cell3Changed();
@@ -916,6 +932,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
     if (m_showCNS) numSections++;
     if (m_showMeanDepth) numSections++;
     if (m_showMaxDepth) numSections++;
+    if (m_showGas) numSections++;
 
     // Tank sections (multi-tank uses grid, gets multiple sections)
     if (m_showPressure) {
@@ -1083,6 +1100,17 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         cell.setFont(m_font, false);
         cell.setTextColor(m_textColor, false);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::MaxDepth, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    if (m_showGas) {
+        Unabara::CellData cell("gas", Unabara::CellType::Gas);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Gas, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
         currentSection++;
@@ -1378,6 +1406,19 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
             ? Units::formatDepthValue(dive->maxDepthUntil(dataPoint.timestamp), unitSystem)
             : "---";
         return format("MAX", value);
+    }
+
+    case Unabara::CellType::Gas: {
+        // Gas mix currently breathed: active cylinder per gas-switch events
+        QString value = "---";
+        if (dive && dive->cylinderCount() > 0) {
+            int idx = dive->activeCylinderAtTime(dataPoint.timestamp);
+            if (idx >= 0 && idx < dive->cylinderCount()) {
+                const CylinderInfo& cyl = dive->cylinderInfo(idx);
+                value = Units::formatGasMix(cyl.o2Percent, cyl.hePercent);
+            }
+        }
+        return format("GAS", value);
     }
 
     default:
@@ -1734,6 +1775,10 @@ QSizeF OverlayGenerator::calculateCellSize(Unabara::CellType cellType, const QFo
             case Unabara::CellType::MaxDepth:
                 header = tr("MAX");
                 value = "99.9 m";        // Typical max depth
+                break;
+            case Unabara::CellType::Gas:
+                header = tr("GAS");
+                value = "EAN32";         // Widest plausible mix string
                 break;
             default:
                 header = "UNKNOWN";

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -406,6 +406,19 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
         return format("MAX", value);
     }
 
+    case Unabara::CellType::Gas: {
+        // Gas mix currently breathed: active cylinder per gas-switch events
+        QString value = "---";
+        if (m_dive && m_dive->cylinderCount() > 0) {
+            int idx = m_dive->activeCylinderAtTime(dataPoint.timestamp);
+            if (idx >= 0 && idx < m_dive->cylinderCount()) {
+                const CylinderInfo& cyl = m_dive->cylinderInfo(idx);
+                value = Units::formatGasMix(cyl.o2Percent, cyl.hePercent);
+            }
+        }
+        return format("GAS", value);
+    }
+
     default:
         return "Unknown";
     }

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -328,6 +328,10 @@ Item {
                     root.generator.setCellTypeVisible("max_depth", root.generator.showMaxDepth)
                     previewContainer.updateCellModel()
                 }
+                function onShowGasChanged() {
+                    root.generator.setCellTypeVisible("gas", root.generator.showGas)
+                    previewContainer.updateCellModel()
+                }
                 function onShowPO2Cell1Changed() {
                     root.generator.setCellTypeVisible("po2_cell1", root.generator.showPO2Cell1)
                     previewContainer.updateCellModel()
@@ -835,6 +839,17 @@ Item {
                     onCheckedChanged: {
                         if (generator && generator.showMaxDepth !== checked) {
                             generator.showMaxDepth = checked
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: showGasCheckbox
+                    text: qsTr("Show Gas Mix")
+                    checked: generator ? generator.showGas : false
+                    onCheckedChanged: {
+                        if (generator && generator.showGas !== checked) {
+                            generator.showGas = checked
                         }
                     }
                 }

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -10,7 +10,8 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). Max depth (MAX cell) is a running max: 9.6 m at 12:35 (current depth 8.7 m), pinned at 40.6 m from the deepest point to the end. |
+| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). Max depth (MAX cell) is a running max: 9.6 m at 12:35 (current depth 8.7 m), pinned at 40.6 m from the deepest point to the end. Gas (GAS cell): `EAN29` for the whole dive — the switch to the diluent cylinder at 0:10 coincides with the first sample, so the O2 cylinder (0) is never the active gas at any sample. |
+| `Galileo_G2-TEK_SM_DecoO2-cleaned.ssrf` | Sidemount OC with deco O2. Gas (GAS cell): `Air` from the start — the 0↔1 sidemount switches at 9:41/14:49/27:37 don't change the displayed mix (both cylinders are air) — then `EAN99` from 37:17, `Air` at 48:01, `EAN99` from 50:05 to the end. |
 | `CCR_Halcyon_Benoit_cleaned.ssrf` | CCR dive — sensor1/2/3 still populate. |
 | `test_multidive.ssrf` | Multiple dives — picker shows them all; opening any one renders correctly. |
 | `OC_ScubaproG2_Benoit.ssrf` | Open-circuit, multi-tank pressures present. `diveMode` resolves to `OpenCircuit`. |
@@ -46,4 +47,5 @@ Run this before merging any change to the dive log parser. Each row below is a s
 | Mean depth (static, AVG cell) | `<depth mean>` in `<divecomputer>` | `<averagedepth>` in `<informationafterdive>` (fallback: time-weighted average of samples) |
 | Max depth (running, MAX cell) | computed from samples (no parsing) — deepest point reached up to the current time | same |
 | Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index |
+| Gas mix (GAS cell) | computed from gas switches + cylinder O2/He (`Air`/`EANxx`/`O2`/`21/35`) | same |
 | Dive mode | inferred from CCR cues | `<divemode kind>` or inferred |


### PR DESCRIPTION
Adds a GAS cell showing the gas mix being breathed at the current dive time, derived from the already-parsed gas switches (SSRF gaschange / UDDF switchmix) and the active cylinder's O2/He fractions.

- DiveData::activeCylinderAtTime(): public accessor extracted from the
  switch-walk in isCylinderActiveAtTime(), which now delegates to it.
  Also fix the GasSwitch comment (timestamp is seconds, not minutes).
- Units::formatGasMix(): shared Subsurface-style formatter — Air,
  EANxx, O2, or O2/He for trimix; rounds before comparing so float
  noise around 21% still reads as Air.
- New CellType::Gas wired through the standard cell pipeline: template
  persistence, Config showGas (overlay/showGas), OverlayGenerator
  property + layout + rendering, CellModel preview mirror, and a
  "Show Gas Mix" checkbox in the overlay editor.
- Renders "---" when the dive has no cylinders or a switch references
  an out-of-range cylinder index.

Fixes #46