### PR TITLE
Text improvement: add configurable text shadows to overlay cell text

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ cmake --build . --config Release
 .\bin\Release\unabara.exe
 ```
 
+### Running the tests
+
+The unit tests (dive log parsers) require Python 3 for fixture generation:
+
+```bash
+cmake .. -DUNABARA_BUILD_TESTS=ON
+cmake --build .
+ctest --output-on-failure
+```
+
+Tests that rely on real dive computer logs are skipped automatically when no
+sample files are present in `tests/data/`.
+
 ## Video Export
 
 For direct video export functionality, FFmpeg needs to be installed on your system:

--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -32,6 +32,29 @@ enum class CellType {
 };
 
 /**
+ * @brief Style of the text shadow rendered behind cell text
+ */
+enum class ShadowType {
+    Offset,           // Crisp copy of the text offset down-right
+    Blurred,          // Soft gaussian-like halo
+    Outline           // Text redrawn at 8 surrounding offsets (contour)
+};
+
+/**
+ * @brief Default shadow values shared by CellData, OverlayGenerator and OverlayTemplate
+ *
+ * The "no hasCustom flag = inherit global" model only works when all three
+ * layers agree on defaults before the first global propagation.
+ */
+namespace ShadowDefaults {
+    constexpr bool enabled = false;
+    constexpr ShadowType type = ShadowType::Offset;
+    inline QColor color() { return QColor(0, 0, 0); }
+    constexpr int size = 2;
+    constexpr double opacity = 0.7;
+}
+
+/**
  * @brief Represents a single data cell in the overlay
  *
  * Each cell displays one type of telemetry data and can be positioned
@@ -56,6 +79,12 @@ public:
     bool hasCustomShowLabel() const { return m_hasCustomShowLabel; }
     int tankIndex() const { return m_tankIndex; }
     bool showLabel() const { return m_showLabel; }
+    bool shadowEnabled() const { return m_shadowEnabled; }
+    ShadowType shadowType() const { return m_shadowType; }
+    QColor shadowColor() const { return m_shadowColor; }
+    int shadowSize() const { return m_shadowSize; }
+    double shadowOpacity() const { return m_shadowOpacity; }
+    bool hasCustomShadow() const { return m_hasCustomShadow; }
 
     // Setters
     void setCellId(const QString& id) { m_cellId = id; }
@@ -65,6 +94,11 @@ public:
     void setFont(const QFont& font, bool isCustom = true);
     void setTextColor(const QColor& color, bool isCustom = true);
     void setShowLabel(bool show, bool isCustom = true);
+    void setShadowEnabled(bool enabled, bool isCustom = true);
+    void setShadowType(ShadowType type, bool isCustom = true);
+    void setShadowColor(const QColor& color, bool isCustom = true);
+    void setShadowSize(int size, bool isCustom = true);
+    void setShadowOpacity(double opacity, bool isCustom = true);
     void setCalculatedSize(const QSizeF& size) { m_calculatedSize = size; }
     void setTankIndex(int index) { m_tankIndex = index; }
 
@@ -72,6 +106,7 @@ public:
     void resetFont() { m_hasCustomFont = false; }
     void resetColor() { m_hasCustomColor = false; }
     void resetShowLabel() { m_hasCustomShowLabel = false; }
+    void resetShadow() { m_hasCustomShadow = false; }
 
     // Serialization
     QJsonObject toJson() const;
@@ -80,6 +115,8 @@ public:
     // Helper methods
     static QString cellTypeToString(CellType type);
     static CellType cellTypeFromString(const QString& str);
+    static QString shadowTypeToString(ShadowType type);
+    static ShadowType shadowTypeFromString(const QString& str);
 
 private:
     QString m_cellId;              // Unique identifier (e.g., "depth", "tank_0")
@@ -93,6 +130,12 @@ private:
     bool m_hasCustomColor;         // True if color differs from global default
     bool m_showLabel;              // Whether the label row ("DEPTH" etc.) is rendered above the value
     bool m_hasCustomShowLabel;     // True if showLabel differs from global default
+    bool m_shadowEnabled;          // Whether a shadow is drawn behind the text
+    ShadowType m_shadowType;       // Shadow style (offset, blurred, outline)
+    QColor m_shadowColor;          // Shadow color (opacity applied separately at render time)
+    int m_shadowSize;              // Shadow size in px (offset distance / blur radius / outline thickness)
+    double m_shadowOpacity;        // Shadow opacity (0.0-1.0)
+    bool m_hasCustomShadow;        // True if any shadow setting differs from global default
     int m_tankIndex;               // For pressure cells: which tank (0-based), -1 for N/A
 };
 

--- a/include/core/overlay_template.h
+++ b/include/core/overlay_template.h
@@ -31,6 +31,11 @@ public:
     QVector<CellData> cells() const { return m_cells; }
     QFont defaultFont() const { return m_defaultFont; }
     QColor defaultTextColor() const { return m_defaultTextColor; }
+    bool defaultShadowEnabled() const { return m_defaultShadowEnabled; }
+    ShadowType defaultShadowType() const { return m_defaultShadowType; }
+    QColor defaultShadowColor() const { return m_defaultShadowColor; }
+    int defaultShadowSize() const { return m_defaultShadowSize; }
+    double defaultShadowOpacity() const { return m_defaultShadowOpacity; }
 
     // Setters
     void setTemplateName(const QString& name) { m_templateName = name; }
@@ -39,6 +44,11 @@ public:
     void setCells(const QVector<CellData>& cells) { m_cells = cells; }
     void setDefaultFont(const QFont& font) { m_defaultFont = font; }
     void setDefaultTextColor(const QColor& color) { m_defaultTextColor = color; }
+    void setDefaultShadowEnabled(bool enabled) { m_defaultShadowEnabled = enabled; }
+    void setDefaultShadowType(ShadowType type) { m_defaultShadowType = type; }
+    void setDefaultShadowColor(const QColor& color) { m_defaultShadowColor = color; }
+    void setDefaultShadowSize(int size) { m_defaultShadowSize = size; }
+    void setDefaultShadowOpacity(double opacity) { m_defaultShadowOpacity = opacity; }
 
     // Cell management
     void addCell(const CellData& cell);
@@ -71,6 +81,11 @@ private:
     QVector<CellData> m_cells;
     QFont m_defaultFont;
     QColor m_defaultTextColor;
+    bool m_defaultShadowEnabled;
+    ShadowType m_defaultShadowType;
+    QColor m_defaultShadowColor;
+    int m_defaultShadowSize;
+    double m_defaultShadowOpacity;
 
     static const QString TEMPLATE_VERSION;  // Current template format version
 };

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -24,6 +24,11 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
     Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor NOTIFY textColorChanged)
     Q_PROPERTY(bool showLabel READ showLabel WRITE setShowLabel NOTIFY showLabelChanged)
+    Q_PROPERTY(bool shadowEnabled READ shadowEnabled WRITE setShadowEnabled NOTIFY shadowChanged)
+    Q_PROPERTY(int shadowType READ shadowType WRITE setShadowType NOTIFY shadowChanged)
+    Q_PROPERTY(QColor shadowColor READ shadowColor WRITE setShadowColor NOTIFY shadowChanged)
+    Q_PROPERTY(int shadowSize READ shadowSize WRITE setShadowSize NOTIFY shadowChanged)
+    Q_PROPERTY(double shadowOpacity READ shadowOpacity WRITE setShadowOpacity NOTIFY shadowChanged)
     Q_PROPERTY(double backgroundOpacity READ backgroundOpacity WRITE setBackgroundOpacity NOTIFY backgroundOpacityChanged)
     Q_PROPERTY(bool showDepth READ showDepth WRITE setShowDepth NOTIFY showDepthChanged)
     Q_PROPERTY(bool showTemperature READ showTemperature WRITE setShowTemperature NOTIFY showTemperatureChanged)
@@ -62,6 +67,11 @@ public:
     QFont font() const { return m_font; }
     QColor textColor() const { return m_textColor; }
     bool showLabel() const { return m_showLabel; }
+    bool shadowEnabled() const { return m_shadowEnabled; }
+    int shadowType() const { return static_cast<int>(m_shadowType); }
+    QColor shadowColor() const { return m_shadowColor; }
+    int shadowSize() const { return m_shadowSize; }
+    double shadowOpacity() const { return m_shadowOpacity; }
     double backgroundOpacity() const { return m_backgroundOpacity; }
     bool showDepth() const { return m_showDepth; }
     bool showTemperature() const { return m_showTemperature; }
@@ -95,6 +105,11 @@ public:
     void setFont(const QFont &font);
     void setTextColor(const QColor &color);
     void setShowLabel(bool show);
+    void setShadowEnabled(bool enabled);
+    void setShadowType(int type);
+    void setShadowColor(const QColor& color);
+    void setShadowSize(int size);
+    void setShadowOpacity(double opacity);
     void setBackgroundOpacity(double opacity);
     void setShowDepth(bool show);
     void setShowTemperature(bool show);
@@ -135,11 +150,17 @@ public:
     Q_INVOKABLE void setCellColor(const QString& cellId, const QColor& color);
     Q_INVOKABLE void setCellShowLabel(const QString& cellId, bool show);
     Q_INVOKABLE bool getCellShowLabel(const QString& cellId) const;
+    Q_INVOKABLE bool getCellShadowEnabled(const QString& cellId) const;
+    Q_INVOKABLE int getCellShadowType(const QString& cellId) const;
+    Q_INVOKABLE QColor getCellShadowColor(const QString& cellId) const;
+    Q_INVOKABLE int getCellShadowSize(const QString& cellId) const;
+    Q_INVOKABLE double getCellShadowOpacity(const QString& cellId) const;
     Q_INVOKABLE void setCellVisible(const QString& cellId, bool visible);
     Q_INVOKABLE void setCellTypeVisible(const QString& cellId, bool visible);
     Q_INVOKABLE void resetCellFont(const QString& cellId);
     Q_INVOKABLE void resetCellColor(const QString& cellId);
     Q_INVOKABLE void resetCellShowLabel(const QString& cellId);
+    Q_INVOKABLE void resetCellShadow(const QString& cellId);
     bool useCellBasedLayout() const { return m_useCellBasedLayout; }
     void setUseCellBasedLayout(bool use);
 
@@ -175,6 +196,7 @@ signals:
     void fontChanged();
     void textColorChanged();
     void showLabelChanged();
+    void shadowChanged();
     void backgroundOpacityChanged();
     void showDepthChanged();
     void showTemperatureChanged();
@@ -218,6 +240,11 @@ private:
     QFont m_font;
     QColor m_textColor;
     bool m_showLabel;
+    bool m_shadowEnabled;
+    Unabara::ShadowType m_shadowType;
+    QColor m_shadowColor;
+    int m_shadowSize;
+    double m_shadowOpacity;
     double m_backgroundOpacity;
     bool m_showDepth;
     bool m_showTemperature;

--- a/include/ui/cell_model.h
+++ b/include/ui/cell_model.h
@@ -31,7 +31,13 @@ public:
         HasCustomColorRole,
         TankIndexRole,
         ShowLabelRole,
-        HasCustomShowLabelRole
+        HasCustomShowLabelRole,
+        ShadowEnabledRole,
+        ShadowTypeRole,
+        ShadowColorRole,
+        ShadowSizeRole,
+        ShadowOpacityRole,
+        HasCustomShadowRole
     };
 
     explicit CellModel(QObject *parent = nullptr);

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -14,6 +14,12 @@ CellData::CellData()
     , m_hasCustomColor(false)
     , m_showLabel(true)
     , m_hasCustomShowLabel(false)
+    , m_shadowEnabled(ShadowDefaults::enabled)
+    , m_shadowType(ShadowDefaults::type)
+    , m_shadowColor(ShadowDefaults::color())
+    , m_shadowSize(ShadowDefaults::size)
+    , m_shadowOpacity(ShadowDefaults::opacity)
+    , m_hasCustomShadow(false)
     , m_tankIndex(-1)
 {
 }
@@ -30,6 +36,12 @@ CellData::CellData(const QString& cellId, CellType cellType)
     , m_hasCustomColor(false)
     , m_showLabel(true)
     , m_hasCustomShowLabel(false)
+    , m_shadowEnabled(ShadowDefaults::enabled)
+    , m_shadowType(ShadowDefaults::type)
+    , m_shadowColor(ShadowDefaults::color())
+    , m_shadowSize(ShadowDefaults::size)
+    , m_shadowOpacity(ShadowDefaults::opacity)
+    , m_hasCustomShadow(false)
     , m_tankIndex(-1)
 {
 }
@@ -50,6 +62,36 @@ void CellData::setShowLabel(bool show, bool isCustom)
 {
     m_showLabel = show;
     m_hasCustomShowLabel = isCustom;
+}
+
+void CellData::setShadowEnabled(bool enabled, bool isCustom)
+{
+    m_shadowEnabled = enabled;
+    m_hasCustomShadow = isCustom;
+}
+
+void CellData::setShadowType(ShadowType type, bool isCustom)
+{
+    m_shadowType = type;
+    m_hasCustomShadow = isCustom;
+}
+
+void CellData::setShadowColor(const QColor& color, bool isCustom)
+{
+    m_shadowColor = color;
+    m_hasCustomShadow = isCustom;
+}
+
+void CellData::setShadowSize(int size, bool isCustom)
+{
+    m_shadowSize = size;
+    m_hasCustomShadow = isCustom;
+}
+
+void CellData::setShadowOpacity(double opacity, bool isCustom)
+{
+    m_shadowOpacity = opacity;
+    m_hasCustomShadow = isCustom;
 }
 
 QJsonObject CellData::toJson() const
@@ -99,6 +141,13 @@ QJsonObject CellData::toJson() const
 
     json["showLabel"] = m_showLabel;
     json["hasCustomShowLabel"] = m_hasCustomShowLabel;
+
+    json["shadowEnabled"] = m_shadowEnabled;
+    json["shadowType"] = shadowTypeToString(m_shadowType);
+    json["shadowColor"] = m_shadowColor.name(QColor::HexArgb);
+    json["shadowSize"] = m_shadowSize;
+    json["shadowOpacity"] = m_shadowOpacity;
+    json["hasCustomShadow"] = m_hasCustomShadow;
 
     return json;
 }
@@ -150,6 +199,16 @@ CellData CellData::fromJson(const QJsonObject& json)
     cell.m_showLabel = json["showLabel"].toBool(true);
     cell.m_hasCustomShowLabel = json["hasCustomShowLabel"].toBool(false);
 
+    // Shadow settings (defaults match ShadowDefaults — old .utp files
+    // predating these fields load with shadows disabled).
+    cell.m_shadowEnabled = json["shadowEnabled"].toBool(ShadowDefaults::enabled);
+    cell.m_shadowType = shadowTypeFromString(json["shadowType"].toString());
+    cell.m_shadowColor = QColor(json["shadowColor"].toString(
+        ShadowDefaults::color().name(QColor::HexArgb)));
+    cell.m_shadowSize = json["shadowSize"].toInt(ShadowDefaults::size);
+    cell.m_shadowOpacity = json["shadowOpacity"].toDouble(ShadowDefaults::opacity);
+    cell.m_hasCustomShadow = json["hasCustomShadow"].toBool(false);
+
     return cell;
 }
 
@@ -191,6 +250,22 @@ CellType CellData::cellTypeFromString(const QString& str)
     if (str == "MaxDepth") return CellType::MaxDepth;
     if (str == "Gas") return CellType::Gas;
     return CellType::Unknown;
+}
+
+QString CellData::shadowTypeToString(ShadowType type)
+{
+    switch (type) {
+        case ShadowType::Blurred: return "blurred";
+        case ShadowType::Outline: return "outline";
+        default: return "offset";
+    }
+}
+
+ShadowType CellData::shadowTypeFromString(const QString& str)
+{
+    if (str == "blurred") return ShadowType::Blurred;
+    if (str == "outline") return ShadowType::Outline;
+    return ShadowType::Offset;
 }
 
 } // namespace Unabara

--- a/src/core/overlay_template.cpp
+++ b/src/core/overlay_template.cpp
@@ -16,6 +16,11 @@ OverlayTemplate::OverlayTemplate()
     , m_backgroundOpacity(1.0)
     , m_defaultFont(QFont("Sans Serif", 12))
     , m_defaultTextColor(Qt::white)
+    , m_defaultShadowEnabled(ShadowDefaults::enabled)
+    , m_defaultShadowType(ShadowDefaults::type)
+    , m_defaultShadowColor(ShadowDefaults::color())
+    , m_defaultShadowSize(ShadowDefaults::size)
+    , m_defaultShadowOpacity(ShadowDefaults::opacity)
 {
 }
 
@@ -133,6 +138,13 @@ QJsonObject OverlayTemplate::toJson() const
     // Default text color
     json["defaultTextColor"] = m_defaultTextColor.name(QColor::HexArgb);
 
+    // Default shadow settings
+    json["defaultShadowEnabled"] = m_defaultShadowEnabled;
+    json["defaultShadowType"] = CellData::shadowTypeToString(m_defaultShadowType);
+    json["defaultShadowColor"] = m_defaultShadowColor.name(QColor::HexArgb);
+    json["defaultShadowSize"] = m_defaultShadowSize;
+    json["defaultShadowOpacity"] = m_defaultShadowOpacity;
+
     // Cells
     QJsonArray cellsArray;
     for (const auto& cell : m_cells) {
@@ -174,6 +186,14 @@ OverlayTemplate OverlayTemplate::fromJson(const QJsonObject& json)
     if (json.contains("defaultTextColor")) {
         templ.m_defaultTextColor = QColor(json["defaultTextColor"].toString());
     }
+
+    // Default shadow settings (absent in templates predating shadows → ShadowDefaults)
+    templ.m_defaultShadowEnabled = json["defaultShadowEnabled"].toBool(ShadowDefaults::enabled);
+    templ.m_defaultShadowType = CellData::shadowTypeFromString(json["defaultShadowType"].toString());
+    templ.m_defaultShadowColor = QColor(json["defaultShadowColor"].toString(
+        ShadowDefaults::color().name(QColor::HexArgb)));
+    templ.m_defaultShadowSize = json["defaultShadowSize"].toInt(ShadowDefaults::size);
+    templ.m_defaultShadowOpacity = json["defaultShadowOpacity"].toDouble(ShadowDefaults::opacity);
 
     // Cells
     if (json.contains("cells")) {

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -17,6 +17,11 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_font(QFont("Sans Serif", 12))
     , m_textColor(Qt::white)
     , m_showLabel(true)
+    , m_shadowEnabled(Unabara::ShadowDefaults::enabled)
+    , m_shadowType(Unabara::ShadowDefaults::type)
+    , m_shadowColor(Unabara::ShadowDefaults::color())
+    , m_shadowSize(Unabara::ShadowDefaults::size)
+    , m_shadowOpacity(Unabara::ShadowDefaults::opacity)
     , m_backgroundOpacity(1.0)
     , m_showDepth(true)
     , m_showTemperature(true)
@@ -188,6 +193,148 @@ void OverlayGenerator::setShowLabel(bool show)
         Unabara::CellData* cell = getCellData(m_selectedCellId);
         if (cell && cell->showLabel() != show) {
             cell->setShowLabel(show, true); // true = custom override
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setShadowEnabled(bool enabled)
+{
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_shadowEnabled != enabled) {
+            m_shadowEnabled = enabled;
+
+            // Apply to all cells that don't have a per-cell override
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomShadow()) {
+                    cell.setShadowEnabled(enabled, false); // false = inherited from global
+                }
+            }
+
+            emit shadowChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell as a per-cell override
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->shadowEnabled() != enabled) {
+            cell->setShadowEnabled(enabled, true); // true = custom override
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setShadowType(int type)
+{
+    auto shadowType = static_cast<Unabara::ShadowType>(
+        qBound(0, type, static_cast<int>(Unabara::ShadowType::Outline)));
+
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_shadowType != shadowType) {
+            m_shadowType = shadowType;
+
+            // Apply to all cells that don't have a per-cell override
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomShadow()) {
+                    cell.setShadowType(shadowType, false); // false = inherited from global
+                }
+            }
+
+            emit shadowChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell as a per-cell override
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->shadowType() != shadowType) {
+            cell->setShadowType(shadowType, true); // true = custom override
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setShadowColor(const QColor& color)
+{
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_shadowColor != color) {
+            m_shadowColor = color;
+
+            // Apply to all cells that don't have a per-cell override
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomShadow()) {
+                    cell.setShadowColor(color, false); // false = inherited from global
+                }
+            }
+
+            emit shadowChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell as a per-cell override
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->shadowColor() != color) {
+            cell->setShadowColor(color, true); // true = custom override
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setShadowSize(int size)
+{
+    size = qBound(1, size, 10);
+
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_shadowSize != size) {
+            m_shadowSize = size;
+
+            // Apply to all cells that don't have a per-cell override
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomShadow()) {
+                    cell.setShadowSize(size, false); // false = inherited from global
+                }
+            }
+
+            emit shadowChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell as a per-cell override
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->shadowSize() != size) {
+            cell->setShadowSize(size, true); // true = custom override
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setShadowOpacity(double opacity)
+{
+    opacity = qBound(0.0, opacity, 1.0);
+
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_shadowOpacity != opacity) {
+            m_shadowOpacity = opacity;
+
+            // Apply to all cells that don't have a per-cell override
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomShadow()) {
+                    cell.setShadowOpacity(opacity, false); // false = inherited from global
+                }
+            }
+
+            emit shadowChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell as a per-cell override
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->shadowOpacity() != opacity) {
+            cell->setShadowOpacity(opacity, true); // true = custom override
             emit cellsChanged();
         }
     }
@@ -504,6 +651,20 @@ void OverlayGenerator::resetCellShowLabel(const QString& cellId)
     }
 }
 
+void OverlayGenerator::resetCellShadow(const QString& cellId)
+{
+    Unabara::CellData* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShadow()) {
+        // Reset the whole shadow group to the global defaults
+        cell->setShadowEnabled(m_shadowEnabled, false);  // false = inherited from global
+        cell->setShadowType(m_shadowType, false);
+        cell->setShadowColor(m_shadowColor, false);
+        cell->setShadowSize(m_shadowSize, false);
+        cell->setShadowOpacity(m_shadowOpacity, false);
+        emit cellsChanged();
+    }
+}
+
 // Cell-based layout management methods
 
 Unabara::CellData* OverlayGenerator::getCellData(const QString& cellId)
@@ -595,6 +756,51 @@ bool OverlayGenerator::getCellShowLabel(const QString& cellId) const
         return cell->showLabel();
     }
     return m_showLabel;
+}
+
+bool OverlayGenerator::getCellShadowEnabled(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShadow()) {
+        return cell->shadowEnabled();
+    }
+    return m_shadowEnabled;
+}
+
+int OverlayGenerator::getCellShadowType(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShadow()) {
+        return static_cast<int>(cell->shadowType());
+    }
+    return static_cast<int>(m_shadowType);
+}
+
+QColor OverlayGenerator::getCellShadowColor(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShadow()) {
+        return cell->shadowColor();
+    }
+    return m_shadowColor;
+}
+
+int OverlayGenerator::getCellShadowSize(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShadow()) {
+        return cell->shadowSize();
+    }
+    return m_shadowSize;
+}
+
+double OverlayGenerator::getCellShadowOpacity(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomShadow()) {
+        return cell->shadowOpacity();
+    }
+    return m_shadowOpacity;
 }
 
 void OverlayGenerator::setCellVisible(const QString& cellId, bool visible)
@@ -770,8 +976,25 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_backgroundOpacity = templ.backgroundOpacity();
     m_font = templ.defaultFont();
     m_textColor = templ.defaultTextColor();
+    m_shadowEnabled = templ.defaultShadowEnabled();
+    m_shadowType = templ.defaultShadowType();
+    m_shadowColor = templ.defaultShadowColor();
+    m_shadowSize = templ.defaultShadowSize();
+    m_shadowOpacity = templ.defaultShadowOpacity();
     m_cells = templ.cells();
     m_useCellBasedLayout = true;
+
+    // Re-propagate global shadow settings into cells without a per-cell
+    // override, in case a hand-edited template disagrees with its defaults
+    for (auto& cell : m_cells) {
+        if (!cell.hasCustomShadow()) {
+            cell.setShadowEnabled(m_shadowEnabled, false);
+            cell.setShadowType(m_shadowType, false);
+            cell.setShadowColor(m_shadowColor, false);
+            cell.setShadowSize(m_shadowSize, false);
+            cell.setShadowOpacity(m_shadowOpacity, false);
+        }
+    }
 
     // Reset all visibility flags before scanning cells
     m_showDepth = false;
@@ -820,6 +1043,7 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     }
 
     emit templateChanged();
+    emit shadowChanged();
     emit cellsChanged();
     emit cellLayoutChanged();
     emit showDepthChanged();
@@ -845,6 +1069,11 @@ Unabara::OverlayTemplate OverlayGenerator::exportTemplate() const
     templ.setBackgroundOpacity(m_backgroundOpacity);
     templ.setDefaultFont(m_font);
     templ.setDefaultTextColor(m_textColor);
+    templ.setDefaultShadowEnabled(m_shadowEnabled);
+    templ.setDefaultShadowType(m_shadowType);
+    templ.setDefaultShadowColor(m_shadowColor);
+    templ.setDefaultShadowSize(m_shadowSize);
+    templ.setDefaultShadowOpacity(m_shadowOpacity);
     templ.setCells(m_cells);
     return templ;
 }
@@ -1426,6 +1655,72 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
     }
 }
 
+namespace {
+
+// One separable sliding-window box blur pass over a premultiplied ARGB32 image.
+// Blurring all 4 channels of premultiplied data is alpha-correct.
+void boxBlurPass(QImage& img, int radius)
+{
+    const int w = img.width();
+    const int h = img.height();
+    const int window = 2 * radius + 1;
+    QVector<QRgb> line(qMax(w, h));
+
+    // Horizontal pass
+    for (int y = 0; y < h; ++y) {
+        QRgb* row = reinterpret_cast<QRgb*>(img.scanLine(y));
+        int sumA = 0, sumR = 0, sumG = 0, sumB = 0;
+        for (int x = -radius; x <= radius; ++x) {
+            QRgb p = row[qBound(0, x, w - 1)];
+            sumA += qAlpha(p); sumR += qRed(p); sumG += qGreen(p); sumB += qBlue(p);
+        }
+        for (int x = 0; x < w; ++x) {
+            line[x] = qRgba(sumR / window, sumG / window, sumB / window, sumA / window);
+            QRgb pOut = row[qBound(0, x - radius, w - 1)];
+            QRgb pIn = row[qBound(0, x + radius + 1, w - 1)];
+            sumA += qAlpha(pIn) - qAlpha(pOut);
+            sumR += qRed(pIn) - qRed(pOut);
+            sumG += qGreen(pIn) - qGreen(pOut);
+            sumB += qBlue(pIn) - qBlue(pOut);
+        }
+        memcpy(row, line.constData(), w * sizeof(QRgb));
+    }
+
+    // Vertical pass
+    const qsizetype stride = img.bytesPerLine() / sizeof(QRgb);
+    QRgb* bits = reinterpret_cast<QRgb*>(img.bits());
+    for (int x = 0; x < w; ++x) {
+        int sumA = 0, sumR = 0, sumG = 0, sumB = 0;
+        for (int y = -radius; y <= radius; ++y) {
+            QRgb p = bits[qBound(0, y, h - 1) * stride + x];
+            sumA += qAlpha(p); sumR += qRed(p); sumG += qGreen(p); sumB += qBlue(p);
+        }
+        for (int y = 0; y < h; ++y) {
+            line[y] = qRgba(sumR / window, sumG / window, sumB / window, sumA / window);
+            QRgb pOut = bits[qBound(0, y - radius, h - 1) * stride + x];
+            QRgb pIn = bits[qBound(0, y + radius + 1, h - 1) * stride + x];
+            sumA += qAlpha(pIn) - qAlpha(pOut);
+            sumR += qRed(pIn) - qRed(pOut);
+            sumG += qGreen(pIn) - qGreen(pOut);
+            sumB += qBlue(pIn) - qBlue(pOut);
+        }
+        for (int y = 0; y < h; ++y) {
+            bits[y * stride + x] = line[y];
+        }
+    }
+}
+
+// Three box blur passes approximate a gaussian blur.
+void boxBlur(QImage& img, int radius)
+{
+    if (radius < 1) return;
+    for (int i = 0; i < 3; ++i) {
+        boxBlurPass(img, radius);
+    }
+}
+
+} // anonymous namespace
+
 void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& imageSize,
                                               const DiveDataPoint& dataPoint, DiveData* dive)
 {
@@ -1440,6 +1735,14 @@ void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& im
         // Get effective font and color (same as before)
         QFont effectiveFont = cell.hasCustomFont() ? cell.font() : m_font;
         QColor effectiveColor = cell.hasCustomColor() ? cell.textColor() : m_textColor;
+
+        // Effective shadow settings (single hasCustomShadow flag covers the group)
+        const bool customShadow = cell.hasCustomShadow();
+        const bool shadowEnabled = customShadow ? cell.shadowEnabled() : m_shadowEnabled;
+        const Unabara::ShadowType shadowType = customShadow ? cell.shadowType() : m_shadowType;
+        QColor shadowColor = customShadow ? cell.shadowColor() : m_shadowColor;
+        const int shadowSize = customShadow ? cell.shadowSize() : m_shadowSize;
+        const double shadowOpacity = customShadow ? cell.shadowOpacity() : m_shadowOpacity;
 
         // Generate displayText (same format as QML CellModel)
         QString displayText = generateCellDisplayText(cell.cellType(), dataPoint,
@@ -1474,6 +1777,46 @@ void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& im
         if (m_showCellBackgrounds) {
             QRect bgRect(pixelX, pixelY, cellWidth, cellHeight);
             painter.fillRect(bgRect, QColor(0, 0, 0, 128));
+        }
+
+        // Draw the shadow first, if enabled (same 1.8 scale factor as fonts)
+        if (shadowEnabled && !displayText.isEmpty()) {
+            shadowColor.setAlphaF(shadowColor.alphaF() * shadowOpacity);
+            const int spx = qMax(1, qRound(shadowSize * 1.8));
+
+            switch (shadowType) {
+            case Unabara::ShadowType::Offset:
+                painter.setPen(shadowColor);
+                painter.drawText(cellRect.translated(spx, spx),
+                                 Qt::AlignHCenter | Qt::TextDontClip, displayText);
+                break;
+            case Unabara::ShadowType::Outline: {
+                static const QPoint dirs[8] = {{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
+                painter.setPen(shadowColor);
+                for (const QPoint& d : dirs) {
+                    painter.drawText(cellRect.translated(d.x() * spx, d.y() * spx),
+                                     Qt::AlignHCenter | Qt::TextDontClip, displayText);
+                }
+                break;
+            }
+            case Unabara::ShadowType::Blurred: {
+                // Render the text into its own image, blur it, composite offset
+                const int margin = spx * 3;  // room for the blur to spread
+                QImage shadowImg(cellWidth + 2 * margin, cellHeight + 2 * margin,
+                                 QImage::Format_ARGB32_Premultiplied);
+                shadowImg.fill(Qt::transparent);
+                {
+                    QPainter sp(&shadowImg);
+                    sp.setFont(renderFont);
+                    sp.setPen(shadowColor);
+                    sp.drawText(QRect(margin + 4, margin + 4, cellWidth - 8, cellHeight - 8),
+                                Qt::AlignHCenter | Qt::TextDontClip, displayText);
+                }
+                boxBlur(shadowImg, spx);
+                painter.drawImage(QPoint(pixelX - margin + spx, pixelY - margin + spx), shadowImg);
+                break;
+            }
+            }
         }
 
         // Draw the text (center-aligned to match QML's Text.AlignHCenter)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,7 @@ int main(int argc, char *argv[])
     QObject::connect(overlayGenerator, &OverlayGenerator::showTimeChanged,          invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::backgroundOpacityChanged, invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showLabelChanged,         invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::shadowChanged,            invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showPO2Cell1Changed,      invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showPO2Cell2Changed,      invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showPO2Cell3Changed,      invalidateOverlay);
@@ -133,6 +134,7 @@ int main(int argc, char *argv[])
     undoManager->trackSignal(SIGNAL(backgroundOpacityChanged()));
     undoManager->trackSignal(SIGNAL(templateChanged()));
     undoManager->trackSignal(SIGNAL(showLabelChanged()));
+    undoManager->trackSignal(SIGNAL(shadowChanged()));
 
     // History boundaries: a template file load (combobox / Load button) and a
     // dive import both reset undo history so it never crosses them. templateLoaded

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -51,6 +51,18 @@ QVariant CellModel::data(const QModelIndex &index, int role) const
         return cell.showLabel();
     case HasCustomShowLabelRole:
         return cell.hasCustomShowLabel();
+    case ShadowEnabledRole:
+        return cell.shadowEnabled();
+    case ShadowTypeRole:
+        return static_cast<int>(cell.shadowType());
+    case ShadowColorRole:
+        return cell.shadowColor();
+    case ShadowSizeRole:
+        return cell.shadowSize();
+    case ShadowOpacityRole:
+        return cell.shadowOpacity();
+    case HasCustomShadowRole:
+        return cell.hasCustomShadow();
     default:
         return QVariant();
     }
@@ -72,6 +84,12 @@ QHash<int, QByteArray> CellModel::roleNames() const
     roles[TankIndexRole] = "tankIndex";
     roles[ShowLabelRole] = "showLabel";
     roles[HasCustomShowLabelRole] = "hasCustomShowLabel";
+    roles[ShadowEnabledRole] = "shadowEnabled";
+    roles[ShadowTypeRole] = "shadowType";
+    roles[ShadowColorRole] = "shadowColor";
+    roles[ShadowSizeRole] = "shadowSize";
+    roles[ShadowOpacityRole] = "shadowOpacity";
+    roles[HasCustomShadowRole] = "hasCustomShadow";
     return roles;
 }
 

--- a/src/ui/qml/InteractiveOverlayPreview.qml
+++ b/src/ui/qml/InteractiveOverlayPreview.qml
@@ -391,6 +391,19 @@ Item {
                         hasCustomFont: model.hasCustomFont
                         hasCustomColor: model.hasCustomColor
 
+                        // Shadow settings from model
+                        shadowEnabled: model.shadowEnabled
+                        shadowType: model.shadowType
+                        shadowColor: model.shadowColor
+                        shadowOpacity: model.shadowOpacity
+                        shadowPx: {
+                            var scaleX = root.generator && root.generator.templateWidth > 0
+                                ? cellContainer.width / root.generator.templateWidth : 1.0
+                            // 1.8 matches the C++ shadow scale in renderCellBasedOverlay
+                            return Math.max(1, model.shadowSize * 1.8 * scaleX)
+                        }
+                        hasCustomShadow: model.hasCustomShadow
+
                         // Selection state
                         selected: model.cellId === interactivePreview.selectedCellId
 

--- a/src/ui/qml/OverlayCell.qml
+++ b/src/ui/qml/OverlayCell.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Effects
 
 /**
  * Individual overlay cell component
@@ -26,6 +27,12 @@ Rectangle {
     property bool overlapping: false
     property bool hasCustomFont: false
     property bool hasCustomColor: false
+    property bool shadowEnabled: false
+    property int shadowType: 0            // 0 = offset, 1 = blurred, 2 = outline
+    property color shadowColor: "black"
+    property real shadowPx: 2             // pre-scaled by the delegate (size * 1.8 * scaleX)
+    property real shadowOpacity: 0.7
+    property bool hasCustomShadow: false
     property bool dragging: mouseArea.drag.active  // Expose drag state
     property var generator: null  // Reference to overlay generator for snap settings
     property bool showBackground: true  // Show cell background (editor only, not for export)
@@ -43,6 +50,35 @@ Rectangle {
     border.color: selected ? "lime" : "transparent"
     border.width: selected ? 3 : 0
 
+    // Slight background for better visibility (editor only).
+    // Kept as first sibling so shadows and text paint above it.
+    Rectangle {
+        anchors.fill: cellText
+        anchors.margins: -4
+        color: "#80000000"  // Semi-transparent black background
+        radius: 4
+        visible: cellRoot.showBackground
+    }
+
+    // Crisp offset (1 copy) / outline (8 copies) shadow — drawn beneath the text
+    Repeater {
+        model: (!cellRoot.shadowEnabled || cellRoot.shadowType === 1) ? []
+             : cellRoot.shadowType === 0 ? [Qt.point(1, 1)]
+             : [Qt.point(-1, -1), Qt.point(0, -1), Qt.point(1, -1), Qt.point(-1, 0),
+                Qt.point(1, 0), Qt.point(-1, 1), Qt.point(0, 1), Qt.point(1, 1)]
+        delegate: Text {
+            x: 4 + modelData.x * cellRoot.shadowPx
+            y: 4 + modelData.y * cellRoot.shadowPx
+            text: cellRoot.displayText
+            font: cellRoot.cellFont
+            color: cellRoot.shadowColor
+            opacity: cellRoot.shadowOpacity
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignTop
+            wrapMode: Text.NoWrap
+        }
+    }
+
     // Cell content
     Text {
         id: cellText
@@ -54,16 +90,24 @@ Rectangle {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignTop
         wrapMode: Text.NoWrap
+        // In blurred mode MultiEffect renders the text (plus its shadow);
+        // an invisible Text still computes its size, so layout is unaffected
+        visible: !(cellRoot.shadowEnabled && cellRoot.shadowType === 1)
+    }
 
-        // Add slight background for better visibility (editor only)
-        Rectangle {
-            anchors.fill: parent
-            anchors.margins: -4
-            color: "#80000000"  // Semi-transparent black background
-            radius: 4
-            z: -1
-            visible: cellRoot.showBackground
-        }
+    // Soft blurred shadow (renders the text and its blurred shadow together)
+    MultiEffect {
+        source: cellText
+        anchors.fill: cellText
+        visible: cellRoot.shadowEnabled && cellRoot.shadowType === 1
+        shadowEnabled: true
+        shadowColor: cellRoot.shadowColor
+        shadowOpacity: cellRoot.shadowOpacity
+        shadowHorizontalOffset: cellRoot.shadowPx
+        shadowVerticalOffset: cellRoot.shadowPx
+        blurMax: 64
+        shadowBlur: Math.min(1.0, cellRoot.shadowPx * 2 / 64)
+        autoPaddingEnabled: true
     }
 
     // Custom property indicators
@@ -104,6 +148,24 @@ Rectangle {
 
             MouseArea {
                 id: customColorMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+            }
+        }
+
+        // Custom shadow indicator
+        Rectangle {
+            width: 8
+            height: 8
+            radius: 4
+            color: "orange"
+            visible: hasCustomShadow
+
+            ToolTip.visible: customShadowMouseArea.containsMouse
+            ToolTip.text: "Custom shadow"
+
+            MouseArea {
+                id: customShadowMouseArea
                 anchors.fill: parent
                 hoverEnabled: true
             }

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -21,6 +21,12 @@ Item {
     property bool currentHasCustomColor: getSelectedCellHasCustomColor()
     property bool currentShowLabel: getCurrentShowLabel()
     property bool currentHasCustomShowLabel: getSelectedCellHasCustomShowLabel()
+    property bool currentShadowEnabled: getCurrentShadowEnabled()
+    property int currentShadowType: getCurrentShadowType()
+    property color currentShadowColor: getCurrentShadowColor()
+    property int currentShadowSize: getCurrentShadowSize()
+    property real currentShadowOpacity: getCurrentShadowOpacity()
+    property bool currentHasCustomShadow: getSelectedCellHasCustomShadow()
 
     implicitHeight: mainColumn.implicitHeight
 
@@ -94,6 +100,64 @@ Item {
         return hasCustom === true
     }
 
+    // Get the effective shadow settings (selected cell or global)
+    function getCurrentShadowEnabled() {
+        if (!generator) return false
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellShadowEnabled(selectedCellId)
+        }
+
+        return generator.shadowEnabled
+    }
+
+    function getCurrentShadowType() {
+        if (!generator) return 0
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellShadowType(selectedCellId)
+        }
+
+        return generator.shadowType
+    }
+
+    function getCurrentShadowColor() {
+        if (!generator) return "black"
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellShadowColor(selectedCellId)
+        }
+
+        return generator.shadowColor
+    }
+
+    function getCurrentShadowSize() {
+        if (!generator) return 2
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellShadowSize(selectedCellId)
+        }
+
+        return generator.shadowSize
+    }
+
+    function getCurrentShadowOpacity() {
+        if (!generator) return 0.7
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellShadowOpacity(selectedCellId)
+        }
+
+        return generator.shadowOpacity
+    }
+
+    function getSelectedCellHasCustomShadow() {
+        if (!hasSelection || !selectedCellId) return false
+
+        var hasCustom = getCellProperty(selectedCellId, "hasCustomShadow")
+        return hasCustom === true
+    }
+
     // Update reactive properties when selection or cells change
     onSelectedCellIdChanged: {
         console.log("Selection changed to:", selectedCellId)
@@ -128,6 +192,13 @@ Item {
                 updateCurrentProperties()
             }
         }
+
+        function onShadowChanged() {
+            if (!hasSelection) {
+                console.log("Global shadow changed")
+                updateCurrentProperties()
+            }
+        }
     }
 
     function updateCurrentProperties() {
@@ -140,6 +211,12 @@ Item {
         currentHasCustomColor = getSelectedCellHasCustomColor()
         currentShowLabel = getCurrentShowLabel()
         currentHasCustomShowLabel = getSelectedCellHasCustomShowLabel()
+        currentShadowEnabled = getCurrentShadowEnabled()
+        currentShadowType = getCurrentShadowType()
+        currentShadowColor = getCurrentShadowColor()
+        currentShadowSize = getCurrentShadowSize()
+        currentShadowOpacity = getCurrentShadowOpacity()
+        currentHasCustomShadow = getSelectedCellHasCustomShadow()
     }
 
     // Cell model for interactive preview
@@ -744,6 +821,120 @@ Item {
                     }
                 }
 
+                Label { text: qsTr("Shadow:") }
+                CheckBox {
+                    id: shadowEnabledCheckBox
+                    Layout.fillWidth: true
+                    text: qsTr("Enable text shadow")
+                    checked: root.currentShadowEnabled
+                    Connections {
+                        target: root
+                        function onCurrentShadowEnabledChanged() {
+                            shadowEnabledCheckBox.checked = root.currentShadowEnabled
+                        }
+                    }
+                    onClicked: {
+                        if (root.generator) {
+                            root.generator.shadowEnabled = checked
+                        }
+                    }
+                }
+
+                Button {
+                    text: "↺"
+                    Layout.preferredWidth: 40
+                    enabled: root.hasSelection && root.currentHasCustomShadow
+                    opacity: enabled ? 1.0 : 0.3
+                    ToolTip.visible: hovered
+                    ToolTip.text: enabled ? qsTr("Reset to global shadow settings") : qsTr("No custom shadow settings")
+                    onClicked: {
+                        if (root.generator && root.selectedCellId) {
+                            root.generator.resetCellShadow(root.selectedCellId)
+                        }
+                    }
+                }
+
+                Label { text: qsTr("Shadow type:") }
+                ComboBox {
+                    id: shadowTypeCombo
+                    Layout.fillWidth: true
+                    enabled: root.currentShadowEnabled
+                    model: [qsTr("Crisp offset"), qsTr("Soft blurred"), qsTr("Outline")]
+                    currentIndex: root.currentShadowType
+                    Connections {
+                        target: root
+                        function onCurrentShadowTypeChanged() {
+                            shadowTypeCombo.currentIndex = root.currentShadowType
+                        }
+                    }
+                    onActivated: {
+                        if (root.generator) {
+                            root.generator.shadowType = currentIndex
+                        }
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                Label { text: qsTr("Shadow color:") }
+                Button {
+                    id: shadowColorButton
+                    Layout.fillWidth: true
+                    enabled: root.currentShadowEnabled
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.currentShadowColor
+                        opacity: shadowColorButton.enabled ? 1.0 : 0.3
+                    }
+
+                    onClicked: shadowColorDialog.open()
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                Label { text: qsTr("Shadow size:") }
+                SpinBox {
+                    id: shadowSizeSpinBox
+                    from: 1
+                    to: 10
+                    enabled: root.currentShadowEnabled
+                    value: root.currentShadowSize
+                    Connections {
+                        target: root
+                        function onCurrentShadowSizeChanged() {
+                            shadowSizeSpinBox.value = root.currentShadowSize
+                        }
+                    }
+                    onValueModified: {
+                        if (root.generator) {
+                            root.generator.shadowSize = value
+                        }
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
+                Label { text: qsTr("Shadow opacity:") }
+                Slider {
+                    id: shadowOpacitySlider
+                    Layout.fillWidth: true
+                    from: 0.0
+                    to: 1.0
+                    enabled: root.currentShadowEnabled
+                    value: root.currentShadowOpacity
+                    Connections {
+                        target: root
+                        function onCurrentShadowOpacityChanged() {
+                            shadowOpacitySlider.value = root.currentShadowOpacity
+                        }
+                    }
+                    onMoved: {
+                        if (root.generator) {
+                            root.generator.shadowOpacity = value
+                        }
+                    }
+                }
+                Item { Layout.preferredWidth: 40 }
+
             }
         }
         
@@ -986,6 +1177,23 @@ Item {
 
         onAccepted: {
             if (generator) generator.textColor = selectedColor
+        }
+    }
+
+    ColorDialog {
+        id: shadowColorDialog
+        title: qsTr("Select Shadow Color")
+        selectedColor: root.currentShadowColor
+
+        Connections {
+            target: root
+            function onCurrentShadowColorChanged() {
+                shadowColorDialog.selectedColor = root.currentShadowColor
+            }
+        }
+
+        onAccepted: {
+            if (generator) generator.shadowColor = selectedColor
         }
     }
 

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -447,6 +447,11 @@ ApplicationWindow {
                         function onFontChanged() { previewImage.updatePreview() }
                         function onTextColorChanged() { previewImage.updatePreview() }
                         function onBackgroundOpacityChanged() { previewImage.updatePreview() }
+                        function onShadowChanged() { previewImage.updatePreview() }
+                        function onShowLabelChanged() { previewImage.updatePreview() }
+                        // Per-cell edits (font, color, showLabel, shadow on a selected
+                        // cell) only emit cellsChanged — refresh the preview for those too
+                        function onCellsChanged() { previewImage.updatePreview() }
                     }
                     
                     // Monitor changes to config properties (unit system only)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(unabara_testlib STATIC
     ${CMAKE_SOURCE_DIR}/include/core/log_parser.h
     ${CMAKE_SOURCE_DIR}/include/core/units.h
     ${CMAKE_SOURCE_DIR}/src/core/cell_data.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/overlay_template.cpp
     ${CMAKE_SOURCE_DIR}/src/core/dive_data.cpp
     ${CMAKE_SOURCE_DIR}/src/core/log_parser.cpp
     ${CMAKE_SOURCE_DIR}/src/core/units.cpp
@@ -51,3 +52,4 @@ unabara_add_test(subsurface_parser_test)
 unabara_add_test(uddf_parser_test)
 unabara_add_test(core_utils_test)
 unabara_add_test(cell_data_test)
+unabara_add_test(overlay_template_test)

--- a/tests/cell_data_test.cpp
+++ b/tests/cell_data_test.cpp
@@ -10,6 +10,7 @@
 
 using Unabara::CellData;
 using Unabara::CellType;
+using Unabara::ShadowType;
 
 class CellDataTest : public QObject
 {
@@ -34,6 +35,21 @@ private slots:
                  CellType::Unknown);
     }
 
+    void shadowTypeStringRoundTrip()
+    {
+        const QList<ShadowType> all = {
+            ShadowType::Offset, ShadowType::Blurred, ShadowType::Outline,
+        };
+        for (ShadowType type : all) {
+            const QString str = CellData::shadowTypeToString(type);
+            QVERIFY2(!str.isEmpty(), "empty shadow type string");
+            QCOMPARE(CellData::shadowTypeFromString(str), type);
+        }
+        // Unknown strings (e.g. from a newer template) degrade gracefully
+        QCOMPARE(CellData::shadowTypeFromString(QStringLiteral("FutureShadow")),
+                 ShadowType::Offset);
+    }
+
     void jsonRoundTripPreservesCell()
     {
         CellData cell(QStringLiteral("tank_1"), CellType::Pressure);
@@ -45,6 +61,11 @@ private slots:
         font.setBold(true);
         cell.setFont(font, true);
         cell.setTextColor(QColor(255, 128, 0), true);
+        cell.setShadowEnabled(true);
+        cell.setShadowType(ShadowType::Outline);
+        cell.setShadowColor(QColor(0, 0, 255, 200));
+        cell.setShadowSize(5);
+        cell.setShadowOpacity(0.4);
 
         const CellData restored = CellData::fromJson(cell.toJson());
         QCOMPARE(restored.cellId(), QStringLiteral("tank_1"));
@@ -57,17 +78,28 @@ private slots:
         QCOMPARE(restored.font().pointSize(), 18);
         QVERIFY(restored.font().bold());
         QCOMPARE(restored.textColor(), QColor(255, 128, 0));
+        QCOMPARE(restored.shadowEnabled(), true);
+        QCOMPARE(restored.shadowType(), ShadowType::Outline);
+        QCOMPARE(restored.shadowColor(), QColor(0, 0, 255, 200));
+        QCOMPARE(restored.shadowSize(), 5);
+        QCOMPARE(restored.shadowOpacity(), 0.4);
+        QVERIFY(restored.hasCustomShadow());
     }
 
     void jsonDefaultsSurviveMinimalInput()
     {
-        // A minimal cell (no custom font/color) must round-trip without
+        // A minimal cell (no custom font/color/shadow) must round-trip without
         // inventing custom styling
         CellData cell(QStringLiteral("depth"), CellType::Depth);
         const CellData restored = CellData::fromJson(cell.toJson());
         QCOMPARE(restored.cellId(), QStringLiteral("depth"));
         QCOMPARE(restored.cellType(), CellType::Depth);
         QCOMPARE(restored.visible(), true);
+        QCOMPARE(restored.shadowEnabled(), false);
+        QCOMPARE(restored.shadowType(), ShadowType::Offset);
+        QCOMPARE(restored.shadowSize(), 2);
+        QCOMPARE(restored.shadowOpacity(), 0.7);
+        QVERIFY(!restored.hasCustomShadow());
     }
 };
 

--- a/tests/overlay_template_test.cpp
+++ b/tests/overlay_template_test.cpp
@@ -1,0 +1,68 @@
+// Tests for OverlayTemplate: the global default settings (font, color, shadow)
+// must survive a toJson/fromJson round-trip — undo snapshots and .utp save/load
+// both go through this path.
+
+#include <QtTest>
+
+#include <QFont>
+#include <QJsonObject>
+
+#include "include/core/overlay_template.h"
+
+using Unabara::CellData;
+using Unabara::CellType;
+using Unabara::OverlayTemplate;
+using Unabara::ShadowType;
+
+class OverlayTemplateTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void jsonRoundTripPreservesDefaults()
+    {
+        OverlayTemplate templ;
+        templ.setTemplateName(QStringLiteral("Test Template"));
+        templ.setBackgroundImagePath(QStringLiteral(":/images/test.png"));
+        templ.setBackgroundOpacity(0.5);
+        templ.setDefaultFont(QFont(QStringLiteral("Monospace"), 18));
+        templ.setDefaultTextColor(QColor(255, 128, 0));
+        templ.setDefaultShadowEnabled(true);
+        templ.setDefaultShadowType(ShadowType::Blurred);
+        templ.setDefaultShadowColor(QColor(10, 20, 30, 200));
+        templ.setDefaultShadowSize(7);
+        templ.setDefaultShadowOpacity(0.4);
+        templ.addCell(CellData(QStringLiteral("depth"), CellType::Depth));
+
+        const OverlayTemplate restored = OverlayTemplate::fromJson(templ.toJson());
+        QCOMPARE(restored.templateName(), QStringLiteral("Test Template"));
+        QCOMPARE(restored.backgroundOpacity(), 0.5);
+        QCOMPARE(restored.defaultFont().family(), QStringLiteral("Monospace"));
+        QCOMPARE(restored.defaultTextColor(), QColor(255, 128, 0));
+        QCOMPARE(restored.defaultShadowEnabled(), true);
+        QCOMPARE(restored.defaultShadowType(), ShadowType::Blurred);
+        QCOMPARE(restored.defaultShadowColor(), QColor(10, 20, 30, 200));
+        QCOMPARE(restored.defaultShadowSize(), 7);
+        QCOMPARE(restored.defaultShadowOpacity(), 0.4);
+        QCOMPARE(restored.cellCount(), 1);
+    }
+
+    void shadowDefaultsSurviveMissingKeys()
+    {
+        // Old .utp files predate the shadow fields — loading them must yield
+        // the shadow defaults (disabled, offset, size 2, opacity 0.7)
+        QJsonObject json;
+        json[QStringLiteral("version")] = QStringLiteral("1.0");
+        json[QStringLiteral("templateName")] = QStringLiteral("Legacy");
+
+        const OverlayTemplate restored = OverlayTemplate::fromJson(json);
+        QCOMPARE(restored.defaultShadowEnabled(), false);
+        QCOMPARE(restored.defaultShadowType(), ShadowType::Offset);
+        QCOMPARE(restored.defaultShadowColor(), QColor(0, 0, 0));
+        QCOMPARE(restored.defaultShadowSize(), 2);
+        QCOMPARE(restored.defaultShadowOpacity(), 0.7);
+    }
+};
+
+QTEST_MAIN(OverlayTemplateTest)
+#include "overlay_template_test.moc"


### PR DESCRIPTION

Adds a shadow option to the overlay editor's Text Settings: enable
checkbox, style selector (crisp offset, soft blurred, outline), color
picker, size spinbox (1-10 px) and opacity slider.

- Rendered by both pipelines: QPainter (offset/outline redraw, 3-pass
  box blur for the soft style) and QML preview (stacked Text copies,
  MultiEffect for blur) with matching 1.8x scale
- Respects global vs per-cell settings via a single hasCustomShadow
  group flag, with reset button and orange cell indicator
- Persisted per-cell and as defaultShadow* template globals in .utp;
  legacy templates load unchanged with shadows off
- Undo/redo tracks shadow edits; left preview now also refreshes on
  per-cell edits (fixes pre-existing staleness for font/color/label)
- New tests: shadow round-trip in cell_data_test, new
  overlay_template_test for template defaults
