### PR TITLE
feat: split NDL/TTS deco info into dedicated STOP and TIME cells + optimizations

### DIFF
--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -28,6 +28,8 @@ enum class CellType {
     MeanDepth,        // Average depth of the dive (static, reported by the dive computer)
     MaxDepth,         // Maximum depth reached so far (running max, like the DC's MAX field)
     Gas,              // Currently breathed gas mix (from gas switches)
+    StopDepth,        // Current deco stop depth ("STOP")
+    StopTime,         // Time at the current deco stop ("TIME")
     Unknown
 };
 

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -35,6 +35,9 @@ class Config : public QObject
     Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
     Q_PROPERTY(bool showMaxDepth READ showMaxDepth WRITE setShowMaxDepth NOTIFY showMaxDepthChanged)
     Q_PROPERTY(bool showGas READ showGas WRITE setShowGas NOTIFY showGasChanged)
+    Q_PROPERTY(bool showTTS READ showTTS WRITE setShowTTS NOTIFY showTTSChanged)
+    Q_PROPERTY(bool showStopDepth READ showStopDepth WRITE setShowStopDepth NOTIFY showStopDepthChanged)
+    Q_PROPERTY(bool showStopTime READ showStopTime WRITE setShowStopTime NOTIFY showStopTimeChanged)
     Q_PROPERTY(Units::UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
     
     // CCR settings
@@ -119,6 +122,12 @@ public:
     void setShowMaxDepth(bool show);
     bool showGas() const;
     void setShowGas(bool show);
+    bool showTTS() const;
+    void setShowTTS(bool show);
+    bool showStopDepth() const;
+    void setShowStopDepth(bool show);
+    bool showStopTime() const;
+    void setShowStopTime(bool show);
 
     Units::UnitSystem unitSystem() const;
     void setUnitSystem(Units::UnitSystem system);
@@ -240,6 +249,9 @@ signals:
     void showMeanDepthChanged();
     void showMaxDepthChanged();
     void showGasChanged();
+    void showTTSChanged();
+    void showStopDepthChanged();
+    void showStopTimeChanged();
     void unitSystemChanged();
     void frameRateChanged();
     void templateDirectoryChanged();
@@ -302,6 +314,9 @@ private:
     bool m_showMeanDepth;
     bool m_showMaxDepth;
     bool m_showGas;
+    bool m_showTTS;
+    bool m_showStopDepth;
+    bool m_showStopTime;
     Units::UnitSystem m_unitSystem;
     double m_frameRate;
     QString m_templateDirectory;

--- a/include/core/dive_data.h
+++ b/include/core/dive_data.h
@@ -14,19 +14,20 @@ struct DiveDataPoint {
     double depth;               // Depth in meters
     double temperature;         // Temperature in Celsius
     QVector<double> pressures;  // Tank pressures in bar (multiple cylinders)
-    double ndl;                 // No Decompression Limit in minutes
+    double ndl;                 // No Decompression Limit in minutes (-1 = no data, 0 = in deco)
     double ceiling;             // Decompression ceiling in meters
     double o2percent;           // O2 percentage
     double tts;                 // Time To Surface in minutes
     double cns;                 // CNS oxygen toxicity in percent (-1 = no data)
+    double stopTime;            // Time at the current deco stop in minutes (0 = no stop)
     QVector<double> po2Sensors; // PO2 sensor values in bar (for CCR dives)
 
     // Constructor with default values
     DiveDataPoint(double time = 0.0, double d = 0.0, double temp = 0.0,
-                  double n = 0.0, double ceil = 0.0,
+                  double n = -1.0, double ceil = 0.0,
                   double o2 = 21.0, double t = 0.0)
         : timestamp(time), depth(d), temperature(temp),
-          ndl(n), ceiling(ceil), o2percent(o2), tts(t), cns(-1.0) {}
+          ndl(n), ceiling(ceil), o2percent(o2), tts(t), cns(-1.0), stopTime(0.0) {}
           
     // Get the pressure for a specific tank (returns 0 if tank doesn't exist)
     Q_INVOKABLE double getPressure(int tankIndex = 0) const {

--- a/include/core/format_parsers/subsurface_parser.h
+++ b/include/core/format_parsers/subsurface_parser.h
@@ -47,6 +47,7 @@ private:
 
     QMap<int, double> m_initialCylinderPressures;
     double m_lastCeiling = 0.0;
+    double m_lastStopTime = 0.0;
     QList<GasSwitch> m_gasSwitches;
     double m_diveDuration = 0.0;
     QMap<QString, DiveSite> m_diveSites;

--- a/include/core/format_parsers/uddf_parser.h
+++ b/include/core/format_parsers/uddf_parser.h
@@ -51,6 +51,7 @@ private:
                        double &lastNDL,
                        double &lastTTS,
                        double &lastCeiling,
+                       double &lastStopTime,
                        double &lastCNS,
                        QMap<int, double> &lastPressures,
                        QMap<int, double> &lastPO2Sensors,

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -39,6 +39,9 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(bool showMeanDepth READ showMeanDepth WRITE setShowMeanDepth NOTIFY showMeanDepthChanged)
     Q_PROPERTY(bool showMaxDepth READ showMaxDepth WRITE setShowMaxDepth NOTIFY showMaxDepthChanged)
     Q_PROPERTY(bool showGas READ showGas WRITE setShowGas NOTIFY showGasChanged)
+    Q_PROPERTY(bool showTTS READ showTTS WRITE setShowTTS NOTIFY showTTSChanged)
+    Q_PROPERTY(bool showStopDepth READ showStopDepth WRITE setShowStopDepth NOTIFY showStopDepthChanged)
+    Q_PROPERTY(bool showStopTime READ showStopTime WRITE setShowStopTime NOTIFY showStopTimeChanged)
 
     // CCR properties
     Q_PROPERTY(bool showPO2Cell1 READ showPO2Cell1 WRITE setShowPO2Cell1 NOTIFY showPO2Cell1Changed)
@@ -82,6 +85,9 @@ public:
     bool showMeanDepth() const { return m_showMeanDepth; }
     bool showMaxDepth() const { return m_showMaxDepth; }
     bool showGas() const { return m_showGas; }
+    bool showTTS() const { return m_showTTS; }
+    bool showStopDepth() const { return m_showStopDepth; }
+    bool showStopTime() const { return m_showStopTime; }
 
     // CCR getters
     bool showPO2Cell1() const { return m_showPO2Cell1; }
@@ -120,6 +126,9 @@ public:
     void setShowMeanDepth(bool show);
     void setShowMaxDepth(bool show);
     void setShowGas(bool show);
+    void setShowTTS(bool show);
+    void setShowStopDepth(bool show);
+    void setShowStopTime(bool show);
 
     // CCR setters
     void setShowPO2Cell1(bool show);
@@ -207,6 +216,9 @@ signals:
     void showMeanDepthChanged();
     void showMaxDepthChanged();
     void showGasChanged();
+    void showTTSChanged();
+    void showStopDepthChanged();
+    void showStopTimeChanged();
 
     // CCR signals
     void showPO2Cell1Changed();
@@ -255,6 +267,9 @@ private:
     bool m_showMeanDepth;
     bool m_showMaxDepth;
     bool m_showGas;
+    bool m_showTTS;
+    bool m_showStopDepth;
+    bool m_showStopTime;
 
     // CCR settings
     bool m_showPO2Cell1;

--- a/include/generators/profile_gen.h
+++ b/include/generators/profile_gen.h
@@ -3,7 +3,10 @@
 
 #include <QColor>
 #include <QImage>
+#include <QMutex>
 #include <QObject>
+
+#include <atomic>
 
 #include "include/core/dive_data.h"
 #include "include/generators/i_frame_generator.h"
@@ -118,6 +121,23 @@ signals:
     void gridShowLabelsChanged();
 
 private:
+    // Everything below the indicator (background, grid, deco zone, depth
+    // curve) is time-independent, so it is rendered once and cached. Each
+    // renderFrame() then just copies the cache and stamps the indicator —
+    // constant-time per pulse tick instead of O(sample count).
+    QImage renderBase(DiveData* dive);
+    void invalidateBaseCache();
+
+    // renderFrame() runs on the QML image-provider thread while setters run
+    // on the GUI thread: the mutex guards the cache, and the atomic
+    // generation counter lets setters invalidate without taking the lock.
+    QMutex m_baseCacheMutex;
+    QImage m_baseCache;
+    std::atomic<quint64> m_baseCacheGen { 1 };
+    quint64 m_baseCacheBuiltGen = 0;
+    DiveData* m_baseCacheDive = nullptr; // identity key only — never dereferenced
+    int m_baseCachePoints = -1;
+
     QColor m_backgroundColor;
     double m_backgroundOpacity;
     QColor m_curveColor;

--- a/resources/templates/CCR_Tek_Rugged.utp
+++ b/resources/templates/CCR_Tek_Rugged.utp
@@ -181,6 +181,52 @@
                 "y": 0.5859375
             },
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 11,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.66,
+                "y": 0.208
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 11,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.66,
+                "y": 0.315
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/resources/templates/CCR_Tek_Rugged_Less_Labels.utp
+++ b/resources/templates/CCR_Tek_Rugged_Less_Labels.utp
@@ -197,6 +197,54 @@
             },
             "showLabel": true,
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 11,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "hasCustomShowLabel": false,
+            "position": {
+                "x": 0.66,
+                "y": 0.208
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 11,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "hasCustomShowLabel": false,
+            "position": {
+                "x": 0.66,
+                "y": 0.315
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_1Tank_Ocean.utp
+++ b/resources/templates/OC_Rec_1Tank_Ocean.utp
@@ -113,6 +113,52 @@
                 "y": 0.22916666666666666
             },
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.25,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.55,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_1Tank_Titanium.utp
+++ b/resources/templates/OC_Rec_1Tank_Titanium.utp
@@ -113,6 +113,52 @@
                 "y": 0.22916666666666666
             },
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.25,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.55,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_NoTanks_Ocean.utp
+++ b/resources/templates/OC_Rec_NoTanks_Ocean.utp
@@ -90,6 +90,52 @@
                 "y": 0.59375
             },
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.2625,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.525,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_NoTanks_Titanium.utp
+++ b/resources/templates/OC_Rec_NoTanks_Titanium.utp
@@ -90,6 +90,52 @@
                 "y": 0.59375
             },
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.2625,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 64,
+                "width": 85
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "font": {
+                "bold": false,
+                "family": "Sans Serif",
+                "italic": false,
+                "pointSize": 15,
+                "weight": 400
+            },
+            "hasCustomColor": false,
+            "hasCustomFont": true,
+            "position": {
+                "x": 0.525,
+                "y": 0.735
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Tek_All_Data_4Tanks.utp
+++ b/resources/templates/OC_Tek_All_Data_4Tanks.utp
@@ -172,6 +172,38 @@
             },
             "textColor": "#fffbc30d",
             "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 87,
+                "width": 113
+            },
+            "cellId": "stop_depth",
+            "cellType": "StopDepth",
+            "hasCustomColor": false,
+            "hasCustomFont": false,
+            "position": {
+                "x": 0.65,
+                "y": 0.302
+            },
+            "showLabel": true,
+            "visible": true
+        },
+        {
+            "calculatedSize": {
+                "height": 87,
+                "width": 113
+            },
+            "cellId": "stop_time",
+            "cellType": "StopTime",
+            "hasCustomColor": false,
+            "hasCustomFont": false,
+            "position": {
+                "x": 0.65,
+                "y": 0.405
+            },
+            "showLabel": true,
+            "visible": true
         }
     ],
     "defaultFont": {

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -229,6 +229,8 @@ QString CellData::cellTypeToString(CellType type)
         case CellType::MeanDepth: return "MeanDepth";
         case CellType::MaxDepth: return "MaxDepth";
         case CellType::Gas: return "Gas";
+        case CellType::StopDepth: return "StopDepth";
+        case CellType::StopTime: return "StopTime";
         default: return "Unknown";
     }
 }
@@ -249,6 +251,8 @@ CellType CellData::cellTypeFromString(const QString& str)
     if (str == "MeanDepth") return CellType::MeanDepth;
     if (str == "MaxDepth") return CellType::MaxDepth;
     if (str == "Gas") return CellType::Gas;
+    if (str == "StopDepth") return CellType::StopDepth;
+    if (str == "StopTime") return CellType::StopTime;
     return CellType::Unknown;
 }
 

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -33,6 +33,9 @@ Config::Config(QObject *parent)
     , m_showMeanDepth(false)
     , m_showMaxDepth(false)
     , m_showGas(false)
+    , m_showTTS(false)
+    , m_showStopDepth(true)
+    , m_showStopTime(true)
     , m_unitSystem(Units::UnitSystem::Metric)
     , m_frameRate(10.0)
     , m_showPO2Cell1(false)
@@ -262,6 +265,45 @@ void Config::setShowGas(bool show)
     if (m_showGas != show) {
         m_showGas = show;
         emit showGasChanged();
+    }
+}
+
+bool Config::showTTS() const
+{
+    return m_showTTS;
+}
+
+void Config::setShowTTS(bool show)
+{
+    if (m_showTTS != show) {
+        m_showTTS = show;
+        emit showTTSChanged();
+    }
+}
+
+bool Config::showStopDepth() const
+{
+    return m_showStopDepth;
+}
+
+void Config::setShowStopDepth(bool show)
+{
+    if (m_showStopDepth != show) {
+        m_showStopDepth = show;
+        emit showStopDepthChanged();
+    }
+}
+
+bool Config::showStopTime() const
+{
+    return m_showStopTime;
+}
+
+void Config::setShowStopTime(bool show)
+{
+    if (m_showStopTime != show) {
+        m_showStopTime = show;
+        emit showStopTimeChanged();
     }
 }
 
@@ -601,6 +643,9 @@ void Config::loadConfig()
     m_showMeanDepth = m_settings.value("overlay/showMeanDepth", false).toBool();
     m_showMaxDepth = m_settings.value("overlay/showMaxDepth", false).toBool();
     m_showGas = m_settings.value("overlay/showGas", false).toBool();
+    m_showTTS = m_settings.value("overlay/showTTS", false).toBool();
+    m_showStopDepth = m_settings.value("overlay/showStopDepth", true).toBool();
+    m_showStopTime = m_settings.value("overlay/showStopTime", true).toBool();
 
     // Load CCR settings
     m_showPO2Cell1 = m_settings.value("overlay/showPO2Cell1", false).toBool();
@@ -751,6 +796,9 @@ void Config::saveConfig()
     m_settings.setValue("overlay/showMeanDepth", m_showMeanDepth);
     m_settings.setValue("overlay/showMaxDepth", m_showMaxDepth);
     m_settings.setValue("overlay/showGas", m_showGas);
+    m_settings.setValue("overlay/showTTS", m_showTTS);
+    m_settings.setValue("overlay/showStopDepth", m_showStopDepth);
+    m_settings.setValue("overlay/showStopTime", m_showStopTime);
 
     // Save CCR settings
     m_settings.setValue("overlay/showPO2Cell1", m_showPO2Cell1);

--- a/src/core/dive_data.cpp
+++ b/src/core/dive_data.cpp
@@ -274,7 +274,11 @@ DiveDataPoint DiveData::dataAtTime(double time) const
     result.timestamp = time;
     result.depth = prev.depth + factor * (next.depth - prev.depth);
     result.temperature = prev.temperature + factor * (next.temperature - prev.temperature);
-    result.ndl = prev.ndl + factor * (next.ndl - prev.ndl);
+    // NDL: -1 means "not reported by the computer" — never blend across the
+    // sentinel, or missing data would fabricate deco state
+    result.ndl = (prev.ndl < 0.0 || next.ndl < 0.0)
+        ? (factor >= 1.0 ? next.ndl : prev.ndl)
+        : prev.ndl + factor * (next.ndl - prev.ndl);
     result.o2percent = prev.o2percent + factor * (next.o2percent - prev.o2percent);
     result.tts = prev.tts + factor * (next.tts - prev.tts);
 
@@ -288,6 +292,9 @@ DiveDataPoint DiveData::dataAtTime(double time) const
     // Do NOT interpolate ceiling - use the value from the previous point
     // Ceiling is a state that persists until changed
     result.ceiling = prev.ceiling;
+
+    // Deco stop time is likewise a held state, not a continuous quantity
+    result.stopTime = prev.stopTime;
     
     // For in_deco state, we also shouldn't interpolate (though it's not part of DiveDataPoint directly)
     

--- a/src/core/format_parsers/fit_parser.cpp
+++ b/src/core/format_parsers/fit_parser.cpp
@@ -328,9 +328,10 @@ DiveData *FitParser::buildDive(const QList<FitMessage> &messages, const Metadata
     // they change, so missing fields reuse the previous sample's value.
     double lastDepth = 0.0;
     double lastTemperature = 0.0;
-    double lastNDL = 0.0;
+    double lastNDL = -1.0; // -1 = no NDL reported yet (not the same as 0 = deco)
     double lastTTS = 0.0;
     double lastCeiling = 0.0;
+    double lastStopTime = 0.0;
     double lastCNS = -1.0;
     QMap<int, double> lastPressures; // pressure channel -> bar
     QVector<quint32> tankSensors = meta.tankSensors;
@@ -428,6 +429,11 @@ DiveData *FitParser::buildDive(const QList<FitMessage> &messages, const Metadata
                     lastCeiling = message.value(93) / 1000.0; // next stop depth, mm -> m
                 }
                 point.ceiling = lastCeiling;
+
+                if (message.has(94)) {
+                    lastStopTime = message.value(94) / 60.0; // next stop time, s -> min
+                }
+                point.stopTime = lastStopTime;
 
                 if (message.has(97)) {
                     lastCNS = message.value(97); // percent

--- a/src/core/format_parsers/subsurface_parser.cpp
+++ b/src/core/format_parsers/subsurface_parser.cpp
@@ -32,6 +32,7 @@ void SubsurfaceParser::resetDiveState()
     m_initialCylinderPressures.clear();
     m_gasSwitches.clear();
     m_lastCeiling = 0.0;
+    m_lastStopTime = 0.0;
     m_currentDiveHasCcrCues = false;
 }
 
@@ -347,7 +348,7 @@ void SubsurfaceParser::parseDiveComputerElement(QXmlStreamReader &xml, DiveData 
     qDebug() << "Parsing divecomputer element";
 
     double lastTemperature = 0.0;
-    double lastNDL = 0.0;
+    double lastNDL = -1.0; // -1 = no NDL reported yet (not the same as 0 = deco)
     double lastTTS = 0.0;
     double lastCNS = -1.0;
 
@@ -738,6 +739,32 @@ void SubsurfaceParser::parseSampleElement(QXmlStreamReader &xml,
         }
     } else {
         point.ceiling = m_lastCeiling;
+    }
+
+    // Subsurface samples are delta-encoded: stoptime can appear with or
+    // without stopdepth, so it carries forward independently of the ceiling
+    if (attrs.hasAttribute("stoptime")) {
+        QString stopTimeStr = attrs.value("stoptime").toString();
+        QRegularExpression stopTimeRe("(\\d+):(\\d+)\\s+min");
+        QRegularExpressionMatch match = stopTimeRe.match(stopTimeStr);
+
+        if (match.hasMatch()) {
+            int minutes = match.captured(1).toInt();
+            int seconds = match.captured(2).toInt();
+            point.stopTime = minutes + seconds / 60.0;
+            m_lastStopTime = point.stopTime;
+            hasData = true;
+        } else {
+            bool ok;
+            double stopTime = stopTimeStr.toDouble(&ok);
+            if (ok) {
+                point.stopTime = stopTime;
+                m_lastStopTime = point.stopTime;
+                hasData = true;
+            }
+        }
+    } else {
+        point.stopTime = m_lastStopTime;
     }
 
     if (hasData) {

--- a/src/core/format_parsers/uddf_parser.cpp
+++ b/src/core/format_parsers/uddf_parser.cpp
@@ -526,12 +526,13 @@ void UDDFParser::parseSamples(QXmlStreamReader &xml, DiveData *dive)
 {
     // UDDF waypoints record changes only — values not present in a waypoint
     // should be inherited from the previous one. We carry forward temperature,
-    // NDL, TTS, ceiling, CNS, per-tank pressure, and per-sensor PO2 across
-    // waypoints, mirroring the SSRF parser's logic.
+    // NDL, TTS, ceiling, stop time, CNS, per-tank pressure, and per-sensor PO2
+    // across waypoints, mirroring the SSRF parser's logic.
     double lastTemperature = 0.0;
-    double lastNDL = 0.0;
+    double lastNDL = -1.0; // -1 = no NDL reported yet (not the same as 0 = deco)
     double lastTTS = 0.0;
     double lastCeiling = 0.0;
+    double lastStopTime = 0.0;
     double lastCNS = -1.0;
     QMap<int, double> lastPressures;
     QMap<int, double> lastPO2Sensors;
@@ -567,7 +568,8 @@ void UDDFParser::parseSamples(QXmlStreamReader &xml, DiveData *dive)
         if (xml.tokenType() == QXmlStreamReader::StartElement
             && xml.name() == QStringLiteral("waypoint")) {
             parseWaypoint(xml, dive, lastTemperature, lastNDL, lastTTS, lastCeiling,
-                          lastCNS, lastPressures, lastPO2Sensors, po2SensorRefToIndex);
+                          lastStopTime, lastCNS, lastPressures, lastPO2Sensors,
+                          po2SensorRefToIndex);
         }
     }
 }
@@ -578,6 +580,7 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
                                double &lastNDL,
                                double &lastTTS,
                                double &lastCeiling,
+                               double &lastStopTime,
                                double &lastCNS,
                                QMap<int, double> &lastPressures,
                                QMap<int, double> &lastPO2Sensors,
@@ -609,6 +612,7 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
     int mandatoryDecostopCount = 0;
     double waypointDecoCeiling = 0.0;        // metres, deepest mandatory stop
     double waypointTotalDecoDuration = 0.0;  // seconds, summed across mandatory stops
+    double waypointDeepestStopDuration = 0.0; // seconds, duration of the deepest stop only
 
     while (!xml.atEnd()) {
         xml.readNext();
@@ -709,6 +713,10 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
                     attrs.value(QStringLiteral("duration")));
                 if (!std::isnan(decodepth) && decodepth > waypointDecoCeiling) {
                     waypointDecoCeiling = decodepth;
+                    // The current stop's own duration — captured here (not
+                    // summed) so element order doesn't matter
+                    waypointDeepestStopDuration =
+                        (!std::isnan(duration) && duration > 0.0) ? duration : 0.0;
                 }
                 if (!std::isnan(duration) && duration > 0.0) {
                     waypointTotalDecoDuration += duration;
@@ -758,6 +766,14 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
 
         point.ceiling = waypointDecoCeiling;
         lastCeiling = point.ceiling;
+
+        // Stop time is the deepest stop's own duration, not the summed TTS
+        if (waypointDeepestStopDuration > 0.0) {
+            point.stopTime = waypointDeepestStopDuration / 60.0;
+            lastStopTime = point.stopTime;
+        } else {
+            point.stopTime = lastStopTime;
+        }
     } else if (ndlSetThisWaypoint) {
         point.ndl = waypointNDL;
         lastNDL = point.ndl;
@@ -765,6 +781,7 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
             point.tts = lastTTS;
         }
         point.ceiling = lastCeiling;
+        point.stopTime = lastStopTime;
     } else {
         if (lastNDL >= 0.0) {
             point.ndl = lastNDL;
@@ -773,6 +790,7 @@ void UDDFParser::parseWaypoint(QXmlStreamReader &xml,
             point.tts = lastTTS;
         }
         point.ceiling = lastCeiling;
+        point.stopTime = lastStopTime;
     }
 
     // Carry CNS forward when this waypoint did not report it.

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -1,5 +1,6 @@
 #include "include/generators/overlay_gen.h"
 #include <QPainter>
+#include <QtMath>
 #include <QFontMetrics>
 #include <QDateTime>
 #include <QDebug>
@@ -32,6 +33,9 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_showMeanDepth(false)
     , m_showMaxDepth(false)
     , m_showGas(false)
+    , m_showTTS(false)
+    , m_showStopDepth(true)
+    , m_showStopTime(true)
     , m_showPO2Cell1(false)
     , m_showPO2Cell2(false)
     , m_showPO2Cell3(false)
@@ -58,6 +62,9 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     m_showMeanDepth = config->showMeanDepth();
     m_showMaxDepth = config->showMaxDepth();
     m_showGas = config->showGas();
+    m_showTTS = config->showTTS();
+    m_showStopDepth = config->showStopDepth();
+    m_showStopTime = config->showStopTime();
     m_showPO2Cell1 = config->showPO2Cell1();
     m_showPO2Cell2 = config->showPO2Cell2();
     m_showPO2Cell3 = config->showPO2Cell3();
@@ -410,6 +417,33 @@ void OverlayGenerator::setShowGas(bool show)
         m_showGas = show;
         // Note: Cell regeneration is handled by QML with dive data
         emit showGasChanged();
+    }
+}
+
+void OverlayGenerator::setShowTTS(bool show)
+{
+    if (m_showTTS != show) {
+        m_showTTS = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showTTSChanged();
+    }
+}
+
+void OverlayGenerator::setShowStopDepth(bool show)
+{
+    if (m_showStopDepth != show) {
+        m_showStopDepth = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showStopDepthChanged();
+    }
+}
+
+void OverlayGenerator::setShowStopTime(bool show)
+{
+    if (m_showStopTime != show) {
+        m_showStopTime = show;
+        // Note: Cell regeneration is handled by QML with dive data
+        emit showStopTimeChanged();
     }
 }
 
@@ -841,6 +875,8 @@ void OverlayGenerator::setCellTypeVisible(const QString& cellId, bool visible)
         {"mean_depth", Unabara::CellType::MeanDepth},
         {"max_depth", Unabara::CellType::MaxDepth},
         {"gas", Unabara::CellType::Gas},
+        {"stop_depth", Unabara::CellType::StopDepth},
+        {"stop_time", Unabara::CellType::StopTime},
         {"po2_cell1", Unabara::CellType::PO2Cell1},
         {"po2_cell2", Unabara::CellType::PO2Cell2},
         {"po2_cell3", Unabara::CellType::PO2Cell3},
@@ -1006,6 +1042,9 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_showMeanDepth = false;
     m_showMaxDepth = false;
     m_showGas = false;
+    m_showTTS = false;
+    m_showStopDepth = false;
+    m_showStopTime = false;
     m_showPO2Cell1 = false;
     m_showPO2Cell2 = false;
     m_showPO2Cell3 = false;
@@ -1031,6 +1070,12 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
             m_showMaxDepth = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::Gas) {
             m_showGas = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::TTS) {
+            m_showTTS = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::StopDepth) {
+            m_showStopDepth = cell.visible();
+        } else if (cell.cellType() == Unabara::CellType::StopTime) {
+            m_showStopTime = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell1) {
             m_showPO2Cell1 = cell.visible();
         } else if (cell.cellType() == Unabara::CellType::PO2Cell2) {
@@ -1055,6 +1100,9 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     emit showMeanDepthChanged();
     emit showMaxDepthChanged();
     emit showGasChanged();
+    emit showTTSChanged();
+    emit showStopDepthChanged();
+    emit showStopTimeChanged();
     emit showPO2Cell1Changed();
     emit showPO2Cell2Changed();
     emit showPO2Cell3Changed();
@@ -1157,6 +1205,9 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
     if (m_showDepth) numSections++;
     if (m_showTemperature) numSections++;
     if (m_showNDL) numSections++;  // NDL/TTS share the same section
+    if (m_showStopDepth) numSections++;
+    if (m_showStopTime) numSections++;
+    if (m_showTTS) numSections++;
     if (m_showTime) numSections++;
     if (m_showCNS) numSections++;
     if (m_showMeanDepth) numSections++;
@@ -1219,6 +1270,40 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         cell.setFont(m_font, false);
         cell.setTextColor(m_textColor, false);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::NDL, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    // Deco stop cells next to NDL/TTS: blank outside deco
+    if (m_showStopDepth) {
+        Unabara::CellData cell("stop_depth", Unabara::CellType::StopDepth);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::StopDepth, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    if (m_showStopTime) {
+        Unabara::CellData cell("stop_time", Unabara::CellType::StopTime);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::StopTime, m_font, templateSize));
+        cell.setVisible(true);
+        m_cells.append(cell);
+        currentSection++;
+    }
+
+    if (m_showTTS) {
+        Unabara::CellData cell("tts", Unabara::CellType::TTS);
+        cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
+        cell.setFont(m_font, false);
+        cell.setTextColor(m_textColor, false);
+        cell.setCalculatedSize(calculateCellSize(Unabara::CellType::TTS, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
         currentSection++;
@@ -1460,18 +1545,6 @@ QImage OverlayGenerator::generateOverlay(DiveData* dive, double timePoint)
     //          << "ndl:" << dataPoint.ndl
     //          << "tts:" << dataPoint.tts;
     
-    // Determine if we're in decompression
-    bool inDeco = (dataPoint.ndl <= 0);
-    
-    // Ensure TTS is reasonable when in deco mode
-    if (inDeco && dataPoint.tts <= 0.0) {
-        qDebug() << "Warning: In decompression but TTS is" << dataPoint.tts 
-                 << "- This might indicate a parsing issue";
-        // Set a minimum value to ensure display makes sense
-        dataPoint.tts = 1.0;
-    }
-
-
     // Set up the painter
     QPainter painter(&result);
     painter.setRenderHint(QPainter::Antialiasing);
@@ -1497,7 +1570,9 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
                                                    bool showLabel) const
 {
     Units::UnitSystem unitSystem = Config::instance()->unitSystem();
-    bool inDeco = (dataPoint.ndl <= 0);
+    // ndl == 0 is a reported deco state; ndl < 0 means the computer never
+    // reported NDL (must NOT read as deco — shows "NDL ---" instead).
+    bool inDeco = (dataPoint.ndl == 0.0);
 
     auto format = [showLabel](const QString& label, const QString& value) {
         return showLabel ? QString("%1\n%2").arg(label, value) : value;
@@ -1519,14 +1594,12 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
     }
 
     case Unabara::CellType::NDL:
-        // Dynamically switch between NDL and TTS based on deco status
+        // Dynamically switch between NDL and TTS based on deco status. The
+        // deco details (stop depth/time) live in the StopDepth/StopTime cells
+        // so this cell keeps a stable two-line geometry.
         if (inDeco) {
             QString ttsStr = dataPoint.tts > 0 ? QString("%1 min").arg(qRound(dataPoint.tts)) : "---";
-            QString decoInfo;
-            if (dataPoint.ceiling > 0) {
-                decoInfo = QString("\nDECO (%1)").arg(Units::formatDepthValue(dataPoint.ceiling, unitSystem));
-            }
-            return format("TTS", ttsStr + decoInfo);
+            return format("TTS", ttsStr);
         } else {
             QString ndlStr = dataPoint.ndl > 0 ? QString("%1 min").arg(qRound(dataPoint.ndl)) : "---";
             return format("NDL", ndlStr);
@@ -1535,6 +1608,24 @@ QString OverlayGenerator::generateCellDisplayText(Unabara::CellType cellType,
     case Unabara::CellType::TTS: {
         QString ttsStr = dataPoint.tts > 0 ? QString("%1 min").arg(qRound(dataPoint.tts)) : "---";
         return format("TTS", ttsStr);
+    }
+
+    case Unabara::CellType::StopDepth: {
+        // Blank value outside deco: parsers carry stop values forward, so the
+        // inDeco gate (not the value alone) decides visibility
+        bool show = inDeco && dataPoint.ceiling > 0;
+        QString value = show ? Units::formatDepthValue(dataPoint.ceiling, unitSystem)
+                             : QString();
+        return format("STOP", value);
+    }
+
+    case Unabara::CellType::StopTime: {
+        bool show = inDeco && dataPoint.stopTime > 0;
+        // Round up: a 22 s remaining stop is still a stop — "0 min" would
+        // read as cleared (Garmin reports this field in seconds)
+        QString value = show ? QString("%1 min").arg(qCeil(dataPoint.stopTime))
+                             : QString();
+        return format("TIME", value);
     }
 
     case Unabara::CellType::Pressure: {
@@ -1825,6 +1916,9 @@ void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& im
     }
 }
 
+// Frozen legacy path: only reachable with an empty cell list, which cannot
+// happen in practice (the constructor always builds a default layout). Kept
+// as-is; it still renders the old combined TTS + DECO line.
 void OverlayGenerator::renderSectionBasedOverlay(QPainter& painter, const QSize& imageSize,
                                                   const DiveDataPoint& dataPoint, DiveData* dive)
 {
@@ -2091,7 +2185,7 @@ QSizeF OverlayGenerator::calculateCellSize(Unabara::CellType cellType, const QFo
                 break;
             case Unabara::CellType::TTS:
                 header = tr("TTS");
-                value = "99 min\n9.9 m";  // Typical TTS + ceiling
+                value = "99 min";    // Typical TTS value
                 break;
             case Unabara::CellType::Pressure:
                 header = tr("TANK 1");   // Typical tank number
@@ -2122,6 +2216,14 @@ QSizeF OverlayGenerator::calculateCellSize(Unabara::CellType cellType, const QFo
             case Unabara::CellType::Gas:
                 header = tr("GAS");
                 value = "EAN32";         // Widest plausible mix string
+                break;
+            case Unabara::CellType::StopDepth:
+                header = tr("STOP");
+                value = "99.9 m";        // Sized for the populated (in-deco) state
+                break;
+            case Unabara::CellType::StopTime:
+                header = tr("TIME");
+                value = "99 min";        // Sized for the populated (in-deco) state
                 break;
             default:
                 header = "UNKNOWN";

--- a/src/generators/profile_gen.cpp
+++ b/src/generators/profile_gen.cpp
@@ -117,6 +117,39 @@ ProfileGenerator::ProfileGenerator(QObject* parent)
     connect(cfg, &Config::unitSystemChanged, this, [this]() {
         if (m_gridEnabled) emit gridDepthIntervalChanged();
     });
+
+    // Every setting that affects the cached base image (anything except the
+    // indicator) invalidates it. Hooking the signals covers both the setters
+    // and the Config-sync lambdas above with one connection each.
+    const std::initializer_list<void (ProfileGenerator::*)()> baseSignals = {
+        &ProfileGenerator::backgroundColorChanged,
+        &ProfileGenerator::backgroundOpacityChanged,
+        &ProfileGenerator::curveColorChanged,
+        &ProfileGenerator::curveWidthChanged,
+        &ProfileGenerator::outputWidthChanged,
+        &ProfileGenerator::outputHeightChanged,
+        &ProfileGenerator::decoZoneColorChanged,
+        &ProfileGenerator::decoZoneOpacityChanged,
+        &ProfileGenerator::gridEnabledChanged,
+        &ProfileGenerator::gridDepthIntervalChanged,
+        &ProfileGenerator::gridTimeIntervalChanged,
+        &ProfileGenerator::gridColorChanged,
+        &ProfileGenerator::gridOpacityChanged,
+        &ProfileGenerator::gridLineWidthChanged,
+        &ProfileGenerator::gridShowLabelsChanged,
+    };
+    for (auto sig : baseSignals) {
+        connect(this, sig, this, &ProfileGenerator::invalidateBaseCache);
+    }
+    // Grid labels are unit-dependent; the lambda above only re-emits when the
+    // grid is enabled, so invalidate unconditionally here to stay safe.
+    connect(cfg, &Config::unitSystemChanged,
+            this, &ProfileGenerator::invalidateBaseCache);
+}
+
+void ProfileGenerator::invalidateBaseCache()
+{
+    m_baseCacheGen.fetch_add(1, std::memory_order_relaxed);
 }
 
 void ProfileGenerator::setBackgroundColor(const QColor& c)
@@ -313,11 +346,45 @@ QImage ProfileGenerator::generate(DiveData* dive, double timePoint)
 
 QImage ProfileGenerator::renderFrame(DiveData* dive, double timePoint, double pulsePhase01)
 {
-    QImage img(m_outputWidth, m_outputHeight, QImage::Format_ARGB32_Premultiplied);
-    img.fill(Qt::transparent);
     if (!dive) {
+        QImage img(m_outputWidth, m_outputHeight, QImage::Format_ARGB32_Premultiplied);
+        img.fill(Qt::transparent);
         return img;
     }
+
+    QImage img;
+    {
+        QMutexLocker lock(&m_baseCacheMutex);
+        const quint64 gen = m_baseCacheGen.load(std::memory_order_relaxed);
+        const int points = dive->allDataPoints().size();
+        // The dive pointer + sample count identify the dive contents well
+        // enough: dives are fully populated by the parser before they reach
+        // the UI, and the count guards against a recycled allocation.
+        if (m_baseCacheBuiltGen != gen || m_baseCacheDive != dive
+            || m_baseCachePoints != points
+            || m_baseCache.width() != m_outputWidth
+            || m_baseCache.height() != m_outputHeight) {
+            m_baseCache = renderBase(dive);
+            m_baseCacheBuiltGen = gen;
+            m_baseCacheDive = dive;
+            m_baseCachePoints = points;
+        }
+        img = m_baseCache; // implicitly shared; detaches on first paint below
+    }
+
+    QPainter painter(&img);
+    const QRectF rect(0, 0, img.width(), img.height());
+    ProfileRenderer::drawIndicator(painter, rect, dive, timePoint, m_indicatorColor,
+                                   static_cast<double>(m_indicatorRadius),
+                                   m_indicatorMode == Pulsing, pulsePhase01);
+
+    return img;
+}
+
+QImage ProfileGenerator::renderBase(DiveData* dive)
+{
+    QImage img(m_outputWidth, m_outputHeight, QImage::Format_ARGB32_Premultiplied);
+    img.fill(Qt::transparent);
 
     QPainter painter(&img);
     const QRectF rect(0, 0, m_outputWidth, m_outputHeight);
@@ -342,9 +409,6 @@ QImage ProfileGenerator::renderFrame(DiveData* dive, double timePoint, double pu
     ProfileRenderer::drawDecoZone(painter, rect, dive, m_decoZoneColor, m_decoZoneOpacity);
     ProfileRenderer::drawDepthCurve(painter, rect, dive, m_curveColor,
                                     static_cast<double>(m_curveWidth));
-    ProfileRenderer::drawIndicator(painter, rect, dive, timePoint, m_indicatorColor,
-                                   static_cast<double>(m_indicatorRadius),
-                                   m_indicatorMode == Pulsing, pulsePhase01);
 
     return img;
 }

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -1,6 +1,7 @@
 #include "include/ui/cell_model.h"
 #include "include/core/units.h"
 #include <QDebug>
+#include <QtMath>
 
 CellModel::CellModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -257,34 +258,22 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
     }
 
     case Unabara::CellType::NDL: {
-        // Dynamically switch between NDL and TTS based on deco status
-        bool inDeco = (dataPoint.ndl <= 0);
+        // Dynamically switch between NDL and TTS based on deco status. The
+        // deco details (stop depth/time) live in the StopDepth/StopTime cells
+        // so this cell keeps a stable two-line geometry.
+        // ndl == 0 is a reported deco state; ndl < 0 means the computer never
+        // reported NDL (must NOT read as deco — shows "NDL ---" instead).
+        bool inDeco = (dataPoint.ndl == 0.0);
 
         if (inDeco) {
-            // Show TTS with DECO indicator when in decompression
-            QString value;
-            if (dataPoint.tts > 0) {
-                value = QString("%1 min").arg(static_cast<int>(dataPoint.tts));
-            } else {
-                value = "---";
-            }
-
-            // Add ceiling info if available
-            QString decoInfo;
-            if (dataPoint.ceiling > 0) {
-                QString ceilingStr = Units::formatDepthValue(dataPoint.ceiling, unitSystem);
-                decoInfo = QString("\nDECO (%1)").arg(ceilingStr);
-            }
-
-            return format("TTS", value + decoInfo);
+            QString value = dataPoint.tts > 0
+                ? QString("%1 min").arg(qRound(dataPoint.tts))
+                : QStringLiteral("---");
+            return format("TTS", value);
         } else {
-            // Show NDL when not in decompression
-            QString value;
-            if (dataPoint.ndl > 0) {
-                value = QString("%1 min").arg(static_cast<int>(dataPoint.ndl));
-            } else {
-                value = "---";
-            }
+            QString value = dataPoint.ndl > 0
+                ? QString("%1 min").arg(qRound(dataPoint.ndl))
+                : QStringLiteral("---");
             return format("NDL", value);
         }
     }
@@ -292,11 +281,29 @@ QString CellModel::formatValue(Unabara::CellType type, const DiveDataPoint& data
     case Unabara::CellType::TTS: {
         QString value;
         if (dataPoint.tts > 0) {
-            value = QString("%1 min").arg(static_cast<int>(dataPoint.tts));
+            value = QString("%1 min").arg(qRound(dataPoint.tts));
         } else {
             value = "---";
         }
         return format("TTS", value);
+    }
+
+    case Unabara::CellType::StopDepth: {
+        // Blank value outside deco: parsers carry stop values forward, so the
+        // inDeco gate (not the value alone) decides visibility
+        bool show = dataPoint.ndl == 0.0 && dataPoint.ceiling > 0;
+        QString value = show ? Units::formatDepthValue(dataPoint.ceiling, unitSystem)
+                             : QString();
+        return format("STOP", value);
+    }
+
+    case Unabara::CellType::StopTime: {
+        bool show = dataPoint.ndl == 0.0 && dataPoint.stopTime > 0;
+        // Round up: a 22 s remaining stop is still a stop — "0 min" would
+        // read as cleared (Garmin reports this field in seconds)
+        QString value = show ? QString("%1 min").arg(qCeil(dataPoint.stopTime))
+                             : QString();
+        return format("TIME", value);
     }
 
     case Unabara::CellType::Pressure: {

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -409,6 +409,18 @@ Item {
                     root.generator.setCellTypeVisible("gas", root.generator.showGas)
                     previewContainer.updateCellModel()
                 }
+                function onShowTTSChanged() {
+                    root.generator.setCellTypeVisible("tts", root.generator.showTTS)
+                    previewContainer.updateCellModel()
+                }
+                function onShowStopDepthChanged() {
+                    root.generator.setCellTypeVisible("stop_depth", root.generator.showStopDepth)
+                    previewContainer.updateCellModel()
+                }
+                function onShowStopTimeChanged() {
+                    root.generator.setCellTypeVisible("stop_time", root.generator.showStopTime)
+                    previewContainer.updateCellModel()
+                }
                 function onShowPO2Cell1Changed() {
                     root.generator.setCellTypeVisible("po2_cell1", root.generator.showPO2Cell1)
                     previewContainer.updateCellModel()
@@ -989,7 +1001,40 @@ Item {
                         }
                     }
                 }
-                
+
+                CheckBox {
+                    id: showTTSCheckbox
+                    text: qsTr("Show Time To Surface")
+                    checked: generator ? generator.showTTS : false
+                    onCheckedChanged: {
+                        if (generator && generator.showTTS !== checked) {
+                            generator.showTTS = checked
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: showStopDepthCheckbox
+                    text: qsTr("Show Deco Stop Depth")
+                    checked: generator ? generator.showStopDepth : true
+                    onCheckedChanged: {
+                        if (generator && generator.showStopDepth !== checked) {
+                            generator.showStopDepth = checked
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: showStopTimeCheckbox
+                    text: qsTr("Show Deco Stop Time")
+                    checked: generator ? generator.showStopTime : true
+                    onCheckedChanged: {
+                        if (generator && generator.showStopTime !== checked) {
+                            generator.showStopTime = checked
+                        }
+                    }
+                }
+
                 CheckBox {
                     id: showPressureCheckbox
                     text: qsTr("Show Tank Pressure")

--- a/src/ui/qml/TimelineView.qml
+++ b/src/ui/qml/TimelineView.qml
@@ -580,10 +580,11 @@ Item {
                             infoText += "Temp: " + dataPoint.temperature.toFixed(1) + "°C  ";
                         }
                         
-                        // Add NDL or TTS based on decompression status
-                        if (dataPoint.ndl <= 0) {
+                        // Add NDL or TTS based on decompression status.
+                        // ndl < 0 means the computer never reported NDL — show neither.
+                        if (dataPoint.ndl === 0) {
                             infoText += "TTS: " + Math.round(dataPoint.tts) + "min (DECO)  ";
-                        } else {
+                        } else if (dataPoint.ndl > 0) {
                             infoText += "NDL: " + Math.round(dataPoint.ndl) + "min  ";
                         }
 

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -676,12 +676,17 @@ ApplicationWindow {
                                     Timer {
                                         interval: 80
                                         repeat: true
-                                        // Suppressed while the video preview is playing — the
+                                        // Runs only while this tab is actually visible: each tick
+                                        // re-renders the full profile (O(sample count)), and on
+                                        // long dives that pegs a core and starves the image
+                                        // providers if left running behind another tab. Also
+                                        // suppressed while the video preview is playing — the
                                         // indicator's position is already moving with dive time
                                         // there, and the wall-clock pulse adds visual noise.
                                         running: profileGenerator
                                                  && profileGenerator.indicatorMode === 1
                                                  && mainWindow.hasActiveDive
+                                                 && contentTabs.currentIndex === 1
                                                  && !videoSyncPlayer.playing
                                         onTriggered: {
                                             var period = profileGenerator ? profileGenerator.pulsePeriodMs : 2000

--- a/tests/SMOKE_TEST.md
+++ b/tests/SMOKE_TEST.md
@@ -10,7 +10,7 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). Max depth (MAX cell) is a running max: 9.6 m at 12:35 (current depth 8.7 m), pinned at 40.6 m from the deepest point to the end. Gas (GAS cell): `EAN29` for the whole dive — the switch to the diluent cylinder at 0:10 coincides with the first sample, so the O2 cylinder (0) is never the active gas at any sample. |
+| `2026-02-28-Monastery_Beach.ssrf` | CCR dive, ~40.6 m max depth, 3 cylinders, gas switches present, CCR sensors (po2Sensors) populated. `diveMode` should resolve to `ClosedCircuit`. CNS ramps to ~55% by the end of the dive (`---` before the first `cns=` sample). Mean depth (AVG cell) shows 19.9 m (from `<depth mean='19.877 m'>`). Max depth (MAX cell) is a running max: 9.6 m at 12:35 (current depth 8.7 m), pinned at 40.6 m from the deepest point to the end. Gas (GAS cell): `EAN29` for the whole dive — the switch to the diluent cylinder at 0:10 coincides with the first sample, so the O2 cylinder (0) is never the active gas at any sample. Deco cells: before 36:00 the NDL cell shows `NDL` and STOP/TIME show only their labels (blank value); at 36:00 the NDL cell switches to `TTS / 5 min` (two lines, no DECO suffix), STOP shows `3.0 m`, TIME shows `1 min`; STOP walks 3.0 → 6.0 → 9.0 m as the dive deepens; from 103:10 (`stopdepth='0.0 m'`, `in_deco='0'`) both cells are blank again. |
 | `Galileo_G2-TEK_SM_DecoO2-cleaned.ssrf` | Sidemount OC with deco O2. Gas (GAS cell): `Air` from the start — the 0↔1 sidemount switches at 9:41/14:49/27:37 don't change the displayed mix (both cylinders are air) — then `EAN99` from 37:17, `Air` at 48:01, `EAN99` from 50:05 to the end. |
 | `CCR_Halcyon_Benoit_cleaned.ssrf` | CCR dive — sensor1/2/3 still populate. |
 | `test_multidive.ssrf` | Multiple dives — picker shows them all; opening any one renders correctly. |
@@ -28,8 +28,9 @@ Run this before merging any change to the dive log parser. Each row below is a s
 
 | File | Expected |
 |---|---|
-| `2025-12-14-14-17-24.fit` | Dive #98, 2025-12-14 14:17 local, OC deco dive on Lake Geneva (location `46.480629, 6.461355`). ~24.1 m max depth, ~77 min, min temp 10 °C. 2 cylinders (Air + EAN80); GAS cell switches to `EAN80` during the final deco stop. CNS ramps to ~15%, `--` at the very start. AVG cell 14.8 m (from the FIT dive summary). Deco phase: NDL 0 with TTS/ceiling populated (ceiling 3 m). |
-| `2026-01-12-10-40-25.fit` | Dive #104, shallow long dive (~9.6 m max, ~114 min), no GPS → location empty. |
+| `2025-12-14-14-17-24.fit` | Dive #98, 2025-12-14 14:17 local, OC deco dive on Lake Geneva (location `46.480629, 6.461355`). ~24.1 m max depth, ~77 min, min temp 10 °C. 2 cylinders (Air + EAN80); GAS cell switches to `EAN80` during the final deco stop. CNS ramps to ~15%, `--` at the very start. AVG cell 14.8 m (from the FIT dive summary). Deco phase: NDL cell switches to a two-line `TTS` display; STOP shows `3.0 m` (record field 93) and TIME the stop countdown (field 94); both blank outside the deco window. |
+| `2026-01-12-10-40-25.fit` | Dive #104, shallow long dive (~9.6 m max, ~114 min), no GPS → location empty. NDL is absent from the first ~11 min of records: the NDL cell must show `NDL / ---` there (NOT switch to TTS — missing NDL is not deco). Later NDL values are huge but genuine (the watch reports up to ~1000 min on shallow dives). STOP/TIME stay blank for the whole dive (fields 93/94 all zero). |
+| `2025-12-26-11-05-34.fit` | Dive #99, OC deco dive. At ~59-60 min (13 m, 6.0 m stop): TTS `9 min`, STOP `6.0 m`, TIME `1 min` — the watch reports only ~22 s of stop time here (field 94, seconds); the TIME cell rounds **up**, so it must never read `0 min` while a stop is required. |
 | Any CCR file from `divelogs_medico_fits.zip` (e.g. `2026-01-25-10-41-00.fit`, dive #114) | `diveMode` resolves to `ClosedCircuit`; 3 cylinders incl. `Air (diluent)` and `EAN50` bailout; PO2 cell shows the active setpoint (0.70 bar). |
 | Non-dive FIT from the zip (e.g. `2026-01-28-05-58-39.fit`) | Clean error: "FIT file does not contain a dive activity", no crash. |
 
@@ -57,6 +58,8 @@ Tank-pod pressures (`TANK_UPDATE`/`SENSOR_PROFILE`) have no coverage in the real
 | Per-sample tank pressure | bar | Pa → bar (via `<tankpressure>` when exporter provides it) | `tank_update` bar×100 → bar (T1/T2 pods only) |
 | Per-sample PO2 (CCR) | `sensor1/2/3` | `<measuredpo2>` (when exporter provides it) | active setpoint (Descent records no sensor values) |
 | Per-sample CNS | `cns='NN%'` attribute | `<cns>` percent element (65.0 = 65 %) | `record` field 97, percent |
+| Deco stop depth (STOP cell) | `stopdepth` attribute | deepest mandatory `<decostop decodepth>` | `record` field 93, mm → m |
+| Deco stop time (TIME cell) | `stoptime` attribute (M:SS) | deepest mandatory `<decostop>`'s `duration` (s → min) | `record` field 94, s → min |
 | Mean depth (static, AVG cell) | `<depth mean>` in `<divecomputer>` | `<averagedepth>` in `<informationafterdive>` (fallback: time-weighted average of samples) | `dive_summary` avg_depth mm → m |
 | Max depth (running, MAX cell) | computed from samples (no parsing) — deepest point reached up to the current time | same | same |
 | Gas switches | `<event name="gaschange">` | `<switchmix ref>` resolved via mix → first tank index | event 57, data = gas slot index |

--- a/tests/cell_data_test.cpp
+++ b/tests/cell_data_test.cpp
@@ -23,7 +23,9 @@ private slots:
             CellType::Depth,    CellType::Temperature, CellType::Time,
             CellType::NDL,      CellType::TTS,         CellType::Pressure,
             CellType::PO2Cell1, CellType::PO2Cell2,    CellType::PO2Cell3,
-            CellType::CompositePO2, CellType::CNS,
+            CellType::CompositePO2, CellType::CNS,     CellType::MeanDepth,
+            CellType::MaxDepth, CellType::Gas,         CellType::StopDepth,
+            CellType::StopTime,
         };
         for (CellType type : all) {
             const QString str = CellData::cellTypeToString(type);

--- a/tests/dive_data_test.cpp
+++ b/tests/dive_data_test.cpp
@@ -65,6 +65,43 @@ private slots:
         QCOMPARE(d.dataAtTime(5.0).ceiling, 6.0);
     }
 
+    void ndlSentinelDoesNotBlend()
+    {
+        // -1 means "computer never reported NDL"; blending across the
+        // sentinel would fabricate a deco state (ndl == 0) that never existed
+        DiveData d;
+        DiveDataPoint a = point(0.0, 10.0); // ndl defaults to -1
+        DiveDataPoint b = point(10.0, 10.0);
+        b.ndl = 40.0;
+        d.addDataPoint(a);
+        d.addDataPoint(b);
+        QCOMPARE(d.dataAtTime(5.0).ndl, -1.0);
+
+        DiveData e;
+        DiveDataPoint c = point(0.0, 10.0);
+        c.ndl = 40.0;
+        DiveDataPoint f = point(10.0, 10.0);
+        f.ndl = 20.0;
+        e.addDataPoint(c);
+        e.addDataPoint(f);
+        QCOMPARE(e.dataAtTime(5.0).ndl, 30.0);
+    }
+
+    void stopTimeIsNotInterpolated()
+    {
+        // Stop time is a held state like ceiling — blending two required stop
+        // times would display a countdown the computer never showed
+        DiveData d;
+        DiveDataPoint a = point(0.0, 30.0);
+        a.stopTime = 3.0;
+        DiveDataPoint b = point(10.0, 28.0);
+        b.stopTime = 1.0;
+        d.addDataPoint(a);
+        d.addDataPoint(b);
+
+        QCOMPARE(d.dataAtTime(5.0).stopTime, 3.0);
+    }
+
     void cnsSentinelDoesNotBlend()
     {
         // -1 means "no data"; interpolating across it would fabricate values

--- a/tests/fit_parser_test.cpp
+++ b/tests/fit_parser_test.cpp
@@ -235,12 +235,30 @@ private slots:
         QCOMPARE(points[3].getPressure(0), 200.5);
         QCOMPARE(points[3].getPressure(1), 180.0);
 
-        // t=9: after the gas switch to EAN50
+        // t=0..3: no deco stop scheduled
+        QCOMPARE(points[0].ceiling, 0.0);
+        QCOMPARE(points[0].stopTime, 0.0);
+
+        // t=5: in deco — record fields 93 (next stop depth), 94 (next stop
+        // time) and 95 (tts) are decoded
+        QCOMPARE(points[4].timestamp, 5.0);
+        QCOMPARE(points[4].ndl, 0.0);
+        QCOMPARE(points[4].ceiling, 3.0);       // 3000 mm
+        QCOMPARE(points[4].stopTime, 2.0);      // 120 s
+        QCOMPARE(points[4].tts, 5.0);           // 300 s
+
+        // t=7: stop time counts down
+        QCOMPARE(points[5].stopTime, 1.0);      // 60 s
+        QCOMPARE(points[5].tts, 3.0);           // 180 s
+
+        // t=9: after the gas switch to EAN50, deco cleared
         QCOMPARE(points[6].timestamp, 9.0);
         QCOMPARE(points[6].depth, 2.0);
         QCOMPARE(points[6].cns, 3.0);
         QCOMPARE(points[6].o2percent, 50.0);
         QCOMPARE(points[6].getPressure(0), 190.0);
+        QCOMPARE(points[6].ceiling, 0.0);
+        QCOMPARE(points[6].stopTime, 0.0);
         qDeleteAll(dives);
     }
 

--- a/tests/make_synth_fit.py
+++ b/tests/make_synth_fit.py
@@ -76,8 +76,10 @@ records += data(2, [('u32z', 1111), ('enum', 28), ('enum', 2), ('u16', 120)])
 records += data(2, [('u32z', 2222), ('enum', 28), ('enum', 2), ('u16', 100)])
 
 # RECORD definition: BIG-ENDIAN, with one developer field (3 bytes) to skip.
-# timestamp 253, depth 92 (mm u32), temp 13 (s8), ndl 96 (u32 s), cns 97 (u8)
-records += definition(3, 20, [(253, 'u32'), (92, 'u32'), (13, 's8'), (96, 'u32'), (97, 'u8')],
+# timestamp 253, depth 92 (mm u32), next stop depth 93 (mm u32),
+# next stop time 94 (u32 s), tts 95 (u32 s), temp 13 (s8), ndl 96 (u32 s), cns 97 (u8)
+records += definition(3, 20, [(253, 'u32'), (92, 'u32'), (93, 'u32'), (94, 'u32'),
+                              (95, 'u32'), (13, 's8'), (96, 'u32'), (97, 'u8')],
                       big_endian=True, dev_fields=[(0, 3, 0)])
 
 # TANK_UPDATE definition (little-endian): timestamp, sensor, pressure bar*100
@@ -85,31 +87,34 @@ records += definition(4, 319, [(253, 'u32'), (0, 'u32z'), (1, 'u16')])
 # EVENT definition: timestamp, event 0, data 3
 records += definition(5, 21, [(253, 'u32'), (0, 'enum'), (3, 'u32')])
 
-def record(ts, depth_mm, temp, ndl_s, cns):
-    return data(3, [('u32', ts), ('u32', depth_mm), ('s8', temp), ('u32', ndl_s), ('u8', cns)],
+def record(ts, depth_mm, stop_mm, stop_s, tts_s, temp, ndl_s, cns):
+    return data(3, [('u32', ts), ('u32', depth_mm), ('u32', stop_mm), ('u32', stop_s),
+                    ('u32', tts_s), ('s8', temp), ('u32', ndl_s), ('u8', cns)],
                 big_endian=True, dev_bytes=b'\xAA\xBB\xCC')
 
 # Pre-dive-start gas switch event (should clamp to t=0, dive starts on gas 0 anyway)
 records += data(5, [('u32', START - 2), ('enum', 57), ('u32', 0)])
 
-# Dive samples: 0..9 s, descending, tank updates interleaved
-records += record(START + 0, 1000, 19, 3000, 0)
+# Dive samples: 0..9 s, descending, tank updates interleaved.
+# t=5 and t=7 are deco samples: ndl 0, next stop 3.0 m with a stop time and tts.
+records += record(START + 0, 1000, 0, 0, 0, 19, 3000, 0)
 records += data(4, [('u32', START + 1), ('u32z', 1111), ('u16', 20050)])  # 200.5 bar
 records += data(4, [('u32', START + 1), ('u32z', 2222), ('u16', 18000)])  # 180.0 bar
-records += record(START + 1, 5000, 19, 2900, 0)
+records += record(START + 1, 5000, 0, 0, 0, 19, 2900, 0)
 # Compressed-timestamp records on local type 1 slot? Compressed local is 2 bits (0-3):
 # reuse local 3 (RECORD) via compressed header (local 3 fits in 2 bits)
 records += compressed(3, (START + 2) & 0x1F,
-                      [('u32', START + 2), ('u32', 10000), ('s8', 18), ('u32', 2500), ('u8', 1)],
+                      [('u32', START + 2), ('u32', 10000), ('u32', 0), ('u32', 0),
+                       ('u32', 0), ('s8', 18), ('u32', 2500), ('u8', 1)],
                       big_endian=True)[:1] + \
-           struct.pack('>IIbIB', START + 2, 10000, 18, 2500, 1) + b'\xAA\xBB\xCC'
-records += record(START + 3, 15000, 18, 2000, 1)
+           struct.pack('>IIIIIbIB', START + 2, 10000, 0, 0, 0, 18, 2500, 1) + b'\xAA\xBB\xCC'
+records += record(START + 3, 15000, 0, 0, 0, 18, 2000, 1)
 # Gas switch to gas index 1 (EAN50) at t=5
 records += data(5, [('u32', START + 5), ('enum', 57), ('u32', 1)])
 records += data(4, [('u32', START + 5), ('u32z', 1111), ('u16', 19000)])  # 190.0 bar
-records += record(START + 5, 20000, 18, 1500, 2)
-records += record(START + 7, 12000, 18, 1800, 2)
-records += record(START + 9, 2000, 19, 3000, 3)
+records += record(START + 5, 20000, 3000, 120, 300, 18, 0, 2)
+records += record(START + 7, 12000, 3000, 60, 180, 18, 0, 2)
+records += record(START + 9, 2000, 0, 0, 0, 19, 3000, 3)
 
 # TANK_SUMMARY: sensor, start, end (bar*100)
 records += definition(6, 323, [(253, 'u32'), (0, 'u32z'), (1, 'u16'), (2, 'u16')])

--- a/tests/subsurface_parser_test.cpp
+++ b/tests/subsurface_parser_test.cpp
@@ -19,7 +19,8 @@ const char kTwoDives[] = R"(<divelog program='subsurface' version='3'>
     <sample time='0:00 min' depth='0.0 m' temp='24.0 C' pressure0='200.0 bar' pressure1='180.0 bar' ndl='99:00 min' />
     <sample time='1:00 min' depth='18.0 m' cns='5%' />
     <event time='2:00 min' name='gaschange' cylinder='1' />
-    <sample time='3:00 min' depth='20.0 m' temp='22.0 C' pressure0='170.0 bar' in_deco='1' tts='4:30 min' />
+    <sample time='3:00 min' depth='20.0 m' temp='22.0 C' pressure0='170.0 bar' in_deco='1' tts='4:30 min' stopdepth='3.0 m' stoptime='2:00 min' />
+    <sample time='4:00 min' depth='19.0 m' />
   </divecomputer>
 </dive>
 <dive number='8' date='2026-03-02' time='11:30:00'>
@@ -80,7 +81,7 @@ private slots:
         auto dives = parseXml(kTwoDives, 7, err);
         QCOMPARE(dives.size(), 1);
         const auto &pts = dives.first()->allDataPoints();
-        QCOMPARE(pts.size(), 3);
+        QCOMPARE(pts.size(), 4);
 
         QCOMPARE(pts[0].timestamp, 0.0);
         QCOMPARE(pts[0].temperature, 24.0);
@@ -97,12 +98,20 @@ private slots:
         QCOMPARE(pts[1].getPressure(1), 180.0);
         QCOMPARE(pts[1].cns, 5.0);
 
-        // in_deco='1' forces NDL to 0; tts parsed as M:SS
+        // in_deco='1' forces NDL to 0; tts/stoptime parsed as M:SS,
+        // stopdepth as metres
         QCOMPARE(pts[2].timestamp, 180.0);
         QCOMPARE(pts[2].ndl, 0.0);
         QCOMPARE(pts[2].tts, 4.5);
         QCOMPARE(pts[2].getPressure(0), 170.0);
         QCOMPARE(pts[2].cns, 5.0); // carried
+        QCOMPARE(pts[2].ceiling, 3.0);
+        QCOMPARE(pts[2].stopTime, 2.0);
+
+        // Delta encoding: a sample omitting stopdepth/stoptime carries both
+        QCOMPARE(pts[3].timestamp, 240.0);
+        QCOMPARE(pts[3].ceiling, 3.0);
+        QCOMPARE(pts[3].stopTime, 2.0);
         qDeleteAll(dives);
     }
 

--- a/tests/uddf_parser_test.cpp
+++ b/tests/uddf_parser_test.cpp
@@ -41,6 +41,7 @@ const char kUddfDive[] = R"(<uddf version='3.2'>
     <waypoint>
       <divetime>120.0</divetime>
       <depth>20,5</depth>
+      <decostop kind='mandatory' decodepth='3.0' duration='120'/>
       <decostop kind='mandatory' decodepth='6.0' duration='180'/>
     </waypoint>
   </samples>
@@ -111,6 +112,7 @@ private slots:
         QCOMPARE(pts[0].temperature, 24.0); // 297.15 K
         QCOMPARE(pts[0].getPressure(0), 200.0);
         QCOMPARE(pts[0].cns, -1.0);
+        QCOMPARE(pts[0].ndl, -1.0); // no deco info reported yet — not "in deco"
 
         QCOMPARE(pts[1].depth, 18.0);
         QCOMPARE(pts[1].temperature, 24.0); // carried
@@ -118,11 +120,15 @@ private slots:
         QCOMPARE(pts[1].cns, 12.5);
         QCOMPARE(pts[1].ndl, 20.0); // 1200 s -> min
 
-        // Comma decimal accepted; mandatory decostop -> ceiling + TTS
+        // Comma decimal accepted. Two mandatory decostops, shallower listed
+        // first: ceiling = deepest stop, TTS = summed durations, stop time =
+        // the deepest stop's own duration (order-independent)
         QCOMPARE(pts[2].depth, 20.5);
         QCOMPARE(pts[2].ceiling, 6.0);
-        QCOMPARE(pts[2].tts, 3.0); // 180 s -> min
+        QCOMPARE(pts[2].tts, 5.0); // 120 s + 180 s -> min
+        QCOMPARE(pts[2].stopTime, 3.0); // 180 s (deepest stop only) -> min
         QCOMPARE(pts[2].cns, 12.5); // carried
+        QCOMPARE(pts[1].stopTime, 0.0); // no stop before deco
         qDeleteAll(dives);
     }
 


### PR DESCRIPTION
The NDL/TTS cell used to grow a third "DECO (<ceiling>)" line when
entering deco, breaking overlay layouts. The cell now keeps a stable
two-line geometry (NDL <-> TTS label + time) and the deco details move
to two new cell types:

- StopDepth ("STOP", id stop_depth): current deco stop depth, rendered
  from the existing per-sample ceiling (already populated by all three
  parsers from stopdepth / FIT field 93 / deepest mandatory decostop).
- StopTime ("TIME", id stop_time): time at the current stop — new
  DiveDataPoint::stopTime field, parsed from SSRF stoptime, FIT record
  field 94 (seconds), and the deepest UDDF decostop's duration. Held
  (never interpolated), and displayed rounded up: Garmin reports short
  deep stops (~20 s) that must not read "0 min" while still required.

Both cells keep their label visible with a blank value line outside
deco, gated on the reported deco state rather than the raw values,
since parsers carry stop values forward and don't reliably clear them.

Data-model fix surfaced by real Garmin logs: NDL now uses -1 as a
"never reported" sentinel (interpolation doesn't blend across it, like
CNS). Missing NDL previously read as ndl=0, i.e. "in deco" — shallow
dives whose first records lack field 96 showed a bogus "TTS 0 min
(DECO)". They now show "NDL ---".

Wiring and UI:
- New show flags (showStopDepth/showStopTime default on) with Config
  persistence, editor checkboxes, template-load sync, and default-layout
  cells; the previously half-wired TTS cell type is now fully wired
  (checkbox, persistence, load-sync; default off).
- All 7 bundled templates gain placed STOP/TIME cells.
- qRound/static_cast<int> divergence between the QML preview and C++
  render unified; removed the tts=1.0 mutation in generateOverlay.

Performance (found while testing long dives):
- The profile pulse-animation timer now runs only while the Dive
  Profile tab is visible — it used to re-render the full profile every
  80 ms behind other tabs, pegging a core on long dives and starving
  the overlay preview.
- ProfileGenerator caches the time-independent layers (background,
  grid, deco zone, curve) as a base image and re-stamps only the
  indicator per frame; mutex-guarded for the image-provider thread,
  invalidated via the base-affecting setting signals. Pulsing on a
  6000-sample dive drops from ~120% to ~20% CPU; profile exports get
  the same reuse.

Tests: new/updated coverage for stopTime and NDL sentinel semantics
(hold rules, carry-forward, deepest-stop-vs-summed-TTS, FIT fields
93/94/95 in the synthetic fixture), cell-type round-trip list made
current, SMOKE_TEST.md expectations extended.