### PR TITLE
feat: Add Garmin FIT dive log import (Descent dive computers).

### DIFF
--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   BUILD_TYPE: Release
-  QT_VERSION: '6.8.2'
+  QT_VERSION: '6.9.3'
   APP_ID: 'org.unabara.unabara'
 
 permissions:
@@ -230,7 +230,7 @@ jobs:
           <key>CFBundleVersion</key>
           <string>1</string>
           <key>LSMinimumSystemVersion</key>
-          <string>10.14</string>
+          <string>12.0</string>
           <key>NSPrincipalClass</key>
           <string>NSApplication</string>
           <key>NSHighResolutionCapable</key>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set(PROJECT_SOURCES
     src/core/format_parsers/parse_utils.cpp
     src/core/format_parsers/subsurface_parser.cpp
     src/core/format_parsers/uddf_parser.cpp
+    src/core/format_parsers/fit_decoder.cpp
+    src/core/format_parsers/fit_parser.cpp
     src/core/config.cpp
     src/core/units.cpp
     src/core/cell_data.cpp
@@ -66,6 +68,8 @@ set(PROJECT_HEADERS
     include/core/format_parsers/parse_utils.h
     include/core/format_parsers/subsurface_parser.h
     include/core/format_parsers/uddf_parser.h
+    include/core/format_parsers/fit_decoder.h
+    include/core/format_parsers/fit_parser.h
     include/core/config.h
     include/core/units.h
     include/core/cell_data.h

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Unabara is a powerful tool for creating telemetry overlays for scuba diving vide
 
 ## Features
 
-- **Import Dive Logs**: Import Subsurface (XML/SSRF) and UDDF dive logs to extract comprehensive diving telemetry. Unabara supports most kinds of diving: from single tank recreational dives to multi-tanks technical dives in Open Circuit or Closed Circuit Rebreather.
+- **Import Dive Logs**: Import Subsurface (XML/SSRF), UDDF and .FIT (Garmin) dive logs to extract comprehensive diving telemetry. Unabara supports most kinds of diving: from single tank recreational dives to multi-tanks technical dives in Open Circuit or Closed Circuit Rebreather.
 - **Visual Timeline**: View and navigate your dive data on an interactive timeline.
 - **Video Import**: Import your dive footage and position it against your dive data on the timeline.
 - **Video Preview & Sync**: Play your footage directly in Unabara and align it with your dive graphically — the timeline cursor follows the video, so you can match the overlay to your dive computer frame by frame. Save per-camera sync profiles for repeatable alignment.
@@ -85,7 +85,7 @@ Pre-built packages are available on the [Releases page](https://github.com/arnau
 
 ### Dependencies
 
-- Qt 6.8.0 or newer (Core, Gui, Quick, Qml, Xml, Concurrent, Widgets, Network, Multimedia)
+- Qt 6.9.3 or newer (Core, Gui, Quick, Qml, Xml, Concurrent, Widgets, Network, Multimedia)
 - CMake 3.16 or newer
 - C++17 compatible compiler (GCC 9+, Clang 10+, MSVC 2019+)
 
@@ -139,7 +139,7 @@ cmake --build .
 
 ### Windows
 
-1. Install [Qt 6.8.0](https://www.qt.io/download) or newer
+1. Install [Qt 6.9.3+](https://www.qt.io/download) or newer
 2. Install [CMake](https://cmake.org/download/)
 3. Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) or newer with C++ desktop development workload
 
@@ -153,7 +153,7 @@ mkdir build
 cd build
 
 # Configure and build
-cmake .. -DCMAKE_PREFIX_PATH=C:\path\to\Qt\6.8.0\msvc2019_64
+cmake .. -DCMAKE_PREFIX_PATH=C:\path\to\Qt\6.9.3\msvc2019_64
 cmake --build . --config Release
 
 # Run the application

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Pre-built packages are available on the [Releases page](https://github.com/arnau
 
 ### macOS
 
+Requires macOS 12 (Monterey) or newer.
+
 1. Download `unabara-macos-universal-x.x.x.dmg`
 2. Open the DMG file
 3. Drag the Unabara app to your Applications folder
@@ -85,7 +87,7 @@ Pre-built packages are available on the [Releases page](https://github.com/arnau
 
 ### Dependencies
 
-- Qt 6.9.3 or newer (Core, Gui, Quick, Qml, Xml, Concurrent, Widgets, Network, Multimedia)
+- Qt 6.8.0 or newer (Core, Gui, Quick, Qml, Xml, Concurrent, Widgets, Network, Multimedia) — macOS builds require Qt 6.9.3+
 - CMake 3.16 or newer
 - C++17 compatible compiler (GCC 9+, Clang 10+, MSVC 2019+)
 
@@ -139,7 +141,7 @@ cmake --build .
 
 ### Windows
 
-1. Install [Qt 6.9.3+](https://www.qt.io/download) or newer
+1. Install [Qt 6.8+](https://www.qt.io/download) or newer
 2. Install [CMake](https://cmake.org/download/)
 3. Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) or newer with C++ desktop development workload
 

--- a/include/core/format_parsers/fit_decoder.h
+++ b/include/core/format_parsers/fit_decoder.h
@@ -1,0 +1,71 @@
+#ifndef FIT_DECODER_H
+#define FIT_DECODER_H
+
+#include <QByteArray>
+#include <QList>
+#include <QMap>
+#include <QString>
+#include <QVector>
+
+class QIODevice;
+
+// One decoded FIT data message. Fields are keyed by the field definition
+// number from the wire format; each holds one or more decoded elements
+// (arrays keep their invalid elements as NaN, invalid scalars are omitted).
+struct FitMessage {
+    quint16 globalId = 0;
+    QMap<quint8, QVector<double>> fields;
+
+    bool has(quint8 fieldNum) const { return fields.contains(fieldNum); }
+    double value(quint8 fieldNum, double fallback = 0.0) const
+    {
+        auto it = fields.constFind(fieldNum);
+        return (it != fields.constEnd() && !it->isEmpty()) ? it->first() : fallback;
+    }
+};
+
+// Wire-level decoder for the FIT container format (clean-room implementation).
+// Turns the byte stream into a flat list of FitMessage; knows nothing about
+// dive semantics — that lives in FitParser.
+class FitDecoder
+{
+public:
+    // Decodes the device's full contents (from position 0). Returns false on a
+    // fatal structural error; messages() still holds everything decoded before
+    // the failure so callers can salvage truncated files.
+    bool decode(QIODevice *device, QString &errorOut);
+
+    const QList<FitMessage> &messages() const { return m_messages; }
+
+    // Cheap format sniff: bytes 8-11 are the ASCII string ".FIT".
+    // Restores the device's seek position.
+    static bool sniff(QIODevice *device);
+
+    static quint16 crc16(const uchar *data, qint64 length);
+
+private:
+    struct FieldDef {
+        quint8 fieldNum = 0;
+        quint8 size = 0;
+        quint8 baseType = 0;
+    };
+
+    struct LocalDef {
+        bool valid = false;
+        quint16 globalId = 0;
+        bool bigEndian = false;
+        QVector<FieldDef> fields;
+        int devDataBytes = 0; // developer fields: decoded for size, skipped as data
+    };
+
+    bool decodeDefinition(const uchar *&p, const uchar *end, quint8 recordHeader,
+                          QString &errorOut);
+    bool decodeData(const uchar *&p, const uchar *end, const LocalDef &def,
+                    QString &errorOut);
+
+    LocalDef m_locals[16];
+    quint32 m_lastTimestamp = 0; // for compressed-timestamp record headers
+    QList<FitMessage> m_messages;
+};
+
+#endif // FIT_DECODER_H

--- a/include/core/format_parsers/fit_decoder.h
+++ b/include/core/format_parsers/fit_decoder.h
@@ -19,8 +19,18 @@ struct FitMessage {
     bool has(quint8 fieldNum) const { return fields.contains(fieldNum); }
     double value(quint8 fieldNum, double fallback = 0.0) const
     {
+        // Return the first *valid* element: array fields keep invalid
+        // elements as NaN placeholders, and NaN must never escape (callers
+        // cast to integer types, which is undefined behavior on NaN)
         auto it = fields.constFind(fieldNum);
-        return (it != fields.constEnd() && !it->isEmpty()) ? it->first() : fallback;
+        if (it != fields.constEnd()) {
+            for (double element : *it) {
+                if (!qIsNaN(element)) {
+                    return element;
+                }
+            }
+        }
+        return fallback;
     }
 };
 

--- a/include/core/format_parsers/fit_parser.h
+++ b/include/core/format_parsers/fit_parser.h
@@ -1,0 +1,54 @@
+#ifndef FIT_PARSER_H
+#define FIT_PARSER_H
+
+#include <QMap>
+#include <QString>
+#include <QVector>
+
+#include "include/core/format_parsers/idive_log_format_parser.h"
+#include "include/core/format_parsers/fit_decoder.h"
+
+// Parser for Garmin FIT activity files (Descent dive computers).
+// Clean-room implementation: message and field numbers are protocol facts
+// taken from public format documentation and independent implementations —
+// no Garmin SDK code is used.
+class FitParser : public IDiveLogFormatParser
+{
+public:
+    FitParser();
+    ~FitParser() override = default;
+
+    bool canParse(QFile &file) const override;
+    QList<DiveData *> parse(QFile &file, int specificDive, QString &errorOut) override;
+    QList<QString> listDives(QFile &file, QString &errorOut) override;
+    QString formatName() const override { return QStringLiteral("Garmin FIT"); }
+
+private:
+    // Per-file metadata gathered before building samples. FIT files put
+    // summary messages (session, dive summary) after the sample records,
+    // so everything is decoded first and read in two passes.
+    struct Metadata {
+        int subSport = -1;              // 53-57, 63 are dive activities
+        bool hasStart = false;
+        quint32 startFit = 0;           // dive start in FIT epoch seconds
+        qint64 timeOffset = 0;          // local wall-clock offset in seconds
+        bool hasPosition = false;
+        double latitude = 0.0;          // degrees
+        double longitude = 0.0;         // degrees
+        double setpointLowBar = 0.0;    // CCR setpoints
+        double setpointHighBar = 0.0;
+        QVector<CylinderInfo> cylinders;
+        QMap<int, int> gasIndexToCylinder; // FIT gas message index -> cylinder index
+        QVector<quint32> tankSensors;   // tank pod sensor IDs, order = pressure channel
+        int diveNumber = 0;
+        double meanDepth = -1.0;        // meters, < 0 when not reported
+        bool sawDiveData = false;       // any depth sample or dive-specific message
+    };
+
+    bool decodeFile(QFile &file, FitDecoder &decoder, QString &errorOut) const;
+    Metadata collectMetadata(const QList<FitMessage> &messages) const;
+    bool isDive(const Metadata &meta, QString &errorOut) const;
+    DiveData *buildDive(const QList<FitMessage> &messages, const Metadata &meta) const;
+};
+
+#endif // FIT_PARSER_H

--- a/include/core/format_parsers/fit_parser.h
+++ b/include/core/format_parsers/fit_parser.h
@@ -1,6 +1,7 @@
 #ifndef FIT_PARSER_H
 #define FIT_PARSER_H
 
+#include <QDateTime>
 #include <QMap>
 #include <QString>
 #include <QVector>
@@ -49,6 +50,9 @@ private:
     Metadata collectMetadata(const QList<FitMessage> &messages) const;
     bool isDive(const Metadata &meta, QString &errorOut) const;
     DiveData *buildDive(const QList<FitMessage> &messages, const Metadata &meta) const;
+
+    static QDateTime startDateTime(const Metadata &meta);
+    static QString formatPosition(const Metadata &meta);
 };
 
 #endif // FIT_PARSER_H

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -300,10 +300,18 @@ DiveDataPoint DiveData::dataAtTime(double time) const
         // Check if we have cylinder information
         if (i < cylinderCount()) {
             const CylinderInfo &cylinder = cylinderInfo(i);
+            double prevPressure = prev.getPressure(i);
+            double nextPressure = next.getPressure(i);
 
-            // If cylinder has valid start/end pressure, use cylinder-based interpolation
-            // This is the primary method as it respects gas switches and handles missing samples
-            if (cylinder.startPressure > 0.0 && cylinder.endPressure > 0.0) {
+            // Recorded samples take precedence: they carry the actual
+            // consumption curve (fast at depth, slow at the stop), which the
+            // synthetic start/end ramp cannot reproduce
+            if (prevPressure > 0.0 && nextPressure > 0.0) {
+                pressure = prevPressure + factor * (nextPressure - prevPressure);
+            }
+            // Without samples, fall back to the cylinder start/end ramp,
+            // which respects gas switches and handles missing data
+            else if (cylinder.startPressure > 0.0 && cylinder.endPressure > 0.0) {
                 if (isCylinderActiveAtTime(i, time)) {
                     // Active cylinder: use cylinder-based interpolation
                     pressure = interpolateCylinderPressure(i, time);
@@ -316,14 +324,6 @@ DiveDataPoint DiveData::dataAtTime(double time) const
                         // Fallback: use start pressure if cylinder was never used
                         pressure = cylinder.startPressure;
                     }
-                }
-            }
-            // If no cylinder data available, fall back to sample-based interpolation
-            else {
-                double prevPressure = prev.getPressure(i);
-                double nextPressure = next.getPressure(i);
-                if (prevPressure > 0.0 && nextPressure > 0.0) {
-                    pressure = prevPressure + factor * (nextPressure - prevPressure);
                 }
             }
         }
@@ -429,11 +429,13 @@ void DiveData::addGasSwitch(double timestamp, int cylinderIndex) {
     gasSwitch.cylinderIndex = cylinderIndex;
     m_gasSwitches.append(gasSwitch);
     
-    // Keep gas switches sorted by timestamp
-    std::sort(m_gasSwitches.begin(), m_gasSwitches.end(), 
-              [](const GasSwitch &a, const GasSwitch &b) {
-                  return a.timestamp < b.timestamp;
-              });
+    // Keep gas switches sorted by timestamp. Stable so that switches sharing
+    // a timestamp (e.g. pre-dive switches clamped to t=0) keep their insertion
+    // order — activeCylinderAtTime picks the last one at or before t.
+    std::stable_sort(m_gasSwitches.begin(), m_gasSwitches.end(),
+                     [](const GasSwitch &a, const GasSwitch &b) {
+                         return a.timestamp < b.timestamp;
+                     });
 }
 
 int DiveData::activeCylinderAtTime(double timestamp) const {

--- a/src/core/format_parsers/fit_decoder.cpp
+++ b/src/core/format_parsers/fit_decoder.cpp
@@ -1,0 +1,368 @@
+#include "include/core/format_parsers/fit_decoder.h"
+
+#include <QDebug>
+#include <QIODevice>
+
+#include <cstring>
+
+namespace {
+
+// FIT base type numbers (low 5 bits of the base type byte; bit 7 flags
+// multi-byte types that honor the definition's architecture).
+enum FitBaseType {
+    BaseEnum = 0,
+    BaseSInt8 = 1,
+    BaseUInt8 = 2,
+    BaseSInt16 = 3,
+    BaseUInt16 = 4,
+    BaseSInt32 = 5,
+    BaseUInt32 = 6,
+    BaseString = 7,
+    BaseFloat32 = 8,
+    BaseFloat64 = 9,
+    BaseUInt8z = 10,
+    BaseUInt16z = 11,
+    BaseUInt32z = 12,
+    BaseByte = 13,
+    BaseSInt64 = 14,
+    BaseUInt64 = 15,
+    BaseUInt64z = 16,
+};
+
+int baseTypeSize(quint8 baseNum)
+{
+    switch (baseNum) {
+        case BaseEnum:
+        case BaseSInt8:
+        case BaseUInt8:
+        case BaseString:
+        case BaseUInt8z:
+        case BaseByte:
+            return 1;
+        case BaseSInt16:
+        case BaseUInt16:
+        case BaseUInt16z:
+            return 2;
+        case BaseSInt32:
+        case BaseUInt32:
+        case BaseFloat32:
+        case BaseUInt32z:
+            return 4;
+        case BaseFloat64:
+        case BaseSInt64:
+        case BaseUInt64:
+        case BaseUInt64z:
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+quint64 readUInt(const uchar *p, int size, bool bigEndian)
+{
+    quint64 value = 0;
+    if (bigEndian) {
+        for (int i = 0; i < size; ++i) {
+            value = (value << 8) | p[i];
+        }
+    } else {
+        for (int i = size - 1; i >= 0; --i) {
+            value = (value << 8) | p[i];
+        }
+    }
+    return value;
+}
+
+// Decodes one element; returns false if the element holds the base type's
+// "invalid" sentinel (field not present in this message).
+bool decodeElement(const uchar *p, quint8 baseNum, bool bigEndian, double &out)
+{
+    const int size = baseTypeSize(baseNum);
+    const quint64 raw = readUInt(p, size, bigEndian);
+
+    switch (baseNum) {
+        case BaseEnum:
+        case BaseUInt8:
+        case BaseByte:
+            if (raw == 0xFF) return false;
+            out = static_cast<double>(raw);
+            return true;
+        case BaseUInt16:
+            if (raw == 0xFFFF) return false;
+            out = static_cast<double>(raw);
+            return true;
+        case BaseUInt32:
+            if (raw == 0xFFFFFFFFULL) return false;
+            out = static_cast<double>(raw);
+            return true;
+        case BaseUInt64:
+            if (raw == ~0ULL) return false;
+            out = static_cast<double>(raw);
+            return true;
+        case BaseUInt8z:
+        case BaseUInt16z:
+        case BaseUInt32z:
+        case BaseUInt64z:
+            if (raw == 0) return false;
+            out = static_cast<double>(raw);
+            return true;
+        case BaseSInt8:
+            if (raw == 0x7F) return false;
+            out = static_cast<double>(static_cast<qint8>(raw));
+            return true;
+        case BaseSInt16:
+            if (raw == 0x7FFF) return false;
+            out = static_cast<double>(static_cast<qint16>(raw));
+            return true;
+        case BaseSInt32:
+            if (raw == 0x7FFFFFFFULL) return false;
+            out = static_cast<double>(static_cast<qint32>(raw));
+            return true;
+        case BaseSInt64:
+            if (raw == 0x7FFFFFFFFFFFFFFFULL) return false;
+            out = static_cast<double>(static_cast<qint64>(raw));
+            return true;
+        case BaseFloat32: {
+            if (raw == 0xFFFFFFFFULL) return false;
+            float f;
+            quint32 bits = static_cast<quint32>(raw);
+            std::memcpy(&f, &bits, sizeof(f));
+            out = static_cast<double>(f);
+            return true;
+        }
+        case BaseFloat64: {
+            if (raw == ~0ULL) return false;
+            double d;
+            std::memcpy(&d, &raw, sizeof(d));
+            out = d;
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+} // namespace
+
+quint16 FitDecoder::crc16(const uchar *data, qint64 length)
+{
+    static const quint16 table[16] = {
+        0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
+        0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400,
+    };
+
+    quint16 crc = 0;
+    for (qint64 i = 0; i < length; ++i) {
+        quint16 tmp = table[crc & 0xF];
+        crc = (crc >> 4) & 0x0FFF;
+        crc = crc ^ tmp ^ table[data[i] & 0xF];
+
+        tmp = table[crc & 0xF];
+        crc = (crc >> 4) & 0x0FFF;
+        crc = crc ^ tmp ^ table[(data[i] >> 4) & 0xF];
+    }
+    return crc;
+}
+
+bool FitDecoder::sniff(QIODevice *device)
+{
+    const qint64 originalPos = device->pos();
+    device->seek(0);
+
+    char header[12];
+    const bool ok = device->read(header, sizeof(header)) == sizeof(header)
+                    && std::memcmp(header + 8, ".FIT", 4) == 0;
+
+    device->seek(originalPos);
+    return ok;
+}
+
+bool FitDecoder::decode(QIODevice *device, QString &errorOut)
+{
+    m_messages.clear();
+    for (LocalDef &local : m_locals) {
+        local = LocalDef();
+    }
+    m_lastTimestamp = 0;
+
+    device->seek(0);
+    const QByteArray content = device->readAll();
+    const uchar *base = reinterpret_cast<const uchar *>(content.constData());
+    const qint64 fileLen = content.size();
+
+    if (fileLen < 14) {
+        errorOut = QStringLiteral("File too small to be a FIT file (%1 bytes)").arg(fileLen);
+        return false;
+    }
+
+    const quint8 headerSize = base[0];
+    const quint32 dataSize = static_cast<quint32>(readUInt(base + 4, 4, false));
+    if (headerSize < 12 || headerSize > fileLen || std::memcmp(base + 8, ".FIT", 4) != 0) {
+        errorOut = QStringLiteral("Invalid FIT file header");
+        return false;
+    }
+    if (static_cast<qint64>(headerSize) + dataSize + 2 > fileLen) {
+        // Truncated file: decode what is there, the record loop will stop at
+        // the actual end of data. Warn but keep going (salvage).
+        qWarning() << "FIT file shorter than header declares:" << fileLen << "bytes,"
+                   << "expected" << (headerSize + dataSize + 2);
+    } else {
+        const quint16 expected =
+            static_cast<quint16>(readUInt(base + headerSize + dataSize, 2, false));
+        if (crc16(base, headerSize + dataSize) != expected) {
+            qWarning() << "FIT file CRC mismatch, importing anyway";
+        }
+    }
+
+    const uchar *p = base + headerSize;
+    const uchar *end = base + qMin<qint64>(fileLen, static_cast<qint64>(headerSize) + dataSize);
+
+    while (p < end) {
+        const quint8 recordHeader = *p++;
+
+        if (recordHeader & 0x80) {
+            // Compressed timestamp header: 2-bit local type, 5-bit time offset
+            // relative to the last full timestamp.
+            const quint8 localType = (recordHeader >> 5) & 0x3;
+            const quint8 offset = recordHeader & 0x1F;
+            quint32 timestamp = (m_lastTimestamp & ~0x1Fu) | offset;
+            if (timestamp < m_lastTimestamp) {
+                timestamp += 0x20;
+            }
+            m_lastTimestamp = timestamp;
+
+            const LocalDef &def = m_locals[localType];
+            if (!def.valid) {
+                errorOut = QStringLiteral("FIT data record for undefined local type %1 at byte %2")
+                               .arg(localType)
+                               .arg(p - 1 - base);
+                return false;
+            }
+            if (!decodeData(p, end, def, errorOut)) {
+                return false;
+            }
+            m_messages.last().fields[253] = {static_cast<double>(timestamp)};
+        } else if (recordHeader & 0x40) {
+            if (!decodeDefinition(p, end, recordHeader, errorOut)) {
+                return false;
+            }
+        } else {
+            const quint8 localType = recordHeader & 0xF;
+            const LocalDef &def = m_locals[localType];
+            if (!def.valid) {
+                errorOut = QStringLiteral("FIT data record for undefined local type %1 at byte %2")
+                               .arg(localType)
+                               .arg(p - 1 - base);
+                return false;
+            }
+            if (!decodeData(p, end, def, errorOut)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool FitDecoder::decodeDefinition(const uchar *&p, const uchar *end, quint8 recordHeader,
+                                  QString &errorOut)
+{
+    if (end - p < 5) {
+        errorOut = QStringLiteral("Truncated FIT definition record");
+        return false;
+    }
+
+    LocalDef def;
+    def.valid = true;
+    // p[0] is reserved
+    def.bigEndian = (p[1] != 0);
+    def.globalId = static_cast<quint16>(readUInt(p + 2, 2, def.bigEndian));
+    const quint8 fieldCount = p[4];
+    p += 5;
+
+    if (end - p < fieldCount * 3) {
+        errorOut = QStringLiteral("Truncated FIT field definitions");
+        return false;
+    }
+    def.fields.reserve(fieldCount);
+    for (int i = 0; i < fieldCount; ++i) {
+        FieldDef field;
+        field.fieldNum = p[0];
+        field.size = p[1];
+        field.baseType = p[2];
+        def.fields.append(field);
+        p += 3;
+    }
+
+    if (recordHeader & 0x20) {
+        // Developer field definitions: we never interpret developer data,
+        // but their total size must be known to skip it in data records.
+        if (end - p < 1) {
+            errorOut = QStringLiteral("Truncated FIT developer field count");
+            return false;
+        }
+        const quint8 devFieldCount = *p++;
+        if (end - p < devFieldCount * 3) {
+            errorOut = QStringLiteral("Truncated FIT developer field definitions");
+            return false;
+        }
+        for (int i = 0; i < devFieldCount; ++i) {
+            def.devDataBytes += p[1];
+            p += 3;
+        }
+    }
+
+    m_locals[recordHeader & 0xF] = def;
+    return true;
+}
+
+bool FitDecoder::decodeData(const uchar *&p, const uchar *end, const LocalDef &def,
+                            QString &errorOut)
+{
+    FitMessage message;
+    message.globalId = def.globalId;
+
+    for (const FieldDef &field : def.fields) {
+        if (end - p < field.size) {
+            errorOut = QStringLiteral("Truncated FIT data record (message %1)").arg(def.globalId);
+            return false;
+        }
+
+        const quint8 baseNum = field.baseType & 0x1F;
+        const int elementSize = baseTypeSize(baseNum);
+
+        // Strings and malformed/unknown field encodings are skipped whole;
+        // the definition's declared size keeps the stream in sync regardless.
+        if (baseNum != BaseString && elementSize > 0 && field.size % elementSize == 0) {
+            QVector<double> elements;
+            bool anyValid = false;
+            const int count = field.size / elementSize;
+            for (int i = 0; i < count; ++i) {
+                double value = qQNaN();
+                if (decodeElement(p + i * elementSize, baseNum, def.bigEndian, value)) {
+                    anyValid = true;
+                } else {
+                    value = qQNaN();
+                }
+                elements.append(value);
+            }
+            if (anyValid) {
+                message.fields.insert(field.fieldNum, elements);
+                if (field.fieldNum == 253 && !qIsNaN(elements.first())) {
+                    m_lastTimestamp = static_cast<quint32>(elements.first());
+                }
+            }
+        }
+
+        p += field.size;
+    }
+
+    if (end - p < def.devDataBytes) {
+        errorOut = QStringLiteral("Truncated FIT developer data (message %1)").arg(def.globalId);
+        return false;
+    }
+    p += def.devDataBytes;
+
+    m_messages.append(message);
+    return true;
+}

--- a/src/core/format_parsers/fit_decoder.cpp
+++ b/src/core/format_parsers/fit_decoder.cpp
@@ -196,12 +196,19 @@ bool FitDecoder::decode(QIODevice *device, QString &errorOut)
     }
 
     const quint8 headerSize = base[0];
-    const quint32 dataSize = static_cast<quint32>(readUInt(base + 4, 4, false));
+    quint32 dataSize = static_cast<quint32>(readUInt(base + 4, 4, false));
     if (headerSize < 12 || headerSize > fileLen || std::memcmp(base + 8, ".FIT", 4) != 0) {
         errorOut = QStringLiteral("Invalid FIT file header");
         return false;
     }
-    if (static_cast<qint64>(headerSize) + dataSize + 2 > fileLen) {
+    if (dataSize == 0) {
+        // Crash-recovered files: the header is written before the data and
+        // dataSize is only backfilled when the file is finalized. Decode to
+        // the end of the file instead (the trailing CRC bytes, if any, will
+        // fail as a record and be salvaged around).
+        qWarning() << "FIT header declares zero data size, decoding to end of file";
+        dataSize = static_cast<quint32>(fileLen - headerSize);
+    } else if (static_cast<qint64>(headerSize) + dataSize + 2 > fileLen) {
         // Truncated file: decode what is there, the record loop will stop at
         // the actual end of data. Warn but keep going (salvage).
         qWarning() << "FIT file shorter than header declares:" << fileLen << "bytes,"

--- a/src/core/format_parsers/fit_parser.cpp
+++ b/src/core/format_parsers/fit_parser.cpp
@@ -1,0 +1,473 @@
+#include "include/core/format_parsers/fit_parser.h"
+
+#include <QDateTime>
+#include <QDebug>
+#include <QTimeZone>
+
+#include <algorithm>
+
+#include "include/core/units.h"
+
+namespace {
+
+// Seconds between the Unix epoch and the FIT epoch (1989-12-31T00:00:00 UTC).
+constexpr qint64 FIT_EPOCH_OFFSET = 631065600;
+
+// FIT global message numbers (protocol facts, dive-relevant subset).
+enum FitGlobalMessage : quint16 {
+    MsgSport = 12,
+    MsgSession = 18,
+    MsgRecord = 20,
+    MsgEvent = 21,
+    MsgActivity = 34,
+    MsgSensorProfile = 147,
+    MsgTimestampCorrelation = 162,
+    MsgDiveSettings = 258,
+    MsgDiveGas = 259,
+    MsgDiveSummary = 268,
+    MsgTankUpdate = 319,
+    MsgTankSummary = 323,
+};
+
+// The timestamp field shared by all messages, and the index field used by
+// per-slot messages such as dive_gas.
+constexpr quint8 FieldTimestamp = 253;
+constexpr quint8 FieldMessageIndex = 254;
+
+bool isDiveSubSport(int subSport)
+{
+    // 53 single-gas, 54 multi-gas, 55 gauge, 56 apnea, 57 apnea hunt, 63 CCR
+    return (subSport >= 53 && subSport <= 57) || subSport == 63;
+}
+
+double semicirclesToDegrees(double semicircles)
+{
+    return semicircles * (180.0 / 2147483648.0);
+}
+
+} // namespace
+
+FitParser::FitParser() = default;
+
+bool FitParser::canParse(QFile &file) const
+{
+    return FitDecoder::sniff(&file);
+}
+
+bool FitParser::decodeFile(QFile &file, FitDecoder &decoder, QString &errorOut) const
+{
+    if (!decoder.decode(&file, errorOut)) {
+        // Salvage: a truncated file (e.g. a crashed watch) is still worth
+        // importing if a usable number of dive samples were decoded.
+        int depthSamples = 0;
+        for (const FitMessage &message : decoder.messages()) {
+            if (message.globalId == MsgRecord && message.has(92)) {
+                depthSamples++;
+            }
+        }
+        if (depthSamples < 2) {
+            return false;
+        }
+        qWarning() << "FIT decode error, importing" << depthSamples
+                   << "salvaged samples anyway:" << errorOut;
+        errorOut.clear();
+    }
+    return true;
+}
+
+FitParser::Metadata FitParser::collectMetadata(const QList<FitMessage> &messages) const
+{
+    Metadata meta;
+
+    QMap<int, CylinderInfo> gasesByIndex;
+    QMap<int, bool> gasIsDiluent;
+    QMap<quint32, QPair<double, double>> tankPressures; // sensor -> start/end bar
+    QVector<double> tankVolumes;                        // liters, parallel to tankSensors
+    bool sawFirstRecord = false;
+    quint32 firstRecordTime = 0;
+
+    for (const FitMessage &message : messages) {
+        switch (message.globalId) {
+            case MsgSport:
+                if (message.has(1)) {
+                    meta.subSport = static_cast<int>(message.value(1));
+                }
+                break;
+
+            case MsgSession:
+                if (message.has(2)) {
+                    meta.hasStart = true;
+                    meta.startFit = static_cast<quint32>(message.value(2));
+                }
+                if (message.has(3) && message.has(4)) {
+                    meta.hasPosition = true;
+                    meta.latitude = semicirclesToDegrees(message.value(3));
+                    meta.longitude = semicirclesToDegrees(message.value(4));
+                }
+                if (meta.subSport < 0 && message.has(6)) {
+                    meta.subSport = static_cast<int>(message.value(6));
+                }
+                break;
+
+            case MsgActivity:
+            case MsgTimestampCorrelation:
+                // Field 5 (activity) / field 3 (timestamp correlation) hold the
+                // device's local wall-clock time for the message's timestamp.
+                {
+                    const quint8 localField = (message.globalId == MsgActivity) ? 5 : 3;
+                    if (message.has(localField) && message.has(FieldTimestamp)) {
+                        meta.timeOffset = static_cast<qint64>(message.value(localField))
+                                          - static_cast<qint64>(message.value(FieldTimestamp));
+                    }
+                }
+                break;
+
+            case MsgDiveSettings:
+                meta.sawDiveData = true;
+                if (message.has(23)) {
+                    meta.setpointLowBar = message.value(23) / 100.0; // centibar
+                }
+                if (message.has(26)) {
+                    meta.setpointHighBar = message.value(26) / 100.0;
+                }
+                break;
+
+            case MsgDiveGas: {
+                meta.sawDiveData = true;
+                const int gasIndex = static_cast<int>(message.value(FieldMessageIndex, 0));
+                const int status = static_cast<int>(message.value(2, 1)); // 0 disabled, 1 enabled, 2 backup
+                if (status == 0) {
+                    break;
+                }
+                CylinderInfo cylinder;
+                cylinder.o2Percent = message.value(1, 21.0);
+                cylinder.hePercent = message.value(0, 0.0);
+                cylinder.description = Units::formatGasMix(cylinder.o2Percent, cylinder.hePercent);
+                gasesByIndex.insert(gasIndex, cylinder);
+                gasIsDiluent.insert(gasIndex, static_cast<int>(message.value(3, 0)) == 1);
+                break;
+            }
+
+            case MsgSensorProfile: {
+                // Sensor type 28 is a tank pressure pod
+                if (static_cast<int>(message.value(52, -1)) != 28) {
+                    break;
+                }
+                meta.tankSensors.append(static_cast<quint32>(message.value(0, 0)));
+                double volumeLiters = 0.0;
+                if (message.has(77)) {
+                    const double rawVolume = message.value(77) / 10.0;
+                    const int units = static_cast<int>(message.value(74, 2)); // 0 PSI, 2 Bar
+                    // Volume is L*10 for Bar pods, CuFt*10 for PSI pods
+                    volumeLiters = (units == 0) ? rawVolume * 28.3168 : rawVolume;
+                }
+                tankVolumes.append(volumeLiters);
+                break;
+            }
+
+            case MsgTankSummary:
+                if (message.has(0)) {
+                    tankPressures.insert(static_cast<quint32>(message.value(0)),
+                                         qMakePair(message.value(1, 0.0) / 100.0,
+                                                   message.value(2, 0.0) / 100.0));
+                }
+                break;
+
+            case MsgDiveSummary:
+                meta.sawDiveData = true;
+                if (message.has(10)) {
+                    meta.diveNumber = static_cast<int>(message.value(10));
+                }
+                if (message.has(2)) {
+                    meta.meanDepth = message.value(2) / 1000.0; // mm -> m
+                }
+                break;
+
+            case MsgRecord:
+                if (!sawFirstRecord && message.has(FieldTimestamp)) {
+                    sawFirstRecord = true;
+                    firstRecordTime = static_cast<quint32>(message.value(FieldTimestamp));
+                }
+                if (message.has(92)) {
+                    meta.sawDiveData = true;
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if (!meta.hasStart && sawFirstRecord) {
+        meta.hasStart = true;
+        meta.startFit = firstRecordTime;
+    }
+
+    // Cylinders in gas-slot order; the FIT gas index maps onto the cylinder index
+    for (auto it = gasesByIndex.constBegin(); it != gasesByIndex.constEnd(); ++it) {
+        CylinderInfo cylinder = it.value();
+        cylinder.index = meta.cylinders.size();
+        if (gasIsDiluent.value(it.key(), false)) {
+            cylinder.description += QStringLiteral(" (diluent)");
+        }
+        meta.gasIndexToCylinder.insert(it.key(), cylinder.index);
+        meta.cylinders.append(cylinder);
+    }
+
+    // Tank pods map onto cylinders by position (FIT has no gas <-> pod link);
+    // pad with default air cylinders if there are more pods than gases.
+    for (int channel = 0; channel < meta.tankSensors.size(); ++channel) {
+        if (channel >= meta.cylinders.size()) {
+            CylinderInfo cylinder;
+            cylinder.index = meta.cylinders.size();
+            cylinder.description = Units::formatGasMix(cylinder.o2Percent, cylinder.hePercent);
+            meta.cylinders.append(cylinder);
+        }
+        if (tankVolumes.value(channel, 0.0) > 0.0) {
+            meta.cylinders[channel].size = tankVolumes.at(channel);
+        }
+        const auto pressures = tankPressures.constFind(meta.tankSensors.at(channel));
+        if (pressures != tankPressures.constEnd()) {
+            meta.cylinders[channel].startPressure = pressures->first;
+            meta.cylinders[channel].endPressure = pressures->second;
+        }
+    }
+
+    return meta;
+}
+
+bool FitParser::isDive(const Metadata &meta, QString &errorOut) const
+{
+    if (meta.subSport >= 0 && !isDiveSubSport(meta.subSport)) {
+        errorOut = QStringLiteral("FIT file does not contain a dive activity");
+        return false;
+    }
+    if (meta.subSport < 0 && !meta.sawDiveData) {
+        errorOut = QStringLiteral("FIT file does not contain a dive activity");
+        return false;
+    }
+    if (!meta.hasStart) {
+        errorOut = QStringLiteral("FIT file contains no dive samples");
+        return false;
+    }
+    return true;
+}
+
+DiveData *FitParser::buildDive(const QList<FitMessage> &messages, const Metadata &meta) const
+{
+    DiveData *dive = new DiveData(nullptr);
+
+    const bool isCcr = (meta.subSport == 63);
+    dive->setDiveMode(isCcr ? DiveData::ClosedCircuit : DiveData::OpenCircuit);
+    dive->setStartTime(QDateTime::fromSecsSinceEpoch(
+        FIT_EPOCH_OFFSET + meta.startFit + meta.timeOffset, QTimeZone::utc()));
+    dive->setDiveNumber(meta.diveNumber);
+    dive->setDiveName(meta.diveNumber > 0 ? QStringLiteral("Dive #%1").arg(meta.diveNumber)
+                                          : QStringLiteral("Garmin Dive"));
+    if (meta.meanDepth >= 0.0) {
+        dive->setMeanDepth(meta.meanDepth);
+    }
+    if (meta.hasPosition && (meta.latitude != 0.0 || meta.longitude != 0.0)) {
+        dive->setLocation(QStringLiteral("%1, %2")
+                              .arg(QString::number(meta.latitude, 'f', 6),
+                                   QString::number(meta.longitude, 'f', 6)));
+    }
+    for (const CylinderInfo &cylinder : meta.cylinders) {
+        dive->addCylinder(cylinder);
+    }
+
+    // Carry-forward sample state: dive computers only record values when
+    // they change, so missing fields reuse the previous sample's value.
+    double lastDepth = 0.0;
+    double lastTemperature = 0.0;
+    double lastNDL = 0.0;
+    double lastTTS = 0.0;
+    double lastCeiling = 0.0;
+    double lastCNS = -1.0;
+    QMap<int, double> lastPressures; // pressure channel -> bar
+    QVector<quint32> tankSensors = meta.tankSensors;
+    double currentO2 =
+        meta.cylinders.isEmpty() ? 21.0 : meta.cylinders.first().o2Percent;
+    // The initial CCR setpoint at the start of the dive is the low setpoint
+    double currentSetpoint = meta.setpointLowBar;
+
+    QVector<DiveDataPoint> points;
+
+    for (const FitMessage &message : messages) {
+        switch (message.globalId) {
+            case MsgTankUpdate: {
+                if (!message.has(0) || !message.has(1)) {
+                    break;
+                }
+                const quint32 sensor = static_cast<quint32>(message.value(0));
+                int channel = tankSensors.indexOf(sensor);
+                if (channel < 0) {
+                    // Unpaired pod seen mid-dive: give it the next free channel
+                    channel = tankSensors.size();
+                    tankSensors.append(sensor);
+                }
+                lastPressures[channel] = message.value(1) / 100.0; // bar * 100
+                break;
+            }
+
+            case MsgEvent: {
+                const int event = static_cast<int>(message.value(0, -1));
+                const int data = static_cast<int>(message.value(3, 0));
+                if (event == 57) {
+                    // Gas switch; data is the FIT gas slot index
+                    const int cylinderIndex = meta.gasIndexToCylinder.value(data, 0);
+                    double relTime = 0.0;
+                    if (message.has(FieldTimestamp)) {
+                        const quint32 timestamp =
+                            static_cast<quint32>(message.value(FieldTimestamp));
+                        // Clamp pre-dive-start switch events to t=0 so the
+                        // starting gas is reflected from the first sample
+                        if (timestamp > meta.startFit) {
+                            relTime = timestamp - meta.startFit;
+                        }
+                    }
+                    dive->addGasSwitch(relTime, cylinderIndex);
+                    if (cylinderIndex < meta.cylinders.size()) {
+                        currentO2 = meta.cylinders.at(cylinderIndex).o2Percent;
+                    }
+                } else if (event == 56 && data >= 24 && data <= 27) {
+                    // Automatic/manual switch to low (24/26) or high (25/27) setpoint
+                    currentSetpoint =
+                        (data == 24 || data == 26) ? meta.setpointLowBar : meta.setpointHighBar;
+                }
+                break;
+            }
+
+            case MsgRecord: {
+                if (!message.has(FieldTimestamp)) {
+                    break;
+                }
+                const quint32 timestamp = static_cast<quint32>(message.value(FieldTimestamp));
+                if (timestamp < meta.startFit) {
+                    break; // pre-dive surface samples
+                }
+
+                DiveDataPoint point;
+                point.timestamp = static_cast<double>(timestamp - meta.startFit);
+
+                if (message.has(92)) {
+                    lastDepth = message.value(92) / 1000.0; // mm -> m
+                }
+                point.depth = lastDepth;
+
+                if (message.has(13)) {
+                    lastTemperature = message.value(13); // degrees C
+                }
+                point.temperature = lastTemperature;
+
+                if (message.has(96)) {
+                    lastNDL = message.value(96) / 60.0; // s -> min
+                }
+                point.ndl = lastNDL;
+
+                if (message.has(95)) {
+                    lastTTS = message.value(95) / 60.0; // s -> min
+                }
+                point.tts = lastTTS;
+
+                if (message.has(93)) {
+                    lastCeiling = message.value(93) / 1000.0; // next stop depth, mm -> m
+                }
+                point.ceiling = lastCeiling;
+
+                if (message.has(97)) {
+                    lastCNS = message.value(97); // percent
+                }
+                point.cns = lastCNS;
+
+                point.o2percent = currentO2;
+
+                for (auto it = lastPressures.constBegin(); it != lastPressures.constEnd(); ++it) {
+                    point.addPressure(it.value(), it.key());
+                }
+
+                if (isCcr && currentSetpoint > 0.0) {
+                    // The Descent records the active setpoint, not sensor
+                    // readings; expose it through PO2 channel 0
+                    point.addPO2Sensor(currentSetpoint, 0);
+                }
+
+                if (!points.isEmpty() && points.last().timestamp == point.timestamp) {
+                    points.last() = point; // compressed-timestamp duplicate: last wins
+                } else {
+                    points.append(point);
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    for (const DiveDataPoint &point : points) {
+        dive->addDataPoint(point);
+    }
+
+    return dive;
+}
+
+QList<DiveData *> FitParser::parse(QFile &file, int specificDive, QString &errorOut)
+{
+    QList<DiveData *> result;
+
+    FitDecoder decoder;
+    if (!decodeFile(file, decoder, errorOut)) {
+        return result;
+    }
+
+    const Metadata meta = collectMetadata(decoder.messages());
+    if (!isDive(meta, errorOut)) {
+        return result;
+    }
+
+    DiveData *dive = buildDive(decoder.messages(), meta);
+    if (dive->allDataPoints().isEmpty()) {
+        delete dive;
+        errorOut = QStringLiteral("FIT file contains no dive samples");
+        return result;
+    }
+
+    // A FIT activity file holds a single dive; honor the specific-dive
+    // request by number the way the other parsers do.
+    if (specificDive >= 0 && dive->diveNumber() != specificDive) {
+        delete dive;
+        return result;
+    }
+
+    result.append(dive);
+    return result;
+}
+
+QList<QString> FitParser::listDives(QFile &file, QString &errorOut)
+{
+    QList<QString> result;
+
+    FitDecoder decoder;
+    if (!decodeFile(file, decoder, errorOut)) {
+        return result;
+    }
+
+    const Metadata meta = collectMetadata(decoder.messages());
+    if (!isDive(meta, errorOut)) {
+        return result;
+    }
+
+    const QDateTime start = QDateTime::fromSecsSinceEpoch(
+        FIT_EPOCH_OFFSET + meta.startFit + meta.timeOffset, QTimeZone::utc());
+    QString entry = QStringLiteral("Dive #%1 - %2")
+                        .arg(meta.diveNumber)
+                        .arg(start.toString(QStringLiteral("yyyy-MM-dd hh:mm")));
+    if (meta.hasPosition && (meta.latitude != 0.0 || meta.longitude != 0.0)) {
+        entry += QStringLiteral(" at %1, %2")
+                     .arg(QString::number(meta.latitude, 'f', 4),
+                          QString::number(meta.longitude, 'f', 4));
+    }
+    result.append(entry);
+    return result;
+}

--- a/src/core/format_parsers/fit_parser.cpp
+++ b/src/core/format_parsers/fit_parser.cpp
@@ -49,6 +49,29 @@ double semicirclesToDegrees(double semicircles)
 
 FitParser::FitParser() = default;
 
+QDateTime FitParser::startDateTime(const Metadata &meta)
+{
+    // FIT timestamps are UTC; timeOffset is the device's local wall-clock
+    // offset. Encode it as a UTC offset so the displayed time matches what
+    // the watch showed while toSecsSinceEpoch() stays the true instant —
+    // video sync compares it against the camera's UTC creation time.
+    int offsetSeconds = static_cast<int>(meta.timeOffset);
+    if (offsetSeconds < -14 * 3600 || offsetSeconds > 14 * 3600) {
+        offsetSeconds = 0; // implausible offset (corrupt correlation message)
+    }
+    return QDateTime::fromSecsSinceEpoch(FIT_EPOCH_OFFSET + meta.startFit,
+                                         QTimeZone(offsetSeconds));
+}
+
+QString FitParser::formatPosition(const Metadata &meta)
+{
+    if (!meta.hasPosition || (meta.latitude == 0.0 && meta.longitude == 0.0)) {
+        return QString();
+    }
+    return QStringLiteral("%1, %2").arg(QString::number(meta.latitude, 'f', 6),
+                                        QString::number(meta.longitude, 'f', 6));
+}
+
 bool FitParser::canParse(QFile &file) const
 {
     return FitDecoder::sniff(&file);
@@ -83,6 +106,7 @@ FitParser::Metadata FitParser::collectMetadata(const QList<FitMessage> &messages
     QMap<int, bool> gasIsDiluent;
     QMap<quint32, QPair<double, double>> tankPressures; // sensor -> start/end bar
     QVector<double> tankVolumes;                        // liters, parallel to tankSensors
+    QVector<quint32> updateSensors;                     // pods seen in tank_update messages
     bool sawFirstRecord = false;
     quint32 firstRecordTime = 0;
 
@@ -134,7 +158,11 @@ FitParser::Metadata FitParser::collectMetadata(const QList<FitMessage> &messages
 
             case MsgDiveGas: {
                 meta.sawDiveData = true;
-                const int gasIndex = static_cast<int>(message.value(FieldMessageIndex, 0));
+                // Fall back to sequential slots when the writer omits the
+                // message index — defaulting all to 0 would collapse the gases
+                const int gasIndex = message.has(FieldMessageIndex)
+                                         ? static_cast<int>(message.value(FieldMessageIndex))
+                                         : gasesByIndex.size();
                 const int status = static_cast<int>(message.value(2, 1)); // 0 disabled, 1 enabled, 2 backup
                 if (status == 0) {
                     break;
@@ -149,11 +177,13 @@ FitParser::Metadata FitParser::collectMetadata(const QList<FitMessage> &messages
             }
 
             case MsgSensorProfile: {
-                // Sensor type 28 is a tank pressure pod
-                if (static_cast<int>(message.value(52, -1)) != 28) {
+                // Sensor type 28 is a tank pressure pod; a pod without a
+                // readable serial can never match a tank_update, so skip it
+                // rather than creating a phantom channel
+                if (static_cast<int>(message.value(52, -1)) != 28 || !message.has(0)) {
                     break;
                 }
-                meta.tankSensors.append(static_cast<quint32>(message.value(0, 0)));
+                meta.tankSensors.append(static_cast<quint32>(message.value(0)));
                 double volumeLiters = 0.0;
                 if (message.has(77)) {
                     const double rawVolume = message.value(77) / 10.0;
@@ -164,6 +194,15 @@ FitParser::Metadata FitParser::collectMetadata(const QList<FitMessage> &messages
                 tankVolumes.append(volumeLiters);
                 break;
             }
+
+            case MsgTankUpdate:
+                if (message.has(0)) {
+                    const quint32 sensor = static_cast<quint32>(message.value(0));
+                    if (!updateSensors.contains(sensor)) {
+                        updateSensors.append(sensor);
+                    }
+                }
+                break;
 
             case MsgTankSummary:
                 if (message.has(0)) {
@@ -201,6 +240,17 @@ FitParser::Metadata FitParser::collectMetadata(const QList<FitMessage> &messages
     if (!meta.hasStart && sawFirstRecord) {
         meta.hasStart = true;
         meta.startFit = firstRecordTime;
+    }
+
+    // Pods seen only in tank_update messages (paired mid-dive, or the
+    // sensor_profile messages are absent) still get a channel here so the
+    // padding loop below gives them a cylinder — otherwise their pressures
+    // would land on channels no overlay cell can display
+    for (quint32 sensor : updateSensors) {
+        if (!meta.tankSensors.contains(sensor)) {
+            meta.tankSensors.append(sensor);
+            tankVolumes.append(0.0);
+        }
     }
 
     // Cylinders in gas-slot order; the FIT gas index maps onto the cylinder index
@@ -259,18 +309,16 @@ DiveData *FitParser::buildDive(const QList<FitMessage> &messages, const Metadata
 
     const bool isCcr = (meta.subSport == 63);
     dive->setDiveMode(isCcr ? DiveData::ClosedCircuit : DiveData::OpenCircuit);
-    dive->setStartTime(QDateTime::fromSecsSinceEpoch(
-        FIT_EPOCH_OFFSET + meta.startFit + meta.timeOffset, QTimeZone::utc()));
+    dive->setStartTime(startDateTime(meta));
     dive->setDiveNumber(meta.diveNumber);
     dive->setDiveName(meta.diveNumber > 0 ? QStringLiteral("Dive #%1").arg(meta.diveNumber)
                                           : QStringLiteral("Garmin Dive"));
     if (meta.meanDepth >= 0.0) {
         dive->setMeanDepth(meta.meanDepth);
     }
-    if (meta.hasPosition && (meta.latitude != 0.0 || meta.longitude != 0.0)) {
-        dive->setLocation(QStringLiteral("%1, %2")
-                              .arg(QString::number(meta.latitude, 'f', 6),
-                                   QString::number(meta.longitude, 'f', 6)));
+    const QString position = formatPosition(meta);
+    if (!position.isEmpty()) {
+        dive->setLocation(position);
     }
     for (const CylinderInfo &cylinder : meta.cylinders) {
         dive->addCylinder(cylinder);
@@ -331,9 +379,15 @@ DiveData *FitParser::buildDive(const QList<FitMessage> &messages, const Metadata
                         currentO2 = meta.cylinders.at(cylinderIndex).o2Percent;
                     }
                 } else if (event == 56 && data >= 24 && data <= 27) {
-                    // Automatic/manual switch to low (24/26) or high (25/27) setpoint
-                    currentSetpoint =
+                    // Automatic/manual switch to low (24/26) or high (25/27)
+                    // setpoint. Hold the previous value when the target is
+                    // unknown (dive_settings missing or partial) rather than
+                    // blanking the PO2 cells for the rest of the dive.
+                    const double target =
                         (data == 24 || data == 26) ? meta.setpointLowBar : meta.setpointHighBar;
+                    if (target > 0.0) {
+                        currentSetpoint = target;
+                    }
                 }
                 break;
             }
@@ -458,15 +512,13 @@ QList<QString> FitParser::listDives(QFile &file, QString &errorOut)
         return result;
     }
 
-    const QDateTime start = QDateTime::fromSecsSinceEpoch(
-        FIT_EPOCH_OFFSET + meta.startFit + meta.timeOffset, QTimeZone::utc());
-    QString entry = QStringLiteral("Dive #%1 - %2")
-                        .arg(meta.diveNumber)
-                        .arg(start.toString(QStringLiteral("yyyy-MM-dd hh:mm")));
-    if (meta.hasPosition && (meta.latitude != 0.0 || meta.longitude != 0.0)) {
-        entry += QStringLiteral(" at %1, %2")
-                     .arg(QString::number(meta.latitude, 'f', 4),
-                          QString::number(meta.longitude, 'f', 4));
+    QString entry =
+        QStringLiteral("Dive #%1 - %2")
+            .arg(meta.diveNumber)
+            .arg(startDateTime(meta).toString(QStringLiteral("yyyy-MM-dd hh:mm:ss")));
+    const QString position = formatPosition(meta);
+    if (!position.isEmpty()) {
+        entry += QStringLiteral(" at ") + position;
     }
     result.append(entry);
     return result;

--- a/src/core/log_parser.cpp
+++ b/src/core/log_parser.cpp
@@ -4,6 +4,7 @@
 #include <QFile>
 #include <QFileInfo>
 
+#include "include/core/format_parsers/fit_parser.h"
 #include "include/core/format_parsers/subsurface_parser.h"
 #include "include/core/format_parsers/uddf_parser.h"
 
@@ -13,6 +14,7 @@ LogParser::LogParser(QObject *parent)
 {
     m_parsers.push_back(std::make_unique<SubsurfaceParser>());
     m_parsers.push_back(std::make_unique<UDDFParser>());
+    m_parsers.push_back(std::make_unique<FitParser>());
 }
 
 LogParser::~LogParser() = default;
@@ -41,7 +43,7 @@ bool LogParser::importFile(const QString &filePath)
     emit busyChanged();
 
     QFile file(filePath);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    if (!file.open(QIODevice::ReadOnly)) {
         m_lastError = tr("Could not open file: %1 - Error: %2").arg(filePath).arg(file.errorString());
         qDebug() << "File open error:" << m_lastError;
         emit errorOccurred(m_lastError);
@@ -103,7 +105,7 @@ bool LogParser::importDive(const QString &filePath, int diveNumber)
     emit busyChanged();
 
     QFile file(filePath);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    if (!file.open(QIODevice::ReadOnly)) {
         m_lastError = tr("Could not open file: %1").arg(file.errorString());
         emit errorOccurred(m_lastError);
         m_busy = false;
@@ -159,7 +161,7 @@ QList<QString> LogParser::getDiveList(const QString &filePath)
     emit busyChanged();
 
     QFile file(filePath);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    if (!file.open(QIODevice::ReadOnly)) {
         m_lastError = tr("Could not open file: %1").arg(file.errorString());
         emit errorOccurred(m_lastError);
         m_busy = false;

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -791,7 +791,7 @@ ApplicationWindow {
     FileDialog {
         id: importDiveLogFileDialog
         title: qsTr("Import Dive Log")
-        nameFilters: ["Dive log files (*.xml *.ssrf *.uddf)", "All files (*)"]
+        nameFilters: ["Dive log files (*.xml *.ssrf *.uddf *.fit)", "All files (*)"]
         onAccepted: {
             console.log("Selected file path:", selectedFile.toString());
             // Use our C++ helper to convert the URL to a local file path

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -24,28 +24,41 @@ Run this before merging any change to the dive log parser. Each row below is a s
 | `Shearwater.uddf` | Loads; depth/temperature populated; comma decimals parsed. CNS appears late in the dive (`<cns>` elements near the end): 65% → 70% at the last sample, `---` before the first report. Mean depth (AVG cell) shows 22.5 m (from `<averagedepth>22.465`). |
 | `Garmin.uddf` | Loads from a different exporter; verifies UDDF dialect handling. |
 
+## Garmin FIT format
+
+| File | Expected |
+|---|---|
+| `2025-12-14-14-17-24.fit` | Dive #98, 2025-12-14 14:17 local, OC deco dive on Lake Geneva (location `46.480629, 6.461355`). ~24.1 m max depth, ~77 min, min temp 10 °C. 2 cylinders (Air + EAN80); GAS cell switches to `EAN80` during the final deco stop. CNS ramps to ~15%, `--` at the very start. AVG cell 14.8 m (from the FIT dive summary). Deco phase: NDL 0 with TTS/ceiling populated (ceiling 3 m). |
+| `2026-01-12-10-40-25.fit` | Dive #104, shallow long dive (~9.6 m max, ~114 min), no GPS → location empty. |
+| Any CCR file from `divelogs_medico_fits.zip` (e.g. `2026-01-25-10-41-00.fit`, dive #114) | `diveMode` resolves to `ClosedCircuit`; 3 cylinders incl. `Air (diluent)` and `EAN50` bailout; PO2 cell shows the active setpoint (0.70 bar). |
+| Non-dive FIT from the zip (e.g. `2026-01-28-05-58-39.fit`) | Clean error: "FIT file does not contain a dive activity", no crash. |
+
+Tank-pod pressures (`TANK_UPDATE`/`SENSOR_PROFILE`) have no coverage in the real samples — they are exercised by a synthesized FIT file (big-endian records, developer fields, compressed timestamps, 2 pods with pressures and volumes, mid-dive gas switch) during development; re-verify with a real Descent T1/T2 log when one becomes available.
+
 ## Format detection
 
 - Rename a UDDF file to `.xml` and import — the file should still load (sniff-based detection, not extension).
 - Rename an SSRF file to `.uddf` — same.
+- Rename a `.fit` file to `.xml` — same (binary sniff on the `.FIT` header signature).
 
 ## Error handling
 
 - Try to import a non-XML file (e.g. an image): expect `errorOccurred` with a useful message, no crash.
+- Truncate a `.fit` file (`head -c 50000 x.fit > cut.fit`) and import: the partial dive loads (salvage) with a warning in the log; a file cut before any samples reports a clean error instead.
 
 ## What gets verified
 
-| Behaviour | SSRF | UDDF |
-|---|---|---|
-| Dive metadata (number, datetime, site name) | ✓ | ✓ |
-| Cylinders with start/end pressure | ✓ | ✓ |
-| Per-sample depth | ✓ | ✓ |
-| Per-sample temperature | Celsius | Kelvin → Celsius |
-| Per-sample tank pressure | bar | Pa → bar (via `<tankpressure>` when exporter provides it) |
-| Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) |
-| Per-sample CNS | `cns='NN%'` attribute | `<cns>` percent element (65.0 = 65 %) |
-| Mean depth (static, AVG cell) | `<depth mean>` in `<divecomputer>` | `<averagedepth>` in `<informationafterdive>` (fallback: time-weighted average of samples) |
-| Max depth (running, MAX cell) | computed from samples (no parsing) — deepest point reached up to the current time | same |
-| Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index |
-| Gas mix (GAS cell) | computed from gas switches + cylinder O2/He (`Air`/`EANxx`/`O2`/`21/35`) | same |
-| Dive mode | inferred from CCR cues | `<divemode kind>` or inferred |
+| Behaviour | SSRF | UDDF | FIT |
+|---|---|---|---|
+| Dive metadata (number, datetime, site name) | ✓ | ✓ | number + local datetime; location = GPS coordinates |
+| Cylinders with start/end pressure | ✓ | ✓ | gases from `dive_gas`, pressures from `tank_summary` (pod) |
+| Per-sample depth | ✓ | ✓ | mm → m |
+| Per-sample temperature | Celsius | Kelvin → Celsius | Celsius |
+| Per-sample tank pressure | bar | Pa → bar (via `<tankpressure>` when exporter provides it) | `tank_update` bar×100 → bar (T1/T2 pods only) |
+| Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) | active setpoint (Descent records no sensor values) |
+| Per-sample CNS | `cns='NN%'` attribute | `<cns>` percent element (65.0 = 65 %) | `record` field 97, percent |
+| Mean depth (static, AVG cell) | `<depth mean>` in `<divecomputer>` | `<averagedepth>` in `<informationafterdive>` (fallback: time-weighted average of samples) | `dive_summary` avg_depth mm → m |
+| Max depth (running, MAX cell) | computed from samples (no parsing) — deepest point reached up to the current time | same | same |
+| Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index | event 57, data = gas slot index |
+| Gas mix (GAS cell) | computed from gas switches + cylinder O2/He (`Air`/`EANxx`/`O2`/`21/35`) | same | same |
+| Dive mode | inferred from CCR cues | `<divemode kind>` or inferred | sub-sport (63 = CCR, 53-57 = OC/gauge/apnea) |

--- a/tests/make_synth_fit.py
+++ b/tests/make_synth_fit.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Synthesize a FIT dive file exercising decoder paths absent from the real
+samples: tank pods, big-endian definitions, compressed timestamps, developer
+fields, and a gas switch."""
+import struct
+
+CRC_TABLE = [0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
+             0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400]
+
+def crc16(data, crc=0):
+    for b in data:
+        tmp = CRC_TABLE[crc & 0xF]
+        crc = (crc >> 4) & 0x0FFF
+        crc = crc ^ tmp ^ CRC_TABLE[b & 0xF]
+        tmp = CRC_TABLE[crc & 0xF]
+        crc = (crc >> 4) & 0x0FFF
+        crc = crc ^ tmp ^ CRC_TABLE[(b >> 4) & 0xF]
+    return crc
+
+BASE = {'enum': (0x00, 'B'), 'u8': (0x02, 'B'), 's8': (0x01, 'b'),
+        'u16': (0x84, 'H'), 's16': (0x83, 'h'), 'u32': (0x86, 'I'),
+        's32': (0x85, 'i'), 'u32z': (0x8C, 'I'), 'string': (0x07, 's')}
+
+def definition(local, global_id, fields, big_endian=False, dev_fields=None):
+    """fields: list of (field_num, base_key) or (field_num, base_key, size)"""
+    header = 0x40 | local
+    if dev_fields:
+        header |= 0x20
+    out = bytes([header, 0, 1 if big_endian else 0])
+    out += struct.pack('>H' if big_endian else '<H', global_id)
+    out += bytes([len(fields)])
+    for f in fields:
+        num, key = f[0], f[1]
+        base, fmt = BASE[key]
+        size = f[2] if len(f) > 2 else struct.calcsize(fmt)
+        out += bytes([num, size, base])
+    if dev_fields:
+        out += bytes([len(dev_fields)])
+        for num, size, idx in dev_fields:
+            out += bytes([num, size, idx])
+    return out
+
+def data(local, fields, big_endian=False, dev_bytes=b''):
+    out = bytes([local])
+    endian = '>' if big_endian else '<'
+    for key, value in fields:
+        fmt = BASE[key][1]
+        out += struct.pack(endian + fmt, value)
+    return out + dev_bytes
+
+def compressed(local, time_offset, fields, big_endian=False):
+    out = bytes([0x80 | (local << 5) | time_offset])
+    endian = '>' if big_endian else '<'
+    for key, value in fields:
+        out += struct.pack(endian + BASE[key][1], value)
+    return out
+
+START = 1100000000  # FIT epoch seconds
+records = b''
+
+# Sport: sub-sport 54 (multi-gas dive)
+records += definition(0, 12, [(1, 'enum')])
+records += data(0, [('enum', 54)])
+
+# Two gases: message_index 254, o2 field 1, he field 0, status 2, type 3
+records += definition(1, 259, [(254, 'u16'), (1, 'u8'), (0, 'u8'), (2, 'enum'), (3, 'enum')])
+records += data(1, [('u16', 0), ('u8', 21), ('u8', 0), ('enum', 1), ('enum', 0)])
+records += data(1, [('u16', 1), ('u8', 50), ('u8', 0), ('enum', 1), ('enum', 0)])
+
+# Two tank pods: sensor id field 0 (u32z), type field 52 (28=pod), units 74 (2=bar), volume 77 (L*10)
+records += definition(2, 147, [(0, 'u32z'), (52, 'enum'), (74, 'enum'), (77, 'u16')])
+records += data(2, [('u32z', 1111), ('enum', 28), ('enum', 2), ('u16', 120)])
+records += data(2, [('u32z', 2222), ('enum', 28), ('enum', 2), ('u16', 100)])
+
+# RECORD definition: BIG-ENDIAN, with one developer field (3 bytes) to skip.
+# timestamp 253, depth 92 (mm u32), temp 13 (s8), ndl 96 (u32 s), cns 97 (u8)
+records += definition(3, 20, [(253, 'u32'), (92, 'u32'), (13, 's8'), (96, 'u32'), (97, 'u8')],
+                      big_endian=True, dev_fields=[(0, 3, 0)])
+
+# TANK_UPDATE definition (little-endian): timestamp, sensor, pressure bar*100
+records += definition(4, 319, [(253, 'u32'), (0, 'u32z'), (1, 'u16')])
+# EVENT definition: timestamp, event 0, data 3
+records += definition(5, 21, [(253, 'u32'), (0, 'enum'), (3, 'u32')])
+
+def record(ts, depth_mm, temp, ndl_s, cns):
+    return data(3, [('u32', ts), ('u32', depth_mm), ('s8', temp), ('u32', ndl_s), ('u8', cns)],
+                big_endian=True, dev_bytes=b'\xAA\xBB\xCC')
+
+# Pre-dive-start gas switch event (should clamp to t=0, dive starts on gas 0 anyway)
+records += data(5, [('u32', START - 2), ('enum', 57), ('u32', 0)])
+
+# Dive samples: 0..9 s, descending, tank updates interleaved
+records += record(START + 0, 1000, 19, 3000, 0)
+records += data(4, [('u32', START + 1), ('u32z', 1111), ('u16', 20050)])  # 200.5 bar
+records += data(4, [('u32', START + 1), ('u32z', 2222), ('u16', 18000)])  # 180.0 bar
+records += record(START + 1, 5000, 19, 2900, 0)
+# Compressed-timestamp records on local type 1 slot? Compressed local is 2 bits (0-3):
+# reuse local 3 (RECORD) via compressed header (local 3 fits in 2 bits)
+records += compressed(3, (START + 2) & 0x1F,
+                      [('u32', START + 2), ('u32', 10000), ('s8', 18), ('u32', 2500), ('u8', 1)],
+                      big_endian=True)[:1] + \
+           struct.pack('>IIbIB', START + 2, 10000, 18, 2500, 1) + b'\xAA\xBB\xCC'
+records += record(START + 3, 15000, 18, 2000, 1)
+# Gas switch to gas index 1 (EAN50) at t=5
+records += data(5, [('u32', START + 5), ('enum', 57), ('u32', 1)])
+records += data(4, [('u32', START + 5), ('u32z', 1111), ('u16', 19000)])  # 190.0 bar
+records += record(START + 5, 20000, 18, 1500, 2)
+records += record(START + 7, 12000, 18, 1800, 2)
+records += record(START + 9, 2000, 19, 3000, 3)
+
+# TANK_SUMMARY: sensor, start, end (bar*100)
+records += definition(6, 323, [(253, 'u32'), (0, 'u32z'), (1, 'u16'), (2, 'u16')])
+records += data(6, [('u32', START + 10), ('u32z', 1111), ('u16', 20050), ('u16', 18500)])
+records += data(6, [('u32', START + 10), ('u32z', 2222), ('u16', 18000), ('u16', 17500)])
+
+# DIVE_SUMMARY: timestamp, dive number field 10, avg depth field 2 (mm)
+records += definition(7, 268, [(253, 'u32'), (10, 'u32'), (2, 'u32')])
+records += data(7, [('u32', START + 10), ('u32', 42), ('u32', 10500)])
+
+# SESSION at the end (like real files): start_time 2, lat 3, lon 4
+records += definition(8, 18, [(253, 'u32'), (2, 'u32'), (3, 's32'), (4, 's32')])
+records += data(8, [('u32', START + 10), ('u32', START),
+                    ('s32', int(46.5 / 180 * 2**31)), ('s32', int(6.5 / 180 * 2**31))])
+
+# ACTIVITY: local_timestamp field 5 = timestamp + 3600 (UTC+1)
+records += definition(9, 34, [(253, 'u32'), (5, 'u32')])
+records += data(9, [('u32', START + 10), ('u32', START + 10 + 3600)])
+
+header = struct.pack('<BBHI4s', 14, 0x20, 2195, len(records), b'.FIT')
+header += struct.pack('<H', crc16(header))
+payload = header + records
+payload += struct.pack('<H', crc16(payload))
+
+with open('synth_dive.fit', 'wb') as f:
+    f.write(payload)
+print(f"wrote synth_dive.fit ({len(payload)} bytes)")


### PR DESCRIPTION
Adds native .fit file support as a third dive log format, implemented as
a clean-room, purpose-built decoder — no Garmin SDK code (its license is
incompatible with GPLv2). Message and field numbers are protocol facts
from public format documentation.

- FitDecoder: generic FIT wire-format decoder (header + CRC-16, definition/data records, per-definition endianness, compressed timestamps, developer-field skipping, invalid-value sentinels). Truncated files are salvaged when they contain usable samples.
- FitParser: dive semantics on top of the decoder. Maps depth, temperature, NDL/TTS/ceiling, CNS, gas mixes and switches, tank pod pressures (T1/T2), mean depth, CCR setpoint (as PO2 channel 0), GPS coordinates, and the device's local-time offset.
- LogParser: drop QIODevice::Text from the open() calls — it corrupts binary formats through CRLF translation (harmless change for the XML parsers).
- Import dialog now lists *.fit; detection remains content-sniff based (".FIT" header signature).
- tests/make_synth_fit.py synthesizes a FIT file covering paths absent from the real samples (big-endian records, developer fields, compressed timestamps, tank pods, mid-dive gas switch).

Verified against 22 real Descent dive logs (OC, deco, CCR) plus non-dive, truncated, and corrupt inputs; SSRF/UDDF regression checked.


Fixes #52