### PR TITLE
test: add a unit test suite for the core dive log logic.

### DIFF
--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -291,9 +291,10 @@ DiveDataPoint DiveData::dataAtTime(double time) const
     
     // For in_deco state, we also shouldn't interpolate (though it's not part of DiveDataPoint directly)
     
-    // Interpolate all tank pressures
-    // Get the maximum number of tanks between both points
-    int maxTanks = qMax(prev.tankCount(), next.tankCount());
+    // Interpolate all tank pressures. Cover every known cylinder, not just
+    // the channels present in the samples — a dive with no per-sample
+    // pressures (manually entered log) still displays the start/end ramp.
+    int maxTanks = qMax(qMax(prev.tankCount(), next.tankCount()), cylinderCount());
     for (int i = 0; i < maxTanks; i++) {
         double pressure = 0.0;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Unit tests (enable with -DUNABARA_BUILD_TESTS=ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Test)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# The synthetic FIT fixture is deterministic — regenerate it at build time so
+# tests and generator can never drift apart
+set(SYNTH_FIT "${CMAKE_CURRENT_BINARY_DIR}/synth_dive.fit")
+add_custom_command(
+    OUTPUT "${SYNTH_FIT}"
+    COMMAND Python3::Interpreter "${CMAKE_CURRENT_SOURCE_DIR}/make_synth_fit.py" "${SYNTH_FIT}"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/make_synth_fit.py"
+    COMMENT "Generating synthetic FIT fixture")
+add_custom_target(unabara_test_fixtures DEPENDS "${SYNTH_FIT}")
+
+# Core sources under test, built once and shared by all test executables.
+# Q_OBJECT headers must be listed so AUTOMOC finds them (they live in
+# include/, not next to their .cpp — same pattern as the main target).
+add_library(unabara_testlib STATIC
+    ${CMAKE_SOURCE_DIR}/include/core/dive_data.h
+    ${CMAKE_SOURCE_DIR}/include/core/log_parser.h
+    ${CMAKE_SOURCE_DIR}/include/core/units.h
+    ${CMAKE_SOURCE_DIR}/src/core/cell_data.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/dive_data.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/log_parser.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/units.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/format_parsers/fit_decoder.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/format_parsers/fit_parser.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/format_parsers/subsurface_parser.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/format_parsers/uddf_parser.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/format_parsers/parse_utils.cpp
+)
+target_include_directories(unabara_testlib PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(unabara_testlib PUBLIC Qt6::Core Qt6::Gui)
+
+function(unabara_add_test NAME)
+    add_executable(${NAME} ${NAME}.cpp)
+    target_link_libraries(${NAME} PRIVATE unabara_testlib Qt6::Test)
+    target_compile_definitions(${NAME} PRIVATE
+        SYNTH_FIT_PATH="${SYNTH_FIT}"
+        TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
+    add_dependencies(${NAME} unabara_test_fixtures)
+    add_test(NAME ${NAME} COMMAND ${NAME})
+    # QFont/QColor tests need a QGuiApplication; keep it headless
+    set_tests_properties(${NAME} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endfunction()
+
+unabara_add_test(fit_parser_test)
+unabara_add_test(dive_data_test)
+unabara_add_test(subsurface_parser_test)
+unabara_add_test(uddf_parser_test)
+unabara_add_test(core_utils_test)
+unabara_add_test(cell_data_test)

--- a/tests/cell_data_test.cpp
+++ b/tests/cell_data_test.cpp
@@ -1,0 +1,75 @@
+// Tests for CellData: template (.utp) JSON serialization round-trips and the
+// CellType string mapping every template file depends on.
+
+#include <QtTest>
+
+#include <QFont>
+#include <QJsonObject>
+
+#include "include/core/cell_data.h"
+
+using Unabara::CellData;
+using Unabara::CellType;
+
+class CellDataTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void cellTypeStringRoundTrip()
+    {
+        const QList<CellType> all = {
+            CellType::Depth,    CellType::Temperature, CellType::Time,
+            CellType::NDL,      CellType::TTS,         CellType::Pressure,
+            CellType::PO2Cell1, CellType::PO2Cell2,    CellType::PO2Cell3,
+            CellType::CompositePO2, CellType::CNS,
+        };
+        for (CellType type : all) {
+            const QString str = CellData::cellTypeToString(type);
+            QVERIFY2(!str.isEmpty(), "empty type string");
+            QCOMPARE(CellData::cellTypeFromString(str), type);
+        }
+        // Unknown strings (e.g. from a newer template) degrade gracefully
+        QCOMPARE(CellData::cellTypeFromString(QStringLiteral("FutureCell")),
+                 CellType::Unknown);
+    }
+
+    void jsonRoundTripPreservesCell()
+    {
+        CellData cell(QStringLiteral("tank_1"), CellType::Pressure);
+        cell.setPosition(QPointF(0.25, 0.75));
+        cell.setVisible(false);
+        cell.setTankIndex(1);
+        cell.setShowLabel(false);
+        QFont font(QStringLiteral("Monospace"), 18);
+        font.setBold(true);
+        cell.setFont(font, true);
+        cell.setTextColor(QColor(255, 128, 0), true);
+
+        const CellData restored = CellData::fromJson(cell.toJson());
+        QCOMPARE(restored.cellId(), QStringLiteral("tank_1"));
+        QCOMPARE(restored.cellType(), CellType::Pressure);
+        QCOMPARE(restored.position(), QPointF(0.25, 0.75));
+        QCOMPARE(restored.visible(), false);
+        QCOMPARE(restored.tankIndex(), 1);
+        QCOMPARE(restored.showLabel(), false);
+        QCOMPARE(restored.font().family(), QStringLiteral("Monospace"));
+        QCOMPARE(restored.font().pointSize(), 18);
+        QVERIFY(restored.font().bold());
+        QCOMPARE(restored.textColor(), QColor(255, 128, 0));
+    }
+
+    void jsonDefaultsSurviveMinimalInput()
+    {
+        // A minimal cell (no custom font/color) must round-trip without
+        // inventing custom styling
+        CellData cell(QStringLiteral("depth"), CellType::Depth);
+        const CellData restored = CellData::fromJson(cell.toJson());
+        QCOMPARE(restored.cellId(), QStringLiteral("depth"));
+        QCOMPARE(restored.cellType(), CellType::Depth);
+        QCOMPARE(restored.visible(), true);
+    }
+};
+
+QTEST_MAIN(CellDataTest)
+#include "cell_data_test.moc"

--- a/tests/core_utils_test.cpp
+++ b/tests/core_utils_test.cpp
@@ -1,0 +1,84 @@
+// Tests for parse_utils (shared parsing helpers) and Units (display
+// formatting and unit conversions).
+
+#include <QtTest>
+
+#include <cmath>
+
+#include "include/core/format_parsers/parse_utils.h"
+#include "include/core/units.h"
+
+class CoreUtilsTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // ---- parse_utils ----
+
+    void parseLocaleDoubleAcceptsBothSeparators()
+    {
+        QCOMPARE(parse_utils::parseLocaleDouble(u"2.1"), 2.1);
+        QCOMPARE(parse_utils::parseLocaleDouble(u"2,1"), 2.1);
+        QCOMPARE(parse_utils::parseLocaleDouble(u"-3,5"), -3.5);
+        QCOMPARE(parse_utils::parseLocaleDouble(u"120"), 120.0);
+        QVERIFY(std::isnan(parse_utils::parseLocaleDouble(u"abc")));
+        QVERIFY(std::isnan(parse_utils::parseLocaleDouble(u"")));
+    }
+
+    void parseISO8601Variants()
+    {
+        const QDateTime plain = parse_utils::parseISO8601(u"2026-02-28T11:04:56");
+        QVERIFY(plain.isValid());
+        QCOMPARE(plain.toString(QStringLiteral("yyyy-MM-dd hh:mm:ss")),
+                 QStringLiteral("2026-02-28 11:04:56"));
+
+        const QDateTime zulu = parse_utils::parseISO8601(u"2026-02-28T11:04:56Z");
+        QVERIFY(zulu.isValid());
+        const QDateTime offset = parse_utils::parseISO8601(u"2026-02-28T13:04:56+02:00");
+        QVERIFY(offset.isValid());
+        // Same instant expressed two ways
+        QCOMPARE(offset.toUTC(), zulu.toUTC());
+
+        QVERIFY(!parse_utils::parseISO8601(u"not a date").isValid());
+    }
+
+    void unitConversionHelpers()
+    {
+        QCOMPARE(parse_utils::kelvinToCelsius(273.15), 0.0);
+        QCOMPARE(parse_utils::kelvinToCelsius(297.15), 24.0);
+        QCOMPARE(parse_utils::pascalToBar(100000.0), 1.0);
+        QCOMPARE(parse_utils::pascalToBar(20050000.0), 200.5);
+    }
+
+    // ---- Units ----
+
+    void gasMixNames()
+    {
+        QCOMPARE(Units::formatGasMix(21.0, 0.0), QStringLiteral("Air"));
+        QCOMPARE(Units::formatGasMix(20.9, 0.0), QStringLiteral("Air")); // rounds
+        QCOMPARE(Units::formatGasMix(32.0, 0.0), QStringLiteral("EAN32"));
+        QCOMPARE(Units::formatGasMix(100.0, 0.0), QStringLiteral("O2"));
+        QCOMPARE(Units::formatGasMix(18.0, 45.0), QStringLiteral("18/45"));
+    }
+
+    void metricImperialConversions()
+    {
+        QVERIFY(qAbs(Units::metersToFeet(10.0) - 32.8084) < 0.001);
+        QVERIFY(qAbs(Units::feetToMeters(Units::metersToFeet(12.3)) - 12.3) < 1e-9);
+        QCOMPARE(Units::celsiusToFahrenheit(0.0), 32.0);
+        QCOMPARE(Units::fahrenheitToCelsius(212.0), 100.0);
+        QVERIFY(qAbs(Units::barToPsi(1.0) - 14.5038) < 0.001);
+        QVERIFY(qAbs(Units::psiToBar(Units::barToPsi(200.0)) - 200.0) < 1e-9);
+    }
+
+    void formattedValues()
+    {
+        QCOMPARE(Units::formatDepth(18.04, Units::UnitSystem::Metric),
+                 QStringLiteral("18.0"));
+        QCOMPARE(Units::formatDepth(10.0, Units::UnitSystem::Imperial),
+                 QStringLiteral("32.8"));
+    }
+};
+
+QTEST_GUILESS_MAIN(CoreUtilsTest)
+#include "core_utils_test.moc"

--- a/tests/dive_data_test.cpp
+++ b/tests/dive_data_test.cpp
@@ -1,0 +1,179 @@
+// Tests for the DiveData model: interpolation semantics, gas switch
+// resolution, and derived values. These encode the display contracts the
+// overlay generator relies on.
+
+#include <QtTest>
+
+#include "include/core/dive_data.h"
+
+namespace {
+
+DiveDataPoint point(double t, double depth)
+{
+    DiveDataPoint p;
+    p.timestamp = t;
+    p.depth = depth;
+    return p;
+}
+
+} // namespace
+
+class DiveDataTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void interpolatesBetweenPoints()
+    {
+        DiveData d;
+        d.addDataPoint(point(0.0, 10.0));
+        d.addDataPoint(point(10.0, 20.0));
+
+        QCOMPARE(d.dataAtTime(5.0).depth, 15.0);
+        // Clamped outside the recorded range
+        QCOMPARE(d.dataAtTime(-1.0).depth, 10.0);
+        QCOMPARE(d.dataAtTime(99.0).depth, 20.0);
+        QCOMPARE(d.durationSeconds(), 10);
+    }
+
+    void addDataPointKeepsOrder()
+    {
+        DiveData d;
+        d.addDataPoint(point(5.0, 2.0));
+        d.addDataPoint(point(0.0, 1.0));
+        d.addDataPoint(point(10.0, 3.0));
+
+        const auto &pts = d.allDataPoints();
+        QCOMPARE(pts.size(), 3);
+        QCOMPARE(pts[0].timestamp, 0.0);
+        QCOMPARE(pts[1].timestamp, 5.0);
+        QCOMPARE(pts[2].timestamp, 10.0);
+    }
+
+    void ceilingIsNotInterpolated()
+    {
+        // Ceiling is a state that persists until changed — blending two stop
+        // depths would display a stop that never existed
+        DiveData d;
+        DiveDataPoint a = point(0.0, 30.0);
+        a.ceiling = 6.0;
+        DiveDataPoint b = point(10.0, 28.0);
+        b.ceiling = 3.0;
+        d.addDataPoint(a);
+        d.addDataPoint(b);
+
+        QCOMPARE(d.dataAtTime(5.0).ceiling, 6.0);
+    }
+
+    void cnsSentinelDoesNotBlend()
+    {
+        // -1 means "no data"; interpolating across it would fabricate values
+        DiveData d;
+        DiveDataPoint a = point(0.0, 10.0); // cns defaults to -1
+        DiveDataPoint b = point(10.0, 10.0);
+        b.cns = 10.0;
+        d.addDataPoint(a);
+        d.addDataPoint(b);
+        QCOMPARE(d.dataAtTime(5.0).cns, -1.0);
+
+        DiveData e;
+        DiveDataPoint c = point(0.0, 10.0);
+        c.cns = 10.0;
+        DiveDataPoint f = point(10.0, 10.0);
+        f.cns = 20.0;
+        e.addDataPoint(c);
+        e.addDataPoint(f);
+        QCOMPARE(e.dataAtTime(5.0).cns, 15.0);
+    }
+
+    void pressurePrefersRecordedSamples()
+    {
+        // With real samples on the channel, the cylinder start/end ramp must
+        // not override them
+        DiveData d;
+        CylinderInfo cyl;
+        cyl.startPressure = 200.0;
+        cyl.endPressure = 100.0; // ramp midpoint would be 150
+        d.addCylinder(cyl);
+
+        DiveDataPoint a = point(0.0, 10.0);
+        a.addPressure(200.0, 0);
+        DiveDataPoint b = point(10.0, 10.0);
+        b.addPressure(190.0, 0);
+        d.addDataPoint(a);
+        d.addDataPoint(b);
+
+        QCOMPARE(d.dataAtTime(5.0).getPressure(0), 195.0);
+    }
+
+    void pressureFallsBackToCylinderRamp()
+    {
+        // No per-sample pressures: the start/end linear ramp is the fallback
+        DiveData d;
+        CylinderInfo cyl;
+        cyl.startPressure = 200.0;
+        cyl.endPressure = 100.0;
+        d.addCylinder(cyl);
+
+        d.addDataPoint(point(0.0, 10.0));
+        d.addDataPoint(point(10.0, 10.0));
+
+        QCOMPARE(d.dataAtTime(5.0).getPressure(0), 150.0);
+    }
+
+    void gasSwitchesResolveDeterministically()
+    {
+        DiveData d;
+        d.addCylinder(CylinderInfo());
+        d.addCylinder(CylinderInfo());
+        d.addDataPoint(point(0.0, 10.0));
+        d.addDataPoint(point(600.0, 10.0));
+
+        // Two switches clamped to the same instant: the last added wins
+        d.addGasSwitch(0.0, 0);
+        d.addGasSwitch(0.0, 1);
+        QCOMPARE(d.activeCylinderAtTime(0.0), 1);
+
+        d.addGasSwitch(300.0, 0);
+        QCOMPARE(d.activeCylinderAtTime(200.0), 1);
+        QCOMPARE(d.activeCylinderAtTime(400.0), 0);
+    }
+
+    void gasSwitchRejectsInvalidCylinder()
+    {
+        DiveData d;
+        d.addCylinder(CylinderInfo());
+        d.addGasSwitch(0.0, 5); // out of range: ignored
+        QCOMPARE(d.activeCylinderAtTime(10.0), 0);
+    }
+
+    void maxDepthUntilTracksRunningMaximum()
+    {
+        DiveData d;
+        d.addDataPoint(point(0.0, 10.0));
+        d.addDataPoint(point(10.0, 20.0));
+        d.addDataPoint(point(20.0, 15.0));
+
+        QCOMPARE(d.maxDepth(), 20.0);
+        // Includes the interpolated depth at the query time (15 m at t=5)
+        QCOMPARE(d.maxDepthUntil(5.0), 15.0);
+        QCOMPARE(d.maxDepthUntil(10.0), 20.0);
+        QCOMPARE(d.maxDepthUntil(20.0), 20.0);
+    }
+
+    void meanDepthExplicitBeatsDerived()
+    {
+        DiveData d;
+        d.addDataPoint(point(0.0, 0.0));
+        d.addDataPoint(point(10.0, 10.0));
+
+        // Unset: time-weighted average of the profile
+        QCOMPARE(d.meanDepth(), 5.0);
+        // A log-reported average (e.g. FIT DIVE_SUMMARY) takes precedence
+        d.setMeanDepth(12.5);
+        QCOMPARE(d.meanDepth(), 12.5);
+    }
+};
+
+QTEST_GUILESS_MAIN(DiveDataTest)
+#include "dive_data_test.moc"

--- a/tests/fit_parser_test.cpp
+++ b/tests/fit_parser_test.cpp
@@ -1,0 +1,446 @@
+// Unit tests for the dive log parsers, centered on the Garmin FIT importer.
+//
+// Fixtures:
+//  - SYNTH_FIT_PATH: deterministic file from make_synth_fit.py (generated at
+//    build time), covering big-endian records, compressed timestamps,
+//    developer fields, tank pods, and a gas switch.
+//  - TEST_DATA_DIR: local sample logs (untracked). Tests that need them
+//    QSKIP when the files are absent, so the suite is CI-safe.
+
+#include <QtTest>
+
+#include "include/core/dive_data.h"
+#include "include/core/format_parsers/fit_decoder.h"
+#include "include/core/format_parsers/fit_parser.h"
+#include "include/core/format_parsers/subsurface_parser.h"
+#include "include/core/format_parsers/uddf_parser.h"
+
+namespace {
+
+// The synthetic dive's ground truth (see make_synth_fit.py)
+constexpr qint64 kSynthStartEpoch = 631065600 + 1100000000; // 2024-11-08T11:33:20Z
+constexpr int kSynthUtcOffset = 3600;                       // ACTIVITY says UTC+1
+
+QByteArray readAll(const QString &path)
+{
+    QFile f(path);
+    return f.open(QIODevice::ReadOnly) ? f.readAll() : QByteArray();
+}
+
+QList<DiveData *> parseBytes(const QByteArray &bytes, QString &err)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write(bytes);
+    tmp.flush();
+    tmp.seek(0);
+    FitParser parser;
+    return parser.parse(tmp, -1, err);
+}
+
+// Minimal in-memory FIT builder for malformed/edge-case streams the Python
+// generator does not produce. Little-endian only.
+class FitBuilder
+{
+public:
+    // fields: {fieldNum, size, baseType}
+    void definition(quint8 local, quint16 globalId,
+                    const QVector<std::array<quint8, 3>> &fields)
+    {
+        m_records.append(char(0x40 | local));
+        m_records.append('\0');
+        m_records.append('\0'); // little-endian
+        m_records.append(char(globalId & 0xFF));
+        m_records.append(char(globalId >> 8));
+        m_records.append(char(fields.size()));
+        for (const auto &f : fields) {
+            m_records.append(char(f[0]));
+            m_records.append(char(f[1]));
+            m_records.append(char(f[2]));
+        }
+    }
+
+    void dataRecord(quint8 local, const QByteArray &payload)
+    {
+        m_records.append(char(local));
+        m_records.append(payload);
+    }
+
+    static QByteArray u32(quint32 v)
+    {
+        QByteArray out;
+        for (int i = 0; i < 4; ++i) {
+            out.append(char((v >> (8 * i)) & 0xFF));
+        }
+        return out;
+    }
+
+    QByteArray build() const
+    {
+        QByteArray header(12, '\0');
+        header[0] = 12; // 12-byte header, no header CRC
+        header[1] = 0x20;
+        const quint32 size = static_cast<quint32>(m_records.size());
+        for (int i = 0; i < 4; ++i) {
+            header[4 + i] = char((size >> (8 * i)) & 0xFF);
+        }
+        header.replace(8, 4, ".FIT");
+        QByteArray payload = header + m_records;
+        const quint16 crc = FitDecoder::crc16(
+            reinterpret_cast<const uchar *>(payload.constData()), payload.size());
+        payload.append(char(crc & 0xFF));
+        payload.append(char(crc >> 8));
+        return payload;
+    }
+
+private:
+    QByteArray m_records;
+};
+
+} // namespace
+
+class FitParserTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QByteArray m_synthBytes;
+
+    QList<DiveData *> parseSynth(QString &err)
+    {
+        return parseBytes(m_synthBytes, err);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        m_synthBytes = readAll(QStringLiteral(SYNTH_FIT_PATH));
+        QVERIFY2(!m_synthBytes.isEmpty(), "synthetic fixture missing — build error");
+    }
+
+    // ---- Wire-level ----
+
+    void sniffAcceptsFit()
+    {
+        QTemporaryFile tmp;
+        tmp.open();
+        tmp.write(m_synthBytes);
+        tmp.flush();
+        tmp.seek(3); // sniff must work from any position and restore it
+        QVERIFY(FitDecoder::sniff(&tmp));
+        QCOMPARE(tmp.pos(), qint64(3));
+    }
+
+    void sniffRejectsOthers()
+    {
+        QTemporaryFile tmp;
+        tmp.open();
+        tmp.write(QByteArrayLiteral("<?xml version=\"1.0\"?><divelog></divelog>"));
+        tmp.flush();
+        tmp.seek(0);
+        QVERIFY(!FitDecoder::sniff(&tmp));
+
+        QTemporaryFile small;
+        small.open();
+        small.write(QByteArrayLiteral("short"));
+        small.flush();
+        small.seek(0);
+        QVERIFY(!FitDecoder::sniff(&small));
+    }
+
+    // ---- Synthetic dive: full pipeline ----
+
+    void synthMetadata()
+    {
+        QString err;
+        auto dives = parseSynth(err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+
+        QCOMPARE(d->diveNumber(), 42);
+        QCOMPARE(d->diveMode(), DiveData::OpenCircuit);
+        QCOMPARE(d->durationSeconds(), 9);
+        QCOMPARE(d->maxDepth(), 20.0);
+        QCOMPARE(d->minTemperature(), 18.0);
+        QCOMPARE(d->meanDepth(), 10.5); // from DIVE_SUMMARY avg_depth
+        QCOMPARE(d->location(), QStringLiteral("46.500000, 6.500000"));
+        qDeleteAll(dives);
+    }
+
+    void synthStartTime()
+    {
+        QString err;
+        auto dives = parseSynth(err);
+        QCOMPARE(dives.size(), 1);
+        const QDateTime start = dives.first()->startTime();
+
+        // The epoch must be the true UTC instant (video sync depends on it)...
+        QCOMPARE(start.toSecsSinceEpoch(), kSynthStartEpoch);
+        // ...while the displayed wall clock matches the watch (UTC+1)
+        QCOMPARE(start.offsetFromUtc(), kSynthUtcOffset);
+        QCOMPARE(start.toString(QStringLiteral("yyyy-MM-dd hh:mm:ss")),
+                 QStringLiteral("2024-11-08 12:33:20"));
+        qDeleteAll(dives);
+    }
+
+    void synthCylinders()
+    {
+        QString err;
+        auto dives = parseSynth(err);
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+
+        QCOMPARE(d->cylinderCount(), 2);
+        const CylinderInfo &air = d->cylinderInfo(0);
+        QCOMPARE(air.o2Percent, 21.0);
+        QCOMPARE(air.size, 12.0);
+        QCOMPARE(air.startPressure, 200.5);
+        QCOMPARE(air.endPressure, 185.0);
+
+        const CylinderInfo &ean = d->cylinderInfo(1);
+        QCOMPARE(ean.o2Percent, 50.0);
+        QCOMPARE(ean.size, 10.0);
+        QCOMPARE(ean.startPressure, 180.0);
+        QCOMPARE(ean.endPressure, 175.0);
+        QVERIFY(ean.description.contains(QStringLiteral("50")));
+        qDeleteAll(dives);
+    }
+
+    void synthSamples()
+    {
+        QString err;
+        auto dives = parseSynth(err);
+        QCOMPARE(dives.size(), 1);
+        const auto &points = dives.first()->allDataPoints();
+        QCOMPARE(points.size(), 7);
+
+        // t=0: surface, no tank data yet
+        QCOMPARE(points[0].timestamp, 0.0);
+        QCOMPARE(points[0].depth, 1.0);
+        QCOMPARE(points[0].temperature, 19.0);
+        QCOMPARE(points[0].ndl, 50.0);
+        QCOMPARE(points[0].cns, 0.0);
+        QCOMPARE(points[0].tankCount(), 0);
+
+        // t=2 came in via a compressed-timestamp record
+        QCOMPARE(points[2].timestamp, 2.0);
+        QCOMPARE(points[2].depth, 10.0);
+
+        // t=3: big-endian record; pressures carried from the t=1 tank updates
+        QCOMPARE(points[3].timestamp, 3.0);
+        QCOMPARE(points[3].depth, 15.0);
+        QVERIFY(qFuzzyCompare(points[3].ndl, 2000.0 / 60.0));
+        QCOMPARE(points[3].cns, 1.0);
+        QCOMPARE(points[3].getPressure(0), 200.5);
+        QCOMPARE(points[3].getPressure(1), 180.0);
+
+        // t=9: after the gas switch to EAN50
+        QCOMPARE(points[6].timestamp, 9.0);
+        QCOMPARE(points[6].depth, 2.0);
+        QCOMPARE(points[6].cns, 3.0);
+        QCOMPARE(points[6].o2percent, 50.0);
+        QCOMPARE(points[6].getPressure(0), 190.0);
+        qDeleteAll(dives);
+    }
+
+    void synthGasSwitches()
+    {
+        QString err;
+        auto dives = parseSynth(err);
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+
+        // Pre-start switch clamps to t=0 on gas 0; switch to EAN50 at t=5
+        QCOMPARE(d->activeCylinderAtTime(0.0), 0);
+        QCOMPARE(d->activeCylinderAtTime(4.0), 0);
+        QCOMPARE(d->activeCylinderAtTime(5.0), 1);
+        QCOMPARE(d->activeCylinderAtTime(9.0), 1);
+        qDeleteAll(dives);
+    }
+
+    void synthListDives()
+    {
+        QTemporaryFile tmp;
+        tmp.open();
+        tmp.write(m_synthBytes);
+        tmp.flush();
+        FitParser parser;
+        QString err;
+        const QList<QString> entries = parser.listDives(tmp, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(entries.size(), 1);
+        QCOMPARE(entries.first(),
+                 QStringLiteral("Dive #42 - 2024-11-08 12:33:20 at 46.500000, 6.500000"));
+    }
+
+    void pressureInterpolationPrefersSamples()
+    {
+        QString err;
+        auto dives = parseSynth(err);
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+
+        // Between the t=1 (200.5) and t=5 (190.0) tank updates the value must
+        // follow the recorded samples, not the TANK_SUMMARY 200.5->185 ramp
+        QCOMPARE(d->dataAtTime(4.0).getPressure(0), 195.25);
+        // After the last update the recorded value holds; the summary ramp
+        // would drift toward 185
+        QCOMPARE(d->dataAtTime(6.0).getPressure(0), 190.0);
+        QCOMPARE(d->dataAtTime(8.0).getPressure(0), 190.0);
+        // Pod 2 never updates after t=1: constant samples, constant display
+        QCOMPARE(d->dataAtTime(6.0).getPressure(1), 180.0);
+        qDeleteAll(dives);
+    }
+
+    // ---- Robustness ----
+
+    void truncatedFileSalvages()
+    {
+        // Drop the tail (summary/session/activity + some records); enough
+        // depth records must remain for the salvage rule to accept it
+        QString err;
+        auto dives = parseBytes(m_synthBytes.left(m_synthBytes.size() * 2 / 3), err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        QVERIFY(dives.first()->allDataPoints().size() >= 2);
+        qDeleteAll(dives);
+    }
+
+    void zeroDataSizeSalvages()
+    {
+        // Crash-recovered files: header written before data, dataSize never
+        // backfilled. The decoder must fall back to end-of-file.
+        QByteArray bytes = m_synthBytes;
+        bytes[4] = bytes[5] = bytes[6] = bytes[7] = '\0';
+        QString err;
+        auto dives = parseBytes(bytes, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        QCOMPARE(dives.first()->allDataPoints().size(), 7);
+        qDeleteAll(dives);
+    }
+
+    void garbageWithMagicFailsCleanly()
+    {
+        QByteArray bytes(200, '\x5A');
+        bytes[0] = 12;
+        bytes.replace(8, 4, ".FIT");
+        QString err;
+        auto dives = parseBytes(bytes, err);
+        QVERIFY(dives.isEmpty());
+        QVERIFY(!err.isEmpty());
+    }
+
+    void nonDiveFitRejected()
+    {
+        // A running activity: sport message + heart-rate-only records
+        FitBuilder b;
+        b.definition(0, 12, {{{1, 1, 0x00}}});         // SPORT: sub_sport enum
+        b.dataRecord(0, QByteArrayLiteral("\x01"));    // 1 = running
+        b.definition(1, 20, {{{253, 4, 0x86}, {3, 1, 0x02}}}); // RECORD: ts, heart_rate
+        b.dataRecord(1, FitBuilder::u32(1100000000) + QByteArrayLiteral("\x78"));
+        b.dataRecord(1, FitBuilder::u32(1100000001) + QByteArrayLiteral("\x79"));
+
+        QString err;
+        auto dives = parseBytes(b.build(), err);
+        QVERIFY(dives.isEmpty());
+        QVERIFY2(err.contains(QStringLiteral("dive")), qPrintable(err));
+    }
+
+    void nanArrayElementDoesNotEscape()
+    {
+        // Depth declared as a 2-element u32 array whose first element is the
+        // invalid sentinel: value() must return the valid element, not NaN
+        FitBuilder b;
+        b.definition(0, 12, {{{1, 1, 0x00}}});
+        b.dataRecord(0, QByteArrayLiteral("\x36")); // 54 = multi-gas dive
+        b.definition(1, 20, {{{253, 4, 0x86}, {92, 8, 0x86}}}); // ts + depth[2]
+        b.dataRecord(1, FitBuilder::u32(1100000000) + FitBuilder::u32(0xFFFFFFFF)
+                            + FitBuilder::u32(5000));
+        b.dataRecord(1, FitBuilder::u32(1100000001) + FitBuilder::u32(0xFFFFFFFF)
+                            + FitBuilder::u32(6000));
+
+        QString err;
+        auto dives = parseBytes(b.build(), err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        const auto &points = dives.first()->allDataPoints();
+        QCOMPARE(points.size(), 2);
+        QCOMPARE(points[0].depth, 5.0);
+        QCOMPARE(points[1].depth, 6.0);
+        qDeleteAll(dives);
+    }
+
+    // ---- Local-only tier (skipped when sample logs are absent) ----
+
+    void realFitFiles()
+    {
+        const QDir dir(QStringLiteral(TEST_DATA_DIR));
+        const QStringList files = dir.entryList({QStringLiteral("*.fit")}, QDir::Files);
+        if (files.isEmpty()) {
+            QSKIP("no real .fit samples in tests/data");
+        }
+        for (const QString &name : files) {
+            QFile f(dir.filePath(name));
+            QVERIFY(f.open(QIODevice::ReadOnly));
+            FitParser parser;
+            QVERIFY2(parser.canParse(f), qPrintable(name));
+            QString err;
+            auto dives = parser.parse(f, -1, err);
+            QVERIFY2(err.isEmpty(), qPrintable(name + ": " + err));
+            QCOMPARE(dives.size(), 1);
+            DiveData *d = dives.first();
+            QVERIFY2(d->allDataPoints().size() > 100, qPrintable(name));
+            QVERIFY2(d->maxDepth() > 1.0, qPrintable(name));
+            QVERIFY2(d->startTime().isValid(), qPrintable(name));
+            QVERIFY2(qAbs(d->startTime().offsetFromUtc()) <= 14 * 3600, qPrintable(name));
+            qDeleteAll(dives);
+        }
+    }
+
+    void crossFormatDispatch()
+    {
+        const QDir dir(QStringLiteral(TEST_DATA_DIR));
+        const QString ssrf = dir.filePath(QStringLiteral("blue_hole.ssrf"));
+        if (!QFile::exists(ssrf)) {
+            QSKIP("no .ssrf samples in tests/data");
+        }
+        QFile f(ssrf);
+        QVERIFY(f.open(QIODevice::ReadOnly));
+
+        // The FIT parser must not claim XML logs, and the XML parser must
+        // still parse them with the binary-safe (non-Text) open mode
+        FitParser fit;
+        QVERIFY(!fit.canParse(f));
+        SubsurfaceParser subsurface;
+        QVERIFY(subsurface.canParse(f));
+        QString err;
+        auto dives = subsurface.parse(f, -1, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QVERIFY(!dives.isEmpty());
+        QVERIFY(dives.first()->allDataPoints().size() > 10);
+        qDeleteAll(dives);
+    }
+
+    void uddfRegression()
+    {
+        const QDir dir(QStringLiteral(TEST_DATA_DIR));
+        const QString uddf = dir.filePath(QStringLiteral("Garmin.uddf"));
+        if (!QFile::exists(uddf)) {
+            QSKIP("no .uddf samples in tests/data");
+        }
+        QFile f(uddf);
+        QVERIFY(f.open(QIODevice::ReadOnly));
+        UDDFParser parser;
+        QVERIFY(parser.canParse(f));
+        QString err;
+        auto dives = parser.parse(f, -1, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QVERIFY(!dives.isEmpty());
+        qDeleteAll(dives);
+    }
+};
+
+QTEST_GUILESS_MAIN(FitParserTest)
+#include "fit_parser_test.moc"

--- a/tests/make_synth_fit.py
+++ b/tests/make_synth_fit.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Synthesize a FIT dive file exercising decoder paths absent from the real
 samples: tank pods, big-endian definitions, compressed timestamps, developer
-fields, and a gas switch."""
+fields, and a gas switch.
+
+Usage: make_synth_fit.py [output-path]   (default: ./synth_dive.fit)"""
 import struct
+import sys
 
 CRC_TABLE = [0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
              0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400]
@@ -131,6 +134,7 @@ header += struct.pack('<H', crc16(header))
 payload = header + records
 payload += struct.pack('<H', crc16(payload))
 
-with open('synth_dive.fit', 'wb') as f:
+out_path = sys.argv[1] if len(sys.argv) > 1 else 'synth_dive.fit'
+with open(out_path, 'wb') as f:
     f.write(payload)
-print(f"wrote synth_dive.fit ({len(payload)} bytes)")
+print(f"wrote {out_path} ({len(payload)} bytes)")

--- a/tests/subsurface_parser_test.cpp
+++ b/tests/subsurface_parser_test.cpp
@@ -1,0 +1,223 @@
+// Tests for the Subsurface XML/SSRF parser and the LogParser dispatcher,
+// using synthetic in-test XML so no sample files are required.
+
+#include <QtTest>
+
+#include "include/core/dive_data.h"
+#include "include/core/log_parser.h"
+#include "include/core/format_parsers/subsurface_parser.h"
+
+namespace {
+
+const char kTwoDives[] = R"(<divelog program='subsurface' version='3'>
+<dives>
+<dive number='7' date='2026-03-01' time='10:00:00'>
+  <location>Test Reef</location>
+  <cylinder size='12.0 l' workpressure='232.0 bar' description='D12' o2='32.0%' start='200.0 bar' end='150.0 bar' />
+  <cylinder size='11.1 l' description='AL80' o2='50.0%' start='180.0 bar' end='160.0 bar' />
+  <divecomputer model='Test DC'>
+    <sample time='0:00 min' depth='0.0 m' temp='24.0 C' pressure0='200.0 bar' pressure1='180.0 bar' ndl='99:00 min' />
+    <sample time='1:00 min' depth='18.0 m' cns='5%' />
+    <event time='2:00 min' name='gaschange' cylinder='1' />
+    <sample time='3:00 min' depth='20.0 m' temp='22.0 C' pressure0='170.0 bar' in_deco='1' tts='4:30 min' />
+  </divecomputer>
+</dive>
+<dive number='8' date='2026-03-02' time='11:30:00'>
+  <divecomputer model='Test DC'>
+    <sample time='0:00 min' depth='0.0 m' temp='20.0 C' />
+    <sample time='0:30 min' depth='5.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>)";
+
+QList<DiveData *> parseXml(const QByteArray &xml, int specificDive, QString &err)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write(xml);
+    tmp.flush();
+    tmp.seek(0);
+    SubsurfaceParser parser;
+    return parser.parse(tmp, specificDive, err);
+}
+
+} // namespace
+
+class SubsurfaceParserTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void parsesDiveMetadataAndCylinders()
+    {
+        QString err;
+        auto dives = parseXml(kTwoDives, 7, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+
+        QCOMPARE(d->diveNumber(), 7);
+        QCOMPARE(d->location(), QStringLiteral("Test Reef"));
+        QCOMPARE(d->startTime().toString(QStringLiteral("yyyy-MM-dd hh:mm:ss")),
+                 QStringLiteral("2026-03-01 10:00:00"));
+
+        QCOMPARE(d->cylinderCount(), 2);
+        const CylinderInfo &main = d->cylinderInfo(0);
+        QCOMPARE(main.size, 12.0);
+        QCOMPARE(main.workPressure, 232.0);
+        QCOMPARE(main.o2Percent, 32.0);
+        QCOMPARE(main.startPressure, 200.0);
+        QCOMPARE(main.endPressure, 150.0);
+        QCOMPARE(main.description, QStringLiteral("D12"));
+        QCOMPARE(d->cylinderInfo(1).o2Percent, 50.0);
+        qDeleteAll(dives);
+    }
+
+    void samplesWithCarryForward()
+    {
+        QString err;
+        auto dives = parseXml(kTwoDives, 7, err);
+        QCOMPARE(dives.size(), 1);
+        const auto &pts = dives.first()->allDataPoints();
+        QCOMPARE(pts.size(), 3);
+
+        QCOMPARE(pts[0].timestamp, 0.0);
+        QCOMPARE(pts[0].temperature, 24.0);
+        QCOMPARE(pts[0].ndl, 99.0);
+        QCOMPARE(pts[0].getPressure(0), 200.0);
+        QCOMPARE(pts[0].getPressure(1), 180.0);
+        QCOMPARE(pts[0].cns, -1.0); // no CNS data yet
+
+        // Sample 2 omits temp/pressures: previous values carry forward
+        QCOMPARE(pts[1].timestamp, 60.0);
+        QCOMPARE(pts[1].depth, 18.0);
+        QCOMPARE(pts[1].temperature, 24.0);
+        QCOMPARE(pts[1].getPressure(0), 200.0);
+        QCOMPARE(pts[1].getPressure(1), 180.0);
+        QCOMPARE(pts[1].cns, 5.0);
+
+        // in_deco='1' forces NDL to 0; tts parsed as M:SS
+        QCOMPARE(pts[2].timestamp, 180.0);
+        QCOMPARE(pts[2].ndl, 0.0);
+        QCOMPARE(pts[2].tts, 4.5);
+        QCOMPARE(pts[2].getPressure(0), 170.0);
+        QCOMPARE(pts[2].cns, 5.0); // carried
+        qDeleteAll(dives);
+    }
+
+    void gasSwitchEventApplies()
+    {
+        QString err;
+        auto dives = parseXml(kTwoDives, 7, err);
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+        QCOMPARE(d->activeCylinderAtTime(60.0), 0);
+        QCOMPARE(d->activeCylinderAtTime(150.0), 1);
+        qDeleteAll(dives);
+    }
+
+    void parsesAllDivesAndSelectsByNumber()
+    {
+        QString err;
+        auto all = parseXml(kTwoDives, -1, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(all.size(), 2);
+        qDeleteAll(all);
+
+        auto only8 = parseXml(kTwoDives, 8, err);
+        QCOMPARE(only8.size(), 1);
+        QCOMPARE(only8.first()->diveNumber(), 8);
+        qDeleteAll(only8);
+
+        // Absent number: empty result, but not an error (LogParser reports it)
+        auto none = parseXml(kTwoDives, 99, err);
+        QVERIFY(none.isEmpty());
+        QVERIFY(err.isEmpty());
+    }
+
+    void listDivesEntries()
+    {
+        QTemporaryFile tmp;
+        tmp.open();
+        tmp.write(QByteArray(kTwoDives));
+        tmp.flush();
+        SubsurfaceParser parser;
+        QString err;
+        const auto entries = parser.listDives(tmp, err);
+        QCOMPARE(entries.size(), 2);
+        QCOMPARE(entries[0],
+                 QStringLiteral("Dive #7 - 2026-03-01 10:00:00 at Test Reef"));
+    }
+
+    void malformedXmlReportsError()
+    {
+        QString err;
+        auto dives = parseXml(QByteArrayLiteral("<divelog><dives><dive number='1'"), -1, err);
+        QVERIFY(dives.isEmpty());
+        QVERIFY(!err.isEmpty());
+    }
+};
+
+// ---- LogParser dispatch (content sniffing, signals) ----
+
+class LogParserDispatchTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void dispatchIgnoresFileExtension()
+    {
+        // SSRF content in a file named .fit: the sniff must win
+        QTemporaryFile tmp(QDir::tempPath() + QStringLiteral("/dispatch_XXXXXX.fit"));
+        tmp.open();
+        tmp.write(QByteArray(kTwoDives));
+        tmp.flush();
+
+        LogParser lp;
+        QList<DiveData *> received;
+        int importSignals = 0;
+        connect(&lp, &LogParser::multipleImported, this,
+                [&](const QList<DiveData *> &dives) {
+                    received = dives;
+                    ++importSignals;
+                });
+        QSignalSpy errors(&lp, &LogParser::errorOccurred);
+        QVERIFY(lp.importFile(tmp.fileName()));
+        QCOMPARE(importSignals, 1);
+        QCOMPARE(errors.count(), 0);
+        QCOMPARE(received.size(), 2);
+        qDeleteAll(received);
+    }
+
+    void unsupportedContentReportsError()
+    {
+        QTemporaryFile tmp;
+        tmp.open();
+        tmp.write(QByteArrayLiteral("not a dive log at all"));
+        tmp.flush();
+
+        LogParser lp;
+        QSignalSpy errors(&lp, &LogParser::errorOccurred);
+        QVERIFY(!lp.importFile(tmp.fileName()));
+        QCOMPARE(errors.count(), 1);
+        QVERIFY(!lp.lastError().isEmpty());
+    }
+};
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    int status = 0;
+    {
+        SubsurfaceParserTest t1;
+        status |= QTest::qExec(&t1, argc, argv);
+    }
+    {
+        LogParserDispatchTest t2;
+        status |= QTest::qExec(&t2, argc, argv);
+    }
+    return status;
+}
+
+#include "subsurface_parser_test.moc"

--- a/tests/uddf_parser_test.cpp
+++ b/tests/uddf_parser_test.cpp
@@ -1,0 +1,173 @@
+// Tests for the UDDF parser using synthetic in-test XML: gas definitions,
+// SI-unit conversions (Kelvin, Pascal, m³), comma decimals, CCR waypoint
+// elements, and deco stops.
+
+#include <QtTest>
+
+#include "include/core/dive_data.h"
+#include "include/core/format_parsers/uddf_parser.h"
+
+namespace {
+
+const char kUddfDive[] = R"(<uddf version='3.2'>
+<gasdefinitions>
+  <mix id='mix1'><name>EAN32</name><o2>0.32</o2><he>0.0</he></mix>
+  <mix id='mix2'><name>TX18/45</name><o2>0,18</o2><he>0,45</he></mix>
+</gasdefinitions>
+<profiledata><repetitiongroup><dive id='d1'>
+  <informationbeforedive>
+    <divenumber>3</divenumber>
+    <datetime>2026-04-23T09:30:00</datetime>
+  </informationbeforedive>
+  <tankdata>
+    <link ref='mix1'/>
+    <tankvolume>0.012</tankvolume>
+    <tankpressurebegin>20000000</tankpressurebegin>
+    <tankpressureend>15000000</tankpressureend>
+  </tankdata>
+  <samples>
+    <waypoint>
+      <divetime>0.0</divetime>
+      <depth>0.0</depth>
+      <temperature>297.15</temperature>
+      <tankpressure ref='mix1'>20000000</tankpressure>
+    </waypoint>
+    <waypoint>
+      <divetime>60.0</divetime>
+      <depth>18.0</depth>
+      <cns>12.5</cns>
+      <nodecotime>1200</nodecotime>
+    </waypoint>
+    <waypoint>
+      <divetime>120.0</divetime>
+      <depth>20,5</depth>
+      <decostop kind='mandatory' decodepth='6.0' duration='180'/>
+    </waypoint>
+  </samples>
+  <informationafterdive><averagedepth>12.3</averagedepth></informationafterdive>
+</dive></repetitiongroup></profiledata>
+</uddf>)";
+
+QList<DiveData *> parseUddf(const QByteArray &xml, QString &err)
+{
+    QTemporaryFile tmp;
+    tmp.open();
+    tmp.write(xml);
+    tmp.flush();
+    tmp.seek(0);
+    UDDFParser parser;
+    return parser.parse(tmp, -1, err);
+}
+
+} // namespace
+
+class UddfParserTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void sniffsUddfRoot()
+    {
+        QTemporaryFile tmp;
+        tmp.open();
+        tmp.write(QByteArray(kUddfDive));
+        tmp.flush();
+        tmp.seek(0);
+        UDDFParser parser;
+        QVERIFY(parser.canParse(tmp));
+        QCOMPARE(tmp.pos(), qint64(0)); // seek position restored
+    }
+
+    void metadataAndSiUnits()
+    {
+        QString err;
+        auto dives = parseUddf(kUddfDive, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+
+        QCOMPARE(d->diveNumber(), 3);
+        QCOMPARE(d->startTime().toString(QStringLiteral("yyyy-MM-dd hh:mm:ss")),
+                 QStringLiteral("2026-04-23 09:30:00"));
+        QCOMPARE(d->meanDepth(), 12.3); // from <averagedepth>
+
+        QCOMPARE(d->cylinderCount(), 1);
+        const CylinderInfo &cyl = d->cylinderInfo(0);
+        QCOMPARE(cyl.o2Percent, 32.0);       // mix fraction 0.32 -> percent
+        QCOMPARE(cyl.size, 12.0);            // 0.012 m^3 -> liters
+        QCOMPARE(cyl.startPressure, 200.0);  // 2e7 Pa -> bar
+        QCOMPARE(cyl.endPressure, 150.0);
+        qDeleteAll(dives);
+    }
+
+    void waypointsWithConversionsAndCarryForward()
+    {
+        QString err;
+        auto dives = parseUddf(kUddfDive, err);
+        QCOMPARE(dives.size(), 1);
+        const auto &pts = dives.first()->allDataPoints();
+        QCOMPARE(pts.size(), 3);
+
+        QCOMPARE(pts[0].temperature, 24.0); // 297.15 K
+        QCOMPARE(pts[0].getPressure(0), 200.0);
+        QCOMPARE(pts[0].cns, -1.0);
+
+        QCOMPARE(pts[1].depth, 18.0);
+        QCOMPARE(pts[1].temperature, 24.0); // carried
+        QCOMPARE(pts[1].getPressure(0), 200.0); // carried
+        QCOMPARE(pts[1].cns, 12.5);
+        QCOMPARE(pts[1].ndl, 20.0); // 1200 s -> min
+
+        // Comma decimal accepted; mandatory decostop -> ceiling + TTS
+        QCOMPARE(pts[2].depth, 20.5);
+        QCOMPARE(pts[2].ceiling, 6.0);
+        QCOMPARE(pts[2].tts, 3.0); // 180 s -> min
+        QCOMPARE(pts[2].cns, 12.5); // carried
+        qDeleteAll(dives);
+    }
+
+    void ccrWaypointsMapToSensors()
+    {
+        const QByteArray xml = QByteArrayLiteral(R"(<uddf version='3.2'>
+<profiledata><repetitiongroup><dive id='d1'>
+  <informationbeforedive><divenumber>1</divenumber>
+    <datetime>2026-01-01T10:00:00</datetime></informationbeforedive>
+  <samples>
+    <waypoint><divetime>0</divetime><depth>10.0</depth>
+      <divemode kind='closedcircuit'/>
+      <measuredpo2 ref='s1'>122000</measuredpo2>
+      <measuredpo2 ref='s2'>130000</measuredpo2>
+    </waypoint>
+    <waypoint><divetime>10</divetime><depth>12.0</depth>
+      <measuredpo2 ref='s2'>131000</measuredpo2>
+    </waypoint>
+  </samples>
+</dive></repetitiongroup></profiledata></uddf>)");
+
+        QString err;
+        auto dives = parseUddf(xml, err);
+        QVERIFY2(err.isEmpty(), qPrintable(err));
+        QCOMPARE(dives.size(), 1);
+        DiveData *d = dives.first();
+        QCOMPARE(d->diveMode(), DiveData::ClosedCircuit);
+
+        const auto &pts = d->allDataPoints();
+        QCOMPARE(pts[0].getPO2Sensor(0), 1.22); // Pa -> bar
+        QCOMPARE(pts[0].getPO2Sensor(1), 1.30);
+        // Sensor refs keep stable indices; missing s1 carries forward
+        QCOMPARE(pts[1].getPO2Sensor(0), 1.22);
+        QCOMPARE(pts[1].getPO2Sensor(1), 1.31);
+        qDeleteAll(dives);
+    }
+
+    void malformedUddfReportsError()
+    {
+        QString err;
+        auto dives = parseUddf(QByteArrayLiteral("<uddf><profiledata>"), err);
+        QVERIFY(dives.isEmpty());
+        QVERIFY(!err.isEmpty());
+    }
+};
+
+QTEST_GUILESS_MAIN(UddfParserTest)
+#include "uddf_parser_test.moc"


### PR DESCRIPTION
Introduces a CTest-based suite (cmake -DUNABARA_BUILD_TESTS=ON), the
project's first automated tests. Six executables, 63 checks, <0.5 s:

- fit_parser_test: FIT decoder/parser end-to-end against a synthetic
  dive (big-endian records, compressed timestamps, developer fields,
  tank pods, gas switch) plus salvage/robustness cases; real Descent
  logs and SSRF/UDDF cross-checks run only when samples are present
  in tests/data (skipped otherwise, so CI needs no private logs).
- dive_data_test: interpolation contracts (ceiling persistence, CNS
  sentinel, sample-vs-ramp pressure), gas-switch determinism,
  maxDepthUntil, mean depth precedence.
- subsurface_parser_test: synthetic SSRF XML incl. carry-forward,
  in_deco, gas-change events, multi-dive selection, and LogParser
  dispatch (content sniffing beats file extension).
- uddf_parser_test: SI conversions, comma decimals, CCR sensor refs,
  deco stops.
- core_utils_test / cell_data_test: parse_utils, Units formatting,
  and .utp cell JSON round-trips.

Core sources build once into a shared static testlib; the synthetic
FIT fixture is regenerated at build time from make_synth_fit.py so
the generator and tests cannot drift.

Also fixes a bug the new tests exposed: dataAtTime() bounded its tank
loop by the samples' channel counts, so dives with cylinder start/end
pressures but no per-sample data (manually entered logs) displayed no
pressure at all — the ramp fallback was unreachable