### PR TITLE
feat: split overlay cell text color into independent label and data colors

### DIFF
--- a/include/core/cell_data.h
+++ b/include/core/cell_data.h
@@ -57,6 +57,15 @@ namespace ShadowDefaults {
 }
 
 /**
+ * @brief Default text color shared by CellData, OverlayGenerator and OverlayTemplate
+ *
+ * Applies to both the label and the value color.
+ */
+namespace ColorDefaults {
+    inline QColor text() { return QColor(Qt::white); }
+}
+
+/**
  * @brief Represents a single data cell in the overlay
  *
  * Each cell displays one type of telemetry data and can be positioned
@@ -74,10 +83,12 @@ public:
     QPointF position() const { return m_position; }
     bool visible() const { return m_visible; }
     QFont font() const { return m_font; }
-    QColor textColor() const { return m_textColor; }
+    QColor labelColor() const { return m_labelColor; }
+    QColor valueColor() const { return m_valueColor; }
     QSizeF calculatedSize() const { return m_calculatedSize; }
     bool hasCustomFont() const { return m_hasCustomFont; }
-    bool hasCustomColor() const { return m_hasCustomColor; }
+    bool hasCustomLabelColor() const { return m_hasCustomLabelColor; }
+    bool hasCustomValueColor() const { return m_hasCustomValueColor; }
     bool hasCustomShowLabel() const { return m_hasCustomShowLabel; }
     int tankIndex() const { return m_tankIndex; }
     bool showLabel() const { return m_showLabel; }
@@ -94,7 +105,8 @@ public:
     void setPosition(const QPointF& pos) { m_position = pos; }
     void setVisible(bool visible) { m_visible = visible; }
     void setFont(const QFont& font, bool isCustom = true);
-    void setTextColor(const QColor& color, bool isCustom = true);
+    void setLabelColor(const QColor& color, bool isCustom = true);
+    void setValueColor(const QColor& color, bool isCustom = true);
     void setShowLabel(bool show, bool isCustom = true);
     void setShadowEnabled(bool enabled, bool isCustom = true);
     void setShadowType(ShadowType type, bool isCustom = true);
@@ -106,7 +118,6 @@ public:
 
     // Reset custom properties to inherit from global
     void resetFont() { m_hasCustomFont = false; }
-    void resetColor() { m_hasCustomColor = false; }
     void resetShowLabel() { m_hasCustomShowLabel = false; }
     void resetShadow() { m_hasCustomShadow = false; }
 
@@ -126,10 +137,12 @@ private:
     QPointF m_position;            // Normalized position (0.0-1.0)
     bool m_visible;                // Whether cell is shown
     QFont m_font;                  // Cell-specific font
-    QColor m_textColor;            // Cell-specific text color
+    QColor m_labelColor;           // Cell-specific label ("DEPTH" etc.) text color
+    QColor m_valueColor;           // Cell-specific value ("29.3 m" etc.) text color
     QSizeF m_calculatedSize;       // Calculated size based on content and font
     bool m_hasCustomFont;          // True if font differs from global default
-    bool m_hasCustomColor;         // True if color differs from global default
+    bool m_hasCustomLabelColor;    // True if label color differs from global default
+    bool m_hasCustomValueColor;    // True if value color differs from global default
     bool m_showLabel;              // Whether the label row ("DEPTH" etc.) is rendered above the value
     bool m_hasCustomShowLabel;     // True if showLabel differs from global default
     bool m_shadowEnabled;          // Whether a shadow is drawn behind the text

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -24,7 +24,8 @@ class Config : public QObject
     // Overlay settings
     Q_PROPERTY(QString templatePath READ templatePath WRITE setTemplatePath NOTIFY templatePathChanged)
     Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
-    Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor NOTIFY textColorChanged)
+    Q_PROPERTY(QColor labelColor READ labelColor WRITE setLabelColor NOTIFY labelColorChanged)
+    Q_PROPERTY(QColor valueColor READ valueColor WRITE setValueColor NOTIFY valueColorChanged)
     Q_PROPERTY(double backgroundOpacity READ backgroundOpacity WRITE setBackgroundOpacity NOTIFY backgroundOpacityChanged)
     Q_PROPERTY(bool showDepth READ showDepth WRITE setShowDepth NOTIFY showDepthChanged)
     Q_PROPERTY(bool showTemperature READ showTemperature WRITE setShowTemperature NOTIFY showTemperatureChanged)
@@ -93,8 +94,10 @@ public:
     QFont font() const;
     void setFont(const QFont &font);
     
-    QColor textColor() const;
-    void setTextColor(const QColor &color);
+    QColor labelColor() const;
+    void setLabelColor(const QColor &color);
+    QColor valueColor() const;
+    void setValueColor(const QColor &color);
 
     double backgroundOpacity() const;
     void setBackgroundOpacity(double opacity);
@@ -238,7 +241,8 @@ signals:
     void lastExportPathChanged();
     void templatePathChanged();
     void fontChanged();
-    void textColorChanged();
+    void labelColorChanged();
+    void valueColorChanged();
     void backgroundOpacityChanged();
     void showDepthChanged();
     void showTemperatureChanged();
@@ -303,7 +307,8 @@ private:
     QString m_lastExportPath;
     QString m_templatePath;
     QFont m_font;
-    QColor m_textColor;
+    QColor m_labelColor;
+    QColor m_valueColor;
     double m_backgroundOpacity;
     bool m_showDepth;
     bool m_showTemperature;

--- a/include/core/overlay_template.h
+++ b/include/core/overlay_template.h
@@ -30,7 +30,8 @@ public:
     double backgroundOpacity() const { return m_backgroundOpacity; }
     QVector<CellData> cells() const { return m_cells; }
     QFont defaultFont() const { return m_defaultFont; }
-    QColor defaultTextColor() const { return m_defaultTextColor; }
+    QColor defaultLabelColor() const { return m_defaultLabelColor; }
+    QColor defaultValueColor() const { return m_defaultValueColor; }
     bool defaultShadowEnabled() const { return m_defaultShadowEnabled; }
     ShadowType defaultShadowType() const { return m_defaultShadowType; }
     QColor defaultShadowColor() const { return m_defaultShadowColor; }
@@ -43,7 +44,8 @@ public:
     void setBackgroundOpacity(double opacity) { m_backgroundOpacity = opacity; }
     void setCells(const QVector<CellData>& cells) { m_cells = cells; }
     void setDefaultFont(const QFont& font) { m_defaultFont = font; }
-    void setDefaultTextColor(const QColor& color) { m_defaultTextColor = color; }
+    void setDefaultLabelColor(const QColor& color) { m_defaultLabelColor = color; }
+    void setDefaultValueColor(const QColor& color) { m_defaultValueColor = color; }
     void setDefaultShadowEnabled(bool enabled) { m_defaultShadowEnabled = enabled; }
     void setDefaultShadowType(ShadowType type) { m_defaultShadowType = type; }
     void setDefaultShadowColor(const QColor& color) { m_defaultShadowColor = color; }
@@ -80,7 +82,8 @@ private:
     double m_backgroundOpacity;
     QVector<CellData> m_cells;
     QFont m_defaultFont;
-    QColor m_defaultTextColor;
+    QColor m_defaultLabelColor;
+    QColor m_defaultValueColor;
     bool m_defaultShadowEnabled;
     ShadowType m_defaultShadowType;
     QColor m_defaultShadowColor;

--- a/include/generators/overlay_gen.h
+++ b/include/generators/overlay_gen.h
@@ -22,7 +22,8 @@ class OverlayGenerator : public QObject, public IFrameGenerator
     Q_PROPERTY(int templateWidth READ templateWidth NOTIFY templateChanged)
     Q_PROPERTY(int templateHeight READ templateHeight NOTIFY templateChanged)
     Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
-    Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor NOTIFY textColorChanged)
+    Q_PROPERTY(QColor labelColor READ labelColor WRITE setLabelColor NOTIFY labelColorChanged)
+    Q_PROPERTY(QColor valueColor READ valueColor WRITE setValueColor NOTIFY valueColorChanged)
     Q_PROPERTY(bool showLabel READ showLabel WRITE setShowLabel NOTIFY showLabelChanged)
     Q_PROPERTY(bool shadowEnabled READ shadowEnabled WRITE setShadowEnabled NOTIFY shadowChanged)
     Q_PROPERTY(int shadowType READ shadowType WRITE setShadowType NOTIFY shadowChanged)
@@ -68,7 +69,8 @@ public:
     int templateWidth() const { return m_templateWidth; }
     int templateHeight() const { return m_templateHeight; }
     QFont font() const { return m_font; }
-    QColor textColor() const { return m_textColor; }
+    QColor labelColor() const { return m_labelColor; }
+    QColor valueColor() const { return m_valueColor; }
     bool showLabel() const { return m_showLabel; }
     bool shadowEnabled() const { return m_shadowEnabled; }
     int shadowType() const { return static_cast<int>(m_shadowType); }
@@ -109,7 +111,8 @@ public:
     // Setters
     void setTemplatePath(const QString &path);
     void setFont(const QFont &font);
-    void setTextColor(const QColor &color);
+    void setLabelColor(const QColor &color);
+    void setValueColor(const QColor &color);
     void setShowLabel(bool show);
     void setShadowEnabled(bool enabled);
     void setShadowType(int type);
@@ -154,9 +157,11 @@ public:
     Q_INVOKABLE int cellCount() const { return m_cells.size(); }
     Q_INVOKABLE void setCellPosition(const QString& cellId, const QPointF& pos);
     Q_INVOKABLE QFont getCellFont(const QString& cellId) const;
-    Q_INVOKABLE QColor getCellColor(const QString& cellId) const;
+    Q_INVOKABLE QColor getCellLabelColor(const QString& cellId) const;
+    Q_INVOKABLE QColor getCellValueColor(const QString& cellId) const;
     Q_INVOKABLE void setCellFont(const QString& cellId, const QFont& font);
-    Q_INVOKABLE void setCellColor(const QString& cellId, const QColor& color);
+    Q_INVOKABLE void setCellLabelColor(const QString& cellId, const QColor& color);
+    Q_INVOKABLE void setCellValueColor(const QString& cellId, const QColor& color);
     Q_INVOKABLE void setCellShowLabel(const QString& cellId, bool show);
     Q_INVOKABLE bool getCellShowLabel(const QString& cellId) const;
     Q_INVOKABLE bool getCellShadowEnabled(const QString& cellId) const;
@@ -167,7 +172,8 @@ public:
     Q_INVOKABLE void setCellVisible(const QString& cellId, bool visible);
     Q_INVOKABLE void setCellTypeVisible(const QString& cellId, bool visible);
     Q_INVOKABLE void resetCellFont(const QString& cellId);
-    Q_INVOKABLE void resetCellColor(const QString& cellId);
+    Q_INVOKABLE void resetCellLabelColor(const QString& cellId);
+    Q_INVOKABLE void resetCellValueColor(const QString& cellId);
     Q_INVOKABLE void resetCellShowLabel(const QString& cellId);
     Q_INVOKABLE void resetCellShadow(const QString& cellId);
     bool useCellBasedLayout() const { return m_useCellBasedLayout; }
@@ -203,7 +209,8 @@ public:
 signals:
     void templateChanged();
     void fontChanged();
-    void textColorChanged();
+    void labelColorChanged();
+    void valueColorChanged();
     void showLabelChanged();
     void shadowChanged();
     void backgroundOpacityChanged();
@@ -250,7 +257,8 @@ private:
     int m_templateWidth;
     int m_templateHeight;
     QFont m_font;
-    QColor m_textColor;
+    QColor m_labelColor;
+    QColor m_valueColor;
     bool m_showLabel;
     bool m_shadowEnabled;
     Unabara::ShadowType m_shadowType;
@@ -298,6 +306,9 @@ private:
 
     // Export-pass state stash (saved by beginExport, restored by endExport)
     bool m_savedShowCellBackgrounds = true;
+
+    // Seed a cell's label/value colors from the globals (isCustom = false)
+    void seedCellColors(Unabara::CellData& cell) const;
 
     // Helper methods for drawing
     int getScaledFontSize(const QFont& baseFont, double scale = 1.0) const;

--- a/include/ui/cell_model.h
+++ b/include/ui/cell_model.h
@@ -24,11 +24,13 @@ public:
         PositionRole,
         VisibleRole,
         FontRole,
-        TextColorRole,
+        LabelColorRole,
+        ValueColorRole,
         DisplayTextRole,
         CalculatedSizeRole,
         HasCustomFontRole,
-        HasCustomColorRole,
+        HasCustomLabelColorRole,
+        HasCustomValueColorRole,
         TankIndexRole,
         ShowLabelRole,
         HasCustomShowLabelRole,
@@ -51,7 +53,6 @@ public:
     Q_INVOKABLE void updateFromGenerator(OverlayGenerator* generator, DiveData* dive, double timePoint);
     Q_INVOKABLE void updateCellPosition(const QString& cellId, const QPointF& position);
     Q_INVOKABLE void updateCellFont(const QString& cellId, const QFont& font);
-    Q_INVOKABLE void updateCellColor(const QString& cellId, const QColor& color);
     Q_INVOKABLE void updateCellVisible(const QString& cellId, bool visible);
 
     // Getters

--- a/resources/templates/CCR_Tek_Rugged.utp
+++ b/resources/templates/CCR_Tek_Rugged.utp
@@ -16,13 +16,22 @@
                 "pointSize": 20,
                 "weight": 400
             },
-            "hasCustomColor": true,
+            "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
                 "x": 0.17543859649122806,
                 "y": 0.5729166666666666
             },
-            "textColor": "#ff19b9fb",
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "visible": true
         },
         {
@@ -41,10 +50,20 @@
             },
             "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
                 "x": 0.5701754385964912,
                 "y": 0.5729166666666666
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "visible": true
         },
         {
@@ -63,10 +82,20 @@
             },
             "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
                 "x": 0.4824561403508772,
                 "y": 0.20833333333333334
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "visible": true
         },
         {
@@ -85,10 +114,20 @@
             },
             "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
                 "x": 0.17543859649122806,
                 "y": 0.20833333333333334
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "visible": true
         },
         {
@@ -107,11 +146,23 @@
             },
             "hasCustomColor": true,
             "hasCustomFont": true,
+            "hasCustomLabelColor": true,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": true,
+            "labelColor": "#ff04fb10",
             "position": {
                 "x": 0.19736842105263158,
                 "y": 0.4296875
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "textColor": "#ff04fb10",
+            "valueColor": "#ff04fb10",
             "visible": true
         },
         {
@@ -130,11 +181,23 @@
             },
             "hasCustomColor": true,
             "hasCustomFont": true,
+            "hasCustomLabelColor": true,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": true,
+            "labelColor": "#ff04fb10",
             "position": {
                 "x": 0.39473684210526316,
                 "y": 0.4296875
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "textColor": "#ff04fb10",
+            "valueColor": "#ff04fb10",
             "visible": true
         },
         {
@@ -153,11 +216,23 @@
             },
             "hasCustomColor": true,
             "hasCustomFont": true,
+            "hasCustomLabelColor": true,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": true,
+            "labelColor": "#ff04fb10",
             "position": {
                 "x": 0.5701754385964912,
                 "y": 0.4296875
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "textColor": "#ff04fb10",
+            "valueColor": "#ff04fb10",
             "visible": true
         },
         {
@@ -176,10 +251,20 @@
             },
             "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
                 "x": 0.4166666666666667,
                 "y": 0.5859375
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
+            "showLabel": true,
             "visible": true
         },
         {
@@ -198,10 +283,19 @@
             },
             "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
-                "x": 0.66,
-                "y": 0.208
+                "x": 0.6469298245614035,
+                "y": 0.20833333333333334
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
             "showLabel": true,
             "visible": true
         },
@@ -221,10 +315,19 @@
             },
             "hasCustomColor": false,
             "hasCustomFont": true,
+            "hasCustomLabelColor": false,
+            "hasCustomShadow": false,
+            "hasCustomShowLabel": false,
+            "hasCustomValueColor": false,
             "position": {
-                "x": 0.66,
-                "y": 0.315
+                "x": 0.6478860439386755,
+                "y": 0.32112424924924926
             },
+            "shadowColor": "#ff000000",
+            "shadowEnabled": false,
+            "shadowOpacity": 0.7,
+            "shadowSize": 2,
+            "shadowType": "offset",
             "showLabel": true,
             "visible": true
         }
@@ -236,7 +339,14 @@
         "pointSize": 14,
         "weight": 400
     },
+    "defaultLabelColor": "#ff3182bc",
+    "defaultShadowColor": "#ff000000",
+    "defaultShadowEnabled": false,
+    "defaultShadowOpacity": 0.7,
+    "defaultShadowSize": 2,
+    "defaultShadowType": "offset",
     "defaultTextColor": "#ffffffff",
+    "defaultValueColor": "#ffffffff",
     "templateName": "CCR_Tek_Rugged",
     "version": "1.0"
 }

--- a/resources/templates/OC_Rec_1Tank_Ocean.utp
+++ b/resources/templates/OC_Rec_1Tank_Ocean.utp
@@ -135,7 +135,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         },
         {
             "calculatedSize": {
@@ -158,7 +158,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_1Tank_Titanium.utp
+++ b/resources/templates/OC_Rec_1Tank_Titanium.utp
@@ -135,7 +135,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         },
         {
             "calculatedSize": {
@@ -158,7 +158,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_NoTanks_Ocean.utp
+++ b/resources/templates/OC_Rec_NoTanks_Ocean.utp
@@ -112,7 +112,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         },
         {
             "calculatedSize": {
@@ -135,7 +135,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         }
     ],
     "defaultFont": {

--- a/resources/templates/OC_Rec_NoTanks_Titanium.utp
+++ b/resources/templates/OC_Rec_NoTanks_Titanium.utp
@@ -112,7 +112,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         },
         {
             "calculatedSize": {
@@ -135,7 +135,7 @@
                 "y": 0.735
             },
             "showLabel": true,
-            "visible": true
+            "visible": false
         }
     ],
     "defaultFont": {

--- a/src/core/cell_data.cpp
+++ b/src/core/cell_data.cpp
@@ -8,10 +8,12 @@ CellData::CellData()
     , m_position(0.0, 0.0)
     , m_visible(true)
     , m_font(QFont("Arial", 12))
-    , m_textColor(Qt::white)
+    , m_labelColor(ColorDefaults::text())
+    , m_valueColor(ColorDefaults::text())
     , m_calculatedSize(0.0, 0.0)
     , m_hasCustomFont(false)
-    , m_hasCustomColor(false)
+    , m_hasCustomLabelColor(false)
+    , m_hasCustomValueColor(false)
     , m_showLabel(true)
     , m_hasCustomShowLabel(false)
     , m_shadowEnabled(ShadowDefaults::enabled)
@@ -30,10 +32,12 @@ CellData::CellData(const QString& cellId, CellType cellType)
     , m_position(0.0, 0.0)
     , m_visible(true)
     , m_font(QFont("Arial", 12))
-    , m_textColor(Qt::white)
+    , m_labelColor(ColorDefaults::text())
+    , m_valueColor(ColorDefaults::text())
     , m_calculatedSize(0.0, 0.0)
     , m_hasCustomFont(false)
-    , m_hasCustomColor(false)
+    , m_hasCustomLabelColor(false)
+    , m_hasCustomValueColor(false)
     , m_showLabel(true)
     , m_hasCustomShowLabel(false)
     , m_shadowEnabled(ShadowDefaults::enabled)
@@ -52,10 +56,16 @@ void CellData::setFont(const QFont& font, bool isCustom)
     m_hasCustomFont = isCustom;
 }
 
-void CellData::setTextColor(const QColor& color, bool isCustom)
+void CellData::setLabelColor(const QColor& color, bool isCustom)
 {
-    m_textColor = color;
-    m_hasCustomColor = isCustom;
+    m_labelColor = color;
+    m_hasCustomLabelColor = isCustom;
+}
+
+void CellData::setValueColor(const QColor& color, bool isCustom)
+{
+    m_valueColor = color;
+    m_hasCustomValueColor = isCustom;
 }
 
 void CellData::setShowLabel(bool show, bool isCustom)
@@ -120,9 +130,14 @@ QJsonObject CellData::toJson() const
         json["font"] = fontJson;
     }
 
-    // Text color (only if custom)
-    if (m_hasCustomColor) {
-        json["textColor"] = m_textColor.name(QColor::HexArgb);
+    // Text colors (only if custom); legacy "textColor" mirrors the value
+    // color so older app versions can still read the template
+    if (m_hasCustomLabelColor) {
+        json["labelColor"] = m_labelColor.name(QColor::HexArgb);
+    }
+    if (m_hasCustomValueColor) {
+        json["valueColor"] = m_valueColor.name(QColor::HexArgb);
+        json["textColor"] = m_valueColor.name(QColor::HexArgb);
     }
 
     // Calculated size (for reference, not strictly necessary)
@@ -137,7 +152,9 @@ QJsonObject CellData::toJson() const
     }
 
     json["hasCustomFont"] = m_hasCustomFont;
-    json["hasCustomColor"] = m_hasCustomColor;
+    json["hasCustomLabelColor"] = m_hasCustomLabelColor;
+    json["hasCustomValueColor"] = m_hasCustomValueColor;
+    json["hasCustomColor"] = m_hasCustomValueColor;
 
     json["showLabel"] = m_showLabel;
     json["hasCustomShowLabel"] = m_hasCustomShowLabel;
@@ -178,10 +195,24 @@ CellData CellData::fromJson(const QJsonObject& json)
         cell.m_hasCustomFont = json["hasCustomFont"].toBool(true);
     }
 
-    // Text color (if present, it's custom)
-    if (json.contains("textColor")) {
-        cell.m_textColor = QColor(json["textColor"].toString());
-        cell.m_hasCustomColor = json["hasCustomColor"].toBool(true);
+    // Text colors. New-format files always carry "hasCustomLabelColor";
+    // legacy files only have the single "textColor", which seeds both.
+    if (json.contains("hasCustomLabelColor")) {
+        if (json.contains("labelColor")) {
+            cell.m_labelColor = QColor(json["labelColor"].toString());
+        }
+        if (json.contains("valueColor")) {
+            cell.m_valueColor = QColor(json["valueColor"].toString());
+        }
+        cell.m_hasCustomLabelColor = json["hasCustomLabelColor"].toBool(false);
+        cell.m_hasCustomValueColor = json["hasCustomValueColor"].toBool(false);
+    } else if (json.contains("textColor")) {
+        const QColor legacy(json["textColor"].toString());
+        const bool legacyCustom = json["hasCustomColor"].toBool(true);
+        cell.m_labelColor = legacy;
+        cell.m_valueColor = legacy;
+        cell.m_hasCustomLabelColor = legacyCustom;
+        cell.m_hasCustomValueColor = legacyCustom;
     }
 
     // Calculated size

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -1,4 +1,5 @@
 #include "include/core/config.h"
+#include "include/core/cell_data.h"
 #include <QStandardPaths>
 #include <QDir>
 #include <QJsonDocument>
@@ -22,7 +23,8 @@ Config::Config(QObject *parent)
     : QObject(parent)
     , m_settings("UnabaraProject", "Unabara")
     , m_font("Sans Serif", 12)
-    , m_textColor(Qt::white)
+    , m_labelColor(Unabara::ColorDefaults::text())
+    , m_valueColor(Unabara::ColorDefaults::text())
     , m_backgroundOpacity(1.0)
     , m_showDepth(true)
     , m_showTemperature(true)
@@ -124,16 +126,29 @@ void Config::setFont(const QFont &font)
     }
 }
 
-QColor Config::textColor() const
+QColor Config::labelColor() const
 {
-    return m_textColor;
+    return m_labelColor;
 }
 
-void Config::setTextColor(const QColor &color)
+void Config::setLabelColor(const QColor &color)
 {
-    if (m_textColor != color) {
-        m_textColor = color;
-        emit textColorChanged();
+    if (m_labelColor != color) {
+        m_labelColor = color;
+        emit labelColorChanged();
+    }
+}
+
+QColor Config::valueColor() const
+{
+    return m_valueColor;
+}
+
+void Config::setValueColor(const QColor &color)
+{
+    if (m_valueColor != color) {
+        m_valueColor = color;
+        emit valueColorChanged();
     }
 }
 
@@ -625,10 +640,16 @@ void Config::loadConfig()
     m_font.setItalic(fontItalic);
     
     // Load text color
+    // Legacy single-color RGB keys seed both colors when the split
+    // label/value keys (HexArgb strings) are absent
     int r = m_settings.value("overlay/textColorR", 255).toInt();
     int g = m_settings.value("overlay/textColorG", 255).toInt();
     int b = m_settings.value("overlay/textColorB", 255).toInt();
-    m_textColor = QColor(r, g, b);
+    const QColor legacyTextColor(r, g, b);
+    m_labelColor = QColor(m_settings.value("overlay/labelColor",
+        legacyTextColor.name(QColor::HexArgb)).toString());
+    m_valueColor = QColor(m_settings.value("overlay/valueColor",
+        legacyTextColor.name(QColor::HexArgb)).toString());
 
     // Load background opacity
     m_backgroundOpacity = m_settings.value("overlay/backgroundOpacity", 1.0).toDouble();
@@ -779,9 +800,12 @@ void Config::saveConfig()
     m_settings.setValue("overlay/fontItalic", m_font.italic());
     
     // Save text color
-    m_settings.setValue("overlay/textColorR", m_textColor.red());
-    m_settings.setValue("overlay/textColorG", m_textColor.green());
-    m_settings.setValue("overlay/textColorB", m_textColor.blue());
+    m_settings.setValue("overlay/labelColor", m_labelColor.name(QColor::HexArgb));
+    m_settings.setValue("overlay/valueColor", m_valueColor.name(QColor::HexArgb));
+    // Legacy keys mirror the value color so older app versions stay usable
+    m_settings.setValue("overlay/textColorR", m_valueColor.red());
+    m_settings.setValue("overlay/textColorG", m_valueColor.green());
+    m_settings.setValue("overlay/textColorB", m_valueColor.blue());
 
     // Save background opacity
     m_settings.setValue("overlay/backgroundOpacity", m_backgroundOpacity);

--- a/src/core/overlay_template.cpp
+++ b/src/core/overlay_template.cpp
@@ -15,7 +15,8 @@ OverlayTemplate::OverlayTemplate()
     , m_backgroundImagePath(":/images/DC_Faces/unabara_round_ocean.png")
     , m_backgroundOpacity(1.0)
     , m_defaultFont(QFont("Sans Serif", 12))
-    , m_defaultTextColor(Qt::white)
+    , m_defaultLabelColor(ColorDefaults::text())
+    , m_defaultValueColor(ColorDefaults::text())
     , m_defaultShadowEnabled(ShadowDefaults::enabled)
     , m_defaultShadowType(ShadowDefaults::type)
     , m_defaultShadowColor(ShadowDefaults::color())
@@ -135,8 +136,11 @@ QJsonObject OverlayTemplate::toJson() const
     fontJson["bold"] = m_defaultFont.bold();
     json["defaultFont"] = fontJson;
 
-    // Default text color
-    json["defaultTextColor"] = m_defaultTextColor.name(QColor::HexArgb);
+    // Default text colors; legacy "defaultTextColor" mirrors the value color
+    // so older app versions can still read the template
+    json["defaultLabelColor"] = m_defaultLabelColor.name(QColor::HexArgb);
+    json["defaultValueColor"] = m_defaultValueColor.name(QColor::HexArgb);
+    json["defaultTextColor"] = m_defaultValueColor.name(QColor::HexArgb);
 
     // Default shadow settings
     json["defaultShadowEnabled"] = m_defaultShadowEnabled;
@@ -182,10 +186,17 @@ OverlayTemplate OverlayTemplate::fromJson(const QJsonObject& json)
         templ.m_defaultFont = font;
     }
 
-    // Default text color
-    if (json.contains("defaultTextColor")) {
-        templ.m_defaultTextColor = QColor(json["defaultTextColor"].toString());
-    }
+    // Default text colors (templates predating the label/value split only
+    // carry "defaultTextColor", which seeds both)
+    const QColor legacyTextColor = json.contains("defaultTextColor")
+        ? QColor(json["defaultTextColor"].toString())
+        : ColorDefaults::text();
+    templ.m_defaultLabelColor = json.contains("defaultLabelColor")
+        ? QColor(json["defaultLabelColor"].toString())
+        : legacyTextColor;
+    templ.m_defaultValueColor = json.contains("defaultValueColor")
+        ? QColor(json["defaultValueColor"].toString())
+        : legacyTextColor;
 
     // Default shadow settings (absent in templates predating shadows → ShadowDefaults)
     templ.m_defaultShadowEnabled = json["defaultShadowEnabled"].toBool(ShadowDefaults::enabled);

--- a/src/generators/overlay_gen.cpp
+++ b/src/generators/overlay_gen.cpp
@@ -16,7 +16,8 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     , m_templateWidth(640)
     , m_templateHeight(120)
     , m_font(QFont("Sans Serif", 12))
-    , m_textColor(Qt::white)
+    , m_labelColor(Unabara::ColorDefaults::text())
+    , m_valueColor(Unabara::ColorDefaults::text())
     , m_showLabel(true)
     , m_shadowEnabled(Unabara::ShadowDefaults::enabled)
     , m_shadowType(Unabara::ShadowDefaults::type)
@@ -51,7 +52,8 @@ OverlayGenerator::OverlayGenerator(QObject *parent)
     m_templatePath = config->templatePath();
     updateTemplateDimensions();
     m_font = config->font();
-    m_textColor = config->textColor();
+    m_labelColor = config->labelColor();
+    m_valueColor = config->valueColor();
     m_backgroundOpacity = config->backgroundOpacity();
     m_showDepth = config->showDepth();
     m_showTemperature = config->showTemperature();
@@ -150,29 +152,57 @@ void OverlayGenerator::setFont(const QFont &font)
     }
 }
 
-void OverlayGenerator::setTextColor(const QColor &color)
+void OverlayGenerator::setLabelColor(const QColor &color)
 {
     if (m_selectedCellId.isEmpty()) {
         // No cell selected - apply to all cells (global default)
-        if (m_textColor != color) {
-            m_textColor = color;
-            Config::instance()->setTextColor(color); // Update Config
+        if (m_labelColor != color) {
+            m_labelColor = color;
+            Config::instance()->setLabelColor(color); // Update Config
 
-            // Apply to all cells that don't have custom colors
+            // Apply to all cells that don't have custom label colors
             for (auto& cell : m_cells) {
-                if (!cell.hasCustomColor()) {
-                    cell.setTextColor(color, false); // false = not custom, inherited from global
+                if (!cell.hasCustomLabelColor()) {
+                    cell.setLabelColor(color, false); // false = not custom, inherited from global
                 }
             }
 
-            emit textColorChanged();
+            emit labelColorChanged();
             emit cellsChanged();
         }
     } else {
         // Cell selected - apply only to selected cell
         Unabara::CellData* cell = getCellData(m_selectedCellId);
-        if (cell && cell->textColor() != color) {
-            cell->setTextColor(color, true); // true = custom color
+        if (cell && cell->labelColor() != color) {
+            cell->setLabelColor(color, true); // true = custom color
+            emit cellsChanged();
+        }
+    }
+}
+
+void OverlayGenerator::setValueColor(const QColor &color)
+{
+    if (m_selectedCellId.isEmpty()) {
+        // No cell selected - apply to all cells (global default)
+        if (m_valueColor != color) {
+            m_valueColor = color;
+            Config::instance()->setValueColor(color); // Update Config
+
+            // Apply to all cells that don't have custom value colors
+            for (auto& cell : m_cells) {
+                if (!cell.hasCustomValueColor()) {
+                    cell.setValueColor(color, false); // false = not custom, inherited from global
+                }
+            }
+
+            emit valueColorChanged();
+            emit cellsChanged();
+        }
+    } else {
+        // Cell selected - apply only to selected cell
+        Unabara::CellData* cell = getCellData(m_selectedCellId);
+        if (cell && cell->valueColor() != color) {
+            cell->setValueColor(color, true); // true = custom color
             emit cellsChanged();
         }
     }
@@ -665,12 +695,22 @@ void OverlayGenerator::resetCellFont(const QString& cellId)
     }
 }
 
-void OverlayGenerator::resetCellColor(const QString& cellId)
+void OverlayGenerator::resetCellLabelColor(const QString& cellId)
 {
     Unabara::CellData* cell = getCellData(cellId);
-    if (cell && cell->hasCustomColor()) {
+    if (cell && cell->hasCustomLabelColor()) {
         // Reset to global default color
-        cell->setTextColor(m_textColor, false);  // false = inherited from global
+        cell->setLabelColor(m_labelColor, false);  // false = inherited from global
+        emit cellsChanged();
+    }
+}
+
+void OverlayGenerator::resetCellValueColor(const QString& cellId)
+{
+    Unabara::CellData* cell = getCellData(cellId);
+    if (cell && cell->hasCustomValueColor()) {
+        // Reset to global default color
+        cell->setValueColor(m_valueColor, false);  // false = inherited from global
         emit cellsChanged();
     }
 }
@@ -700,6 +740,12 @@ void OverlayGenerator::resetCellShadow(const QString& cellId)
 }
 
 // Cell-based layout management methods
+
+void OverlayGenerator::seedCellColors(Unabara::CellData& cell) const
+{
+    cell.setLabelColor(m_labelColor, false);  // false = inherited from global
+    cell.setValueColor(m_valueColor, false);
+}
 
 Unabara::CellData* OverlayGenerator::getCellData(const QString& cellId)
 {
@@ -741,13 +787,22 @@ QFont OverlayGenerator::getCellFont(const QString& cellId) const
     return m_font;
 }
 
-QColor OverlayGenerator::getCellColor(const QString& cellId) const
+QColor OverlayGenerator::getCellLabelColor(const QString& cellId) const
 {
     const auto* cell = getCellData(cellId);
-    if (cell && cell->hasCustomColor()) {
-        return cell->textColor();
+    if (cell && cell->hasCustomLabelColor()) {
+        return cell->labelColor();
     }
-    return m_textColor;
+    return m_labelColor;
+}
+
+QColor OverlayGenerator::getCellValueColor(const QString& cellId) const
+{
+    const auto* cell = getCellData(cellId);
+    if (cell && cell->hasCustomValueColor()) {
+        return cell->valueColor();
+    }
+    return m_valueColor;
 }
 
 void OverlayGenerator::setCellFont(const QString& cellId, const QFont& font)
@@ -761,14 +816,25 @@ void OverlayGenerator::setCellFont(const QString& cellId, const QFont& font)
     }
 }
 
-void OverlayGenerator::setCellColor(const QString& cellId, const QColor& color)
+void OverlayGenerator::setCellLabelColor(const QString& cellId, const QColor& color)
 {
     Unabara::CellData* cell = getCellData(cellId);
     if (cell) {
-        cell->setTextColor(color, true);  // true = custom color
+        cell->setLabelColor(color, true);  // true = custom color
         emit cellLayoutChanged();
     } else {
-        qWarning() << "setCellColor: Cell not found:" << cellId;
+        qWarning() << "setCellLabelColor: Cell not found:" << cellId;
+    }
+}
+
+void OverlayGenerator::setCellValueColor(const QString& cellId, const QColor& color)
+{
+    Unabara::CellData* cell = getCellData(cellId);
+    if (cell) {
+        cell->setValueColor(color, true);  // true = custom color
+        emit cellLayoutChanged();
+    } else {
+        qWarning() << "setCellValueColor: Cell not found:" << cellId;
     }
 }
 
@@ -895,7 +961,7 @@ void OverlayGenerator::setCellTypeVisible(const QString& cellId, bool visible)
     Unabara::CellData newCell(cellId, idToType.value(cellId));
     newCell.setPosition(QPointF(0.5, 0.5));
     newCell.setFont(m_font, false);
-    newCell.setTextColor(m_textColor, false);
+    seedCellColors(newCell);
     newCell.setCalculatedSize(calculateCellSize(newCell.cellType(), m_font, templateSize));
     newCell.setVisible(true);
     m_cells.append(newCell);
@@ -954,7 +1020,7 @@ void OverlayGenerator::setPressureCellsVisible(bool visible, DiveData* dive)
             cell.setTankIndex(0);
             cell.setPosition(QPointF(0.5, 0.5));
             cell.setFont(m_font, false);
-            cell.setTextColor(m_textColor, false);
+            seedCellColors(cell);
             cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Pressure, m_font, templateSize));
             cell.setVisible(true);
             m_cells.append(cell);
@@ -967,7 +1033,7 @@ void OverlayGenerator::setPressureCellsVisible(bool visible, DiveData* dive)
                 int row = i / 2;
                 cell.setPosition(QPointF(0.5 + col * 0.25, 0.5 + row * 0.2));
                 cell.setFont(m_font, false);
-                cell.setTextColor(m_textColor, false);
+                seedCellColors(cell);
                 cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Pressure, m_font, templateSize));
                 cell.setVisible(true);
                 m_cells.append(cell);
@@ -1011,7 +1077,8 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     updateTemplateDimensions();  // Update width/height for new template image
     m_backgroundOpacity = templ.backgroundOpacity();
     m_font = templ.defaultFont();
-    m_textColor = templ.defaultTextColor();
+    m_labelColor = templ.defaultLabelColor();
+    m_valueColor = templ.defaultValueColor();
     m_shadowEnabled = templ.defaultShadowEnabled();
     m_shadowType = templ.defaultShadowType();
     m_shadowColor = templ.defaultShadowColor();
@@ -1020,8 +1087,9 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
     m_cells = templ.cells();
     m_useCellBasedLayout = true;
 
-    // Re-propagate global shadow settings into cells without a per-cell
-    // override, in case a hand-edited template disagrees with its defaults
+    // Re-propagate global shadow and color settings into cells without a
+    // per-cell override — saved templates omit non-custom values, so loaded
+    // cells otherwise sit at constructor defaults instead of the template's
     for (auto& cell : m_cells) {
         if (!cell.hasCustomShadow()) {
             cell.setShadowEnabled(m_shadowEnabled, false);
@@ -1029,6 +1097,12 @@ void OverlayGenerator::loadTemplate(const Unabara::OverlayTemplate& templ)
             cell.setShadowColor(m_shadowColor, false);
             cell.setShadowSize(m_shadowSize, false);
             cell.setShadowOpacity(m_shadowOpacity, false);
+        }
+        if (!cell.hasCustomLabelColor()) {
+            cell.setLabelColor(m_labelColor, false);
+        }
+        if (!cell.hasCustomValueColor()) {
+            cell.setValueColor(m_valueColor, false);
         }
     }
 
@@ -1116,7 +1190,8 @@ Unabara::OverlayTemplate OverlayGenerator::exportTemplate() const
     templ.setBackgroundImagePath(m_templatePath);
     templ.setBackgroundOpacity(m_backgroundOpacity);
     templ.setDefaultFont(m_font);
-    templ.setDefaultTextColor(m_textColor);
+    templ.setDefaultLabelColor(m_labelColor);
+    templ.setDefaultValueColor(m_valueColor);
     templ.setDefaultShadowEnabled(m_shadowEnabled);
     templ.setDefaultShadowType(m_shadowType);
     templ.setDefaultShadowColor(m_shadowColor);
@@ -1246,7 +1321,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("depth", Unabara::CellType::Depth);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Depth, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1257,7 +1332,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("temperature", Unabara::CellType::Temperature);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Temperature, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1268,7 +1343,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("ndl", Unabara::CellType::NDL);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::NDL, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1280,7 +1355,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("stop_depth", Unabara::CellType::StopDepth);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::StopDepth, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1291,7 +1366,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("stop_time", Unabara::CellType::StopTime);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::StopTime, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1302,7 +1377,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("tts", Unabara::CellType::TTS);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::TTS, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1320,7 +1395,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
             cell.setTankIndex(0);
             cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
             cell.setFont(m_font, false);
-            cell.setTextColor(m_textColor, false);
+            seedCellColors(cell);
             cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Pressure, m_font, templateSize));
             cell.setVisible(true);
             m_cells.append(cell);
@@ -1351,7 +1426,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
                 cell.setTankIndex(i);
                 cell.setPosition(QPointF(tankX, tankY));
                 cell.setFont(m_font, false);
-                cell.setTextColor(m_textColor, false);
+                seedCellColors(cell);
                 cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Pressure, m_font, templateSize));
                 cell.setVisible(true);
                 m_cells.append(cell);
@@ -1368,7 +1443,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         cell.setTankIndex(0);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Pressure, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1379,7 +1454,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("time", Unabara::CellType::Time);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Time, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1390,7 +1465,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("cns", Unabara::CellType::CNS);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::CNS, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1401,7 +1476,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("mean_depth", Unabara::CellType::MeanDepth);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::MeanDepth, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1412,7 +1487,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("max_depth", Unabara::CellType::MaxDepth);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::MaxDepth, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1423,7 +1498,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
         Unabara::CellData cell("gas", Unabara::CellType::Gas);
         cell.setPosition(QPointF(currentSection * sectionWidth, yPos));
         cell.setFont(m_font, false);
-        cell.setTextColor(m_textColor, false);
+        seedCellColors(cell);
         cell.setCalculatedSize(calculateCellSize(Unabara::CellType::Gas, m_font, templateSize));
         cell.setVisible(true);
         m_cells.append(cell);
@@ -1447,7 +1522,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
             Unabara::CellData cell("po2_cell1", Unabara::CellType::PO2Cell1);
             cell.setPosition(QPointF(po2Section * po2SectionWidth, po2YPos));
             cell.setFont(m_font, false);
-            cell.setTextColor(m_textColor, false);
+            seedCellColors(cell);
             cell.setCalculatedSize(calculateCellSize(Unabara::CellType::PO2Cell1, m_font, templateSize));
             cell.setVisible(true);
             m_cells.append(cell);
@@ -1458,7 +1533,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
             Unabara::CellData cell("po2_cell2", Unabara::CellType::PO2Cell2);
             cell.setPosition(QPointF(po2Section * po2SectionWidth, po2YPos));
             cell.setFont(m_font, false);
-            cell.setTextColor(m_textColor, false);
+            seedCellColors(cell);
             cell.setCalculatedSize(calculateCellSize(Unabara::CellType::PO2Cell2, m_font, templateSize));
             cell.setVisible(true);
             m_cells.append(cell);
@@ -1469,7 +1544,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
             Unabara::CellData cell("po2_cell3", Unabara::CellType::PO2Cell3);
             cell.setPosition(QPointF(po2Section * po2SectionWidth, po2YPos));
             cell.setFont(m_font, false);
-            cell.setTextColor(m_textColor, false);
+            seedCellColors(cell);
             cell.setCalculatedSize(calculateCellSize(Unabara::CellType::PO2Cell3, m_font, templateSize));
             cell.setVisible(true);
             m_cells.append(cell);
@@ -1480,7 +1555,7 @@ void OverlayGenerator::initializeDefaultCellLayout(DiveData* dive)
             Unabara::CellData cell("composite_po2", Unabara::CellType::CompositePO2);
             cell.setPosition(QPointF(po2Section * po2SectionWidth, po2YPos));
             cell.setFont(m_font, false);
-            cell.setTextColor(m_textColor, false);
+            seedCellColors(cell);
             cell.setCalculatedSize(calculateCellSize(Unabara::CellType::CompositePO2, m_font, templateSize));
             cell.setVisible(true);
             m_cells.append(cell);
@@ -1823,9 +1898,10 @@ void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& im
     for (const auto& cell : m_cells) {
         if (!cell.visible()) continue;
 
-        // Get effective font and color (same as before)
+        // Get effective font and colors (same as before)
         QFont effectiveFont = cell.hasCustomFont() ? cell.font() : m_font;
-        QColor effectiveColor = cell.hasCustomColor() ? cell.textColor() : m_textColor;
+        QColor effectiveLabelColor = cell.hasCustomLabelColor() ? cell.labelColor() : m_labelColor;
+        QColor effectiveValueColor = cell.hasCustomValueColor() ? cell.valueColor() : m_valueColor;
 
         // Effective shadow settings (single hasCustomShadow flag covers the group)
         const bool customShadow = cell.hasCustomShadow();
@@ -1910,9 +1986,28 @@ void OverlayGenerator::renderCellBasedOverlay(QPainter& painter, const QSize& im
             }
         }
 
-        // Draw the text (center-aligned to match QML's Text.AlignHCenter)
-        painter.setPen(effectiveColor);
-        painter.drawText(cellRect, Qt::AlignHCenter, displayText);
+        // Draw the text (center-aligned to match QML's Text.AlignHCenter).
+        // The label line and the value line have independent colors: the
+        // combined string is drawn twice with complementary clip bands so the
+        // multi-line layout stays byte-identical to a single drawText (drawing
+        // the lines separately drifts by a pixel for some font sizes).
+        if (displayText.indexOf(QLatin1Char('\n')) < 0) {
+            painter.setPen(effectiveValueColor);
+            painter.drawText(cellRect, Qt::AlignHCenter, displayText);
+        } else {
+            const QRect labelBand(cellRect.x(), cellRect.y(),
+                                  cellRect.width(), fm.lineSpacing());
+            painter.save();
+            painter.setClipRect(labelBand);
+            painter.setPen(effectiveLabelColor);
+            painter.drawText(cellRect, Qt::AlignHCenter, displayText);
+            painter.setClipRect(QRect(labelBand.x(), labelBand.y() + labelBand.height(),
+                                      labelBand.width(),
+                                      cellRect.height() - labelBand.height()));
+            painter.setPen(effectiveValueColor);
+            painter.drawText(cellRect, Qt::AlignHCenter, displayText);
+            painter.restore();
+        }
     }
 }
 
@@ -1923,7 +2018,7 @@ void OverlayGenerator::renderSectionBasedOverlay(QPainter& painter, const QSize&
                                                   const DiveDataPoint& dataPoint, DiveData* dive)
 {
     painter.setFont(m_font);
-    painter.setPen(m_textColor);
+    painter.setPen(m_valueColor);
 
     int width = imageSize.width();
     int height = imageSize.height();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,8 @@ int main(int argc, char *argv[])
     auto invalidateProfile = [profileFrameCache]() { profileFrameCache->invalidate(); };
 
     QObject::connect(overlayGenerator, &OverlayGenerator::fontChanged,              invalidateOverlay);
-    QObject::connect(overlayGenerator, &OverlayGenerator::textColorChanged,         invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::labelColorChanged,        invalidateOverlay);
+    QObject::connect(overlayGenerator, &OverlayGenerator::valueColorChanged,        invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::templateChanged,          invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showDepthChanged,         invalidateOverlay);
     QObject::connect(overlayGenerator, &OverlayGenerator::showTemperatureChanged,   invalidateOverlay);
@@ -130,7 +131,8 @@ int main(int argc, char *argv[])
     undoManager->trackSignal(SIGNAL(cellsChanged()));
     undoManager->trackSignal(SIGNAL(cellLayoutChanged()));
     undoManager->trackSignal(SIGNAL(fontChanged()));
-    undoManager->trackSignal(SIGNAL(textColorChanged()));
+    undoManager->trackSignal(SIGNAL(labelColorChanged()));
+    undoManager->trackSignal(SIGNAL(valueColorChanged()));
     undoManager->trackSignal(SIGNAL(backgroundOpacityChanged()));
     undoManager->trackSignal(SIGNAL(templateChanged()));
     undoManager->trackSignal(SIGNAL(showLabelChanged()));

--- a/src/ui/cell_model.cpp
+++ b/src/ui/cell_model.cpp
@@ -36,16 +36,20 @@ QVariant CellModel::data(const QModelIndex &index, int role) const
         return cell.visible();
     case FontRole:
         return cell.font();
-    case TextColorRole:
-        return cell.textColor();
+    case LabelColorRole:
+        return cell.labelColor();
+    case ValueColorRole:
+        return cell.valueColor();
     case DisplayTextRole:
         return generateDisplayText(cell);
     case CalculatedSizeRole:
         return cell.calculatedSize();
     case HasCustomFontRole:
         return cell.hasCustomFont();
-    case HasCustomColorRole:
-        return cell.hasCustomColor();
+    case HasCustomLabelColorRole:
+        return cell.hasCustomLabelColor();
+    case HasCustomValueColorRole:
+        return cell.hasCustomValueColor();
     case TankIndexRole:
         return cell.tankIndex();
     case ShowLabelRole:
@@ -77,11 +81,13 @@ QHash<int, QByteArray> CellModel::roleNames() const
     roles[PositionRole] = "position";
     roles[VisibleRole] = "visible";
     roles[FontRole] = "font";
-    roles[TextColorRole] = "textColor";
+    roles[LabelColorRole] = "labelColor";
+    roles[ValueColorRole] = "valueColor";
     roles[DisplayTextRole] = "displayText";
     roles[CalculatedSizeRole] = "calculatedSize";
     roles[HasCustomFontRole] = "hasCustomFont";
-    roles[HasCustomColorRole] = "hasCustomColor";
+    roles[HasCustomLabelColorRole] = "hasCustomLabelColor";
+    roles[HasCustomValueColorRole] = "hasCustomValueColor";
     roles[TankIndexRole] = "tankIndex";
     roles[ShowLabelRole] = "showLabel";
     roles[HasCustomShowLabelRole] = "hasCustomShowLabel";
@@ -172,27 +178,6 @@ void CellModel::updateCellFont(const QString& cellId, const QFont& font)
             m_cells[i].setFont(font, true);
             QModelIndex idx = index(i);
             emit dataChanged(idx, idx, {FontRole, HasCustomFontRole});
-            emit cellDataChanged(cellId);
-            break;
-        }
-    }
-}
-
-void CellModel::updateCellColor(const QString& cellId, const QColor& color)
-{
-    if (!m_generator) {
-        qWarning() << "CellModel::updateCellColor: No generator set";
-        return;
-    }
-
-    m_generator->setCellColor(cellId, color);
-
-    // Update our local copy
-    for (int i = 0; i < m_cells.size(); ++i) {
-        if (m_cells[i].cellId() == cellId) {
-            m_cells[i].setTextColor(color, true);
-            QModelIndex idx = index(i);
-            emit dataChanged(idx, idx, {TextColorRole, HasCustomColorRole});
             emit cellDataChanged(cellId);
             break;
         }

--- a/src/ui/qml/InteractiveOverlayPreview.qml
+++ b/src/ui/qml/InteractiveOverlayPreview.qml
@@ -376,7 +376,8 @@ Item {
                                 italic: f.italic
                             })
                         }
-                        cellTextColor: model.textColor
+                        cellLabelColor: model.labelColor
+                        cellValueColor: model.valueColor
                         displayText: model.displayText
                         // Scale pixel size to current container size
                         // calculatedSize is in pixels, scale proportionally to fit container
@@ -389,7 +390,8 @@ Item {
                             )
                         }
                         hasCustomFont: model.hasCustomFont
-                        hasCustomColor: model.hasCustomColor
+                        hasCustomLabelColor: model.hasCustomLabelColor
+                        hasCustomValueColor: model.hasCustomValueColor
 
                         // Shadow settings from model
                         shadowEnabled: model.shadowEnabled

--- a/src/ui/qml/OverlayCell.qml
+++ b/src/ui/qml/OverlayCell.qml
@@ -20,13 +20,15 @@ Rectangle {
     property point cellPosition: Qt.point(0, 0)  // Normalized position (0.0-1.0)
     property bool cellVisible: true
     property font cellFont: Qt.font({family: "Sans Serif", pointSize: 12})
-    property color cellTextColor: "white"
+    property color cellLabelColor: "white"
+    property color cellValueColor: "white"
     property string displayText: ""
     property size cellCalculatedSize: Qt.size(100, 40)
     property bool selected: false
     property bool overlapping: false
     property bool hasCustomFont: false
-    property bool hasCustomColor: false
+    property bool hasCustomLabelColor: false
+    property bool hasCustomValueColor: false
     property bool shadowEnabled: false
     property int shadowType: 0            // 0 = offset, 1 = blurred, 2 = outline
     property color shadowColor: "black"
@@ -36,6 +38,21 @@ Rectangle {
     property bool dragging: mouseArea.drag.active  // Expose drag state
     property var generator: null  // Reference to overlay generator for snap settings
     property bool showBackground: true  // Show cell background (editor only, not for export)
+
+    // The label line and the value line have independent colors, so the text
+    // is built as StyledText with a <font> tag around the label. The shadow
+    // copies keep drawing the plain displayText (uniform shadow color).
+    function escapeHtml(s) {
+        return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    }
+    function styledDisplayText() {
+        var t = displayText
+        var i = t.indexOf('\n')
+        if (i < 0)
+            return escapeHtml(t)
+        return "<font color=\"" + cellLabelColor + "\">" + escapeHtml(t.substring(0, i))
+             + "</font><br>" + escapeHtml(t.substring(i + 1))
+    }
 
     // Signals
     signal clicked()
@@ -84,9 +101,10 @@ Rectangle {
         id: cellText
         x: 4
         y: 4
-        text: displayText
+        text: cellRoot.styledDisplayText()
+        textFormat: Text.StyledText
         font: cellFont
-        color: cellTextColor
+        color: cellValueColor
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignTop
         wrapMode: Text.NoWrap
@@ -135,13 +153,13 @@ Rectangle {
             }
         }
 
-        // Custom color indicator
+        // Custom color indicator (label and/or value color)
         Rectangle {
             width: 8
             height: 8
             radius: 4
             color: "magenta"
-            visible: hasCustomColor
+            visible: hasCustomLabelColor || hasCustomValueColor
 
             ToolTip.visible: customColorMouseArea.containsMouse
             ToolTip.text: "Custom color"

--- a/src/ui/qml/OverlayEditor.qml
+++ b/src/ui/qml/OverlayEditor.qml
@@ -16,9 +16,11 @@ Item {
 
     // Reactive properties that update when selection or cells change
     property var currentFont: getCurrentFont()
-    property var currentColor: getCurrentColor()
+    property var currentLabelColor: getCurrentLabelColor()
+    property var currentValueColor: getCurrentValueColor()
     property bool currentHasCustomFont: getSelectedCellHasCustomFont()
-    property bool currentHasCustomColor: getSelectedCellHasCustomColor()
+    property bool currentHasCustomLabelColor: getSelectedCellHasCustomLabelColor()
+    property bool currentHasCustomValueColor: getSelectedCellHasCustomValueColor()
     property bool currentShowLabel: getCurrentShowLabel()
     property bool currentHasCustomShowLabel: getSelectedCellHasCustomShowLabel()
     property bool currentShadowEnabled: getCurrentShadowEnabled()
@@ -57,15 +59,25 @@ Item {
         return generator.font
     }
 
-    // Get the effective color (selected cell or global) - reads from generator
-    function getCurrentColor() {
+    // Get the effective colors (selected cell or global) - read from generator
+    function getCurrentLabelColor() {
         if (!generator) return "white"
 
         if (hasSelection && selectedCellId) {
-            return generator.getCellColor(selectedCellId)
+            return generator.getCellLabelColor(selectedCellId)
         }
 
-        return generator.textColor
+        return generator.labelColor
+    }
+
+    function getCurrentValueColor() {
+        if (!generator) return "white"
+
+        if (hasSelection && selectedCellId) {
+            return generator.getCellValueColor(selectedCellId)
+        }
+
+        return generator.valueColor
     }
 
     function getSelectedCellHasCustomFont() {
@@ -75,10 +87,17 @@ Item {
         return hasCustom === true
     }
 
-    function getSelectedCellHasCustomColor() {
+    function getSelectedCellHasCustomLabelColor() {
         if (!hasSelection || !selectedCellId) return false
 
-        var hasCustom = getCellProperty(selectedCellId, "hasCustomColor")
+        var hasCustom = getCellProperty(selectedCellId, "hasCustomLabelColor")
+        return hasCustom === true
+    }
+
+    function getSelectedCellHasCustomValueColor() {
+        if (!hasSelection || !selectedCellId) return false
+
+        var hasCustom = getCellProperty(selectedCellId, "hasCustomValueColor")
         return hasCustom === true
     }
 
@@ -179,9 +198,16 @@ Item {
             }
         }
 
-        function onTextColorChanged() {
+        function onLabelColorChanged() {
             if (!hasSelection) {
-                console.log("Global color changed")
+                console.log("Global label color changed")
+                updateCurrentProperties()
+            }
+        }
+
+        function onValueColorChanged() {
+            if (!hasSelection) {
+                console.log("Global value color changed")
                 updateCurrentProperties()
             }
         }
@@ -203,12 +229,13 @@ Item {
 
     function updateCurrentProperties() {
         var newFont = getCurrentFont()
-        var newColor = getCurrentColor()
-        console.log("Updating properties - Font:", newFont ? newFont.family : "null", "Size:", newFont ? newFont.pointSize : "null", "Color:", newColor)
+        console.log("Updating properties - Font:", newFont ? newFont.family : "null", "Size:", newFont ? newFont.pointSize : "null")
         currentFont = newFont
-        currentColor = newColor
+        currentLabelColor = getCurrentLabelColor()
+        currentValueColor = getCurrentValueColor()
         currentHasCustomFont = getSelectedCellHasCustomFont()
-        currentHasCustomColor = getSelectedCellHasCustomColor()
+        currentHasCustomLabelColor = getSelectedCellHasCustomLabelColor()
+        currentHasCustomValueColor = getSelectedCellHasCustomValueColor()
         currentShowLabel = getCurrentShowLabel()
         currentHasCustomShowLabel = getSelectedCellHasCustomShowLabel()
         currentShadowEnabled = getCurrentShadowEnabled()
@@ -366,7 +393,10 @@ Item {
                 function onFontChanged() {
                     previewContainer.updateCellModel()
                 }
-                function onTextColorChanged() {
+                function onLabelColorChanged() {
+                    previewContainer.updateCellModel()
+                }
+                function onValueColorChanged() {
                     previewContainer.updateCellModel()
                 }
 
@@ -772,30 +802,58 @@ Item {
                 }
                 Item { Layout.preferredWidth: 40 }
 
-                Label { text: qsTr("Color:") }
+                Label { text: qsTr("Label color:") }
                 Button {
-                    id: colorButton
+                    id: labelColorButton
                     Layout.fillWidth: true
 
                     Rectangle {
                         anchors.fill: parent
                         anchors.margins: 4
-                        color: root.currentColor
+                        color: root.currentLabelColor
                     }
 
-                    onClicked: colorDialog.open()
+                    onClicked: labelColorDialog.open()
                 }
 
                 Button {
                     text: "↺"
                     Layout.preferredWidth: 40
-                    enabled: root.hasSelection && root.currentHasCustomColor
+                    enabled: root.hasSelection && root.currentHasCustomLabelColor
                     opacity: enabled ? 1.0 : 0.3
                     ToolTip.visible: hovered
-                    ToolTip.text: enabled ? qsTr("Reset to global color") : qsTr("No custom color")
+                    ToolTip.text: enabled ? qsTr("Reset to global label color") : qsTr("No custom label color")
                     onClicked: {
                         if (root.generator && root.selectedCellId) {
-                            root.generator.resetCellColor(root.selectedCellId)
+                            root.generator.resetCellLabelColor(root.selectedCellId)
+                        }
+                    }
+                }
+
+                Label { text: qsTr("Data color:") }
+                Button {
+                    id: valueColorButton
+                    Layout.fillWidth: true
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        color: root.currentValueColor
+                    }
+
+                    onClicked: valueColorDialog.open()
+                }
+
+                Button {
+                    text: "↺"
+                    Layout.preferredWidth: 40
+                    enabled: root.hasSelection && root.currentHasCustomValueColor
+                    opacity: enabled ? 1.0 : 0.3
+                    ToolTip.visible: hovered
+                    ToolTip.text: enabled ? qsTr("Reset to global data color") : qsTr("No custom data color")
+                    onClicked: {
+                        if (root.generator && root.selectedCellId) {
+                            root.generator.resetCellValueColor(root.selectedCellId)
                         }
                     }
                 }
@@ -1209,19 +1267,36 @@ Item {
     }
     
     ColorDialog {
-        id: colorDialog
-        title: qsTr("Select Text Color")
-        selectedColor: root.currentColor
+        id: labelColorDialog
+        title: qsTr("Select Label Color")
+        selectedColor: root.currentLabelColor
 
         Connections {
             target: root
-            function onCurrentColorChanged() {
-                colorDialog.selectedColor = root.currentColor
+            function onCurrentLabelColorChanged() {
+                labelColorDialog.selectedColor = root.currentLabelColor
             }
         }
 
         onAccepted: {
-            if (generator) generator.textColor = selectedColor
+            if (generator) generator.labelColor = selectedColor
+        }
+    }
+
+    ColorDialog {
+        id: valueColorDialog
+        title: qsTr("Select Data Color")
+        selectedColor: root.currentValueColor
+
+        Connections {
+            target: root
+            function onCurrentValueColorChanged() {
+                valueColorDialog.selectedColor = root.currentValueColor
+            }
+        }
+
+        onAccepted: {
+            if (generator) generator.valueColor = selectedColor
         }
     }
 

--- a/src/ui/qml/VideoSyncPlayer.qml
+++ b/src/ui/qml/VideoSyncPlayer.qml
@@ -119,7 +119,8 @@ Item {
     Connections {
         target: overlayGenerator
         function onFontChanged()              { root.refreshTick++ }
-        function onTextColorChanged()         { root.refreshTick++ }
+        function onLabelColorChanged()        { root.refreshTick++ }
+        function onValueColorChanged()        { root.refreshTick++ }
         function onTemplateChanged()          { root.refreshTick++ }
         function onShowDepthChanged()         { root.refreshTick++ }
         function onShowTemperatureChanged()   { root.refreshTick++ }

--- a/src/ui/qml/main.qml
+++ b/src/ui/qml/main.qml
@@ -445,7 +445,8 @@ ApplicationWindow {
                         function onShowPressureChanged() { previewImage.updatePreview() }
                         function onTemplateChanged() { previewImage.updatePreview() }
                         function onFontChanged() { previewImage.updatePreview() }
-                        function onTextColorChanged() { previewImage.updatePreview() }
+                        function onLabelColorChanged() { previewImage.updatePreview() }
+                        function onValueColorChanged() { previewImage.updatePreview() }
                         function onBackgroundOpacityChanged() { previewImage.updatePreview() }
                         function onShadowChanged() { previewImage.updatePreview() }
                         function onShowLabelChanged() { previewImage.updatePreview() }

--- a/tests/cell_data_test.cpp
+++ b/tests/cell_data_test.cpp
@@ -62,7 +62,9 @@ private slots:
         QFont font(QStringLiteral("Monospace"), 18);
         font.setBold(true);
         cell.setFont(font, true);
-        cell.setTextColor(QColor(255, 128, 0), true);
+        // Deliberately different colors to catch a label/value swap
+        cell.setLabelColor(QColor(255, 128, 0), true);
+        cell.setValueColor(QColor(0, 200, 64), true);
         cell.setShadowEnabled(true);
         cell.setShadowType(ShadowType::Outline);
         cell.setShadowColor(QColor(0, 0, 255, 200));
@@ -79,7 +81,10 @@ private slots:
         QCOMPARE(restored.font().family(), QStringLiteral("Monospace"));
         QCOMPARE(restored.font().pointSize(), 18);
         QVERIFY(restored.font().bold());
-        QCOMPARE(restored.textColor(), QColor(255, 128, 0));
+        QCOMPARE(restored.labelColor(), QColor(255, 128, 0));
+        QCOMPARE(restored.valueColor(), QColor(0, 200, 64));
+        QVERIFY(restored.hasCustomLabelColor());
+        QVERIFY(restored.hasCustomValueColor());
         QCOMPARE(restored.shadowEnabled(), true);
         QCOMPARE(restored.shadowType(), ShadowType::Outline);
         QCOMPARE(restored.shadowColor(), QColor(0, 0, 255, 200));
@@ -102,6 +107,52 @@ private slots:
         QCOMPARE(restored.shadowSize(), 2);
         QCOMPARE(restored.shadowOpacity(), 0.7);
         QVERIFY(!restored.hasCustomShadow());
+        QCOMPARE(restored.labelColor(), QColor(Qt::white));
+        QCOMPARE(restored.valueColor(), QColor(Qt::white));
+        QVERIFY(!restored.hasCustomLabelColor());
+        QVERIFY(!restored.hasCustomValueColor());
+    }
+
+    void legacyTextColorSeedsBothColors()
+    {
+        // Pre-split cell JSON only carries "textColor"; it must seed both the
+        // label and the value color
+        QJsonObject json;
+        json[QStringLiteral("cellId")] = QStringLiteral("depth");
+        json[QStringLiteral("cellType")] = QStringLiteral("Depth");
+        json[QStringLiteral("textColor")] = QStringLiteral("#ffff8000");
+        json[QStringLiteral("hasCustomColor")] = true;
+
+        const CellData restored = CellData::fromJson(json);
+        QCOMPARE(restored.labelColor(), QColor(QStringLiteral("#ffff8000")));
+        QCOMPARE(restored.valueColor(), QColor(QStringLiteral("#ffff8000")));
+        QVERIFY(restored.hasCustomLabelColor());
+        QVERIFY(restored.hasCustomValueColor());
+
+        // Legacy cell without any color keys stays at inherited defaults
+        QJsonObject plain;
+        plain[QStringLiteral("cellId")] = QStringLiteral("time");
+        plain[QStringLiteral("cellType")] = QStringLiteral("Time");
+        const CellData inherited = CellData::fromJson(plain);
+        QCOMPARE(inherited.labelColor(), QColor(Qt::white));
+        QCOMPARE(inherited.valueColor(), QColor(Qt::white));
+        QVERIFY(!inherited.hasCustomLabelColor());
+        QVERIFY(!inherited.hasCustomValueColor());
+    }
+
+    void downgradeCompatFieldsWritten()
+    {
+        // New-format JSON keeps the legacy "textColor"/"hasCustomColor" keys
+        // (mirroring the value color) so older app versions can read it
+        CellData cell(QStringLiteral("depth"), CellType::Depth);
+        cell.setValueColor(QColor(10, 20, 30), true);
+
+        const QJsonObject json = cell.toJson();
+        QCOMPARE(json[QStringLiteral("textColor")].toString(),
+                 QColor(10, 20, 30).name(QColor::HexArgb));
+        QCOMPARE(json[QStringLiteral("hasCustomColor")].toBool(), true);
+        QVERIFY(!json.contains(QStringLiteral("labelColor")));
+        QCOMPARE(json[QStringLiteral("hasCustomLabelColor")].toBool(true), false);
     }
 };
 

--- a/tests/overlay_template_test.cpp
+++ b/tests/overlay_template_test.cpp
@@ -26,7 +26,9 @@ private slots:
         templ.setBackgroundImagePath(QStringLiteral(":/images/test.png"));
         templ.setBackgroundOpacity(0.5);
         templ.setDefaultFont(QFont(QStringLiteral("Monospace"), 18));
-        templ.setDefaultTextColor(QColor(255, 128, 0));
+        // Deliberately different colors to catch a label/value swap
+        templ.setDefaultLabelColor(QColor(255, 128, 0));
+        templ.setDefaultValueColor(QColor(0, 128, 255));
         templ.setDefaultShadowEnabled(true);
         templ.setDefaultShadowType(ShadowType::Blurred);
         templ.setDefaultShadowColor(QColor(10, 20, 30, 200));
@@ -38,7 +40,11 @@ private slots:
         QCOMPARE(restored.templateName(), QStringLiteral("Test Template"));
         QCOMPARE(restored.backgroundOpacity(), 0.5);
         QCOMPARE(restored.defaultFont().family(), QStringLiteral("Monospace"));
-        QCOMPARE(restored.defaultTextColor(), QColor(255, 128, 0));
+        QCOMPARE(restored.defaultLabelColor(), QColor(255, 128, 0));
+        QCOMPARE(restored.defaultValueColor(), QColor(0, 128, 255));
+        // Downgrade-compat field mirrors the value color for older versions
+        QCOMPARE(templ.toJson()[QStringLiteral("defaultTextColor")].toString(),
+                 QColor(0, 128, 255).name(QColor::HexArgb));
         QCOMPARE(restored.defaultShadowEnabled(), true);
         QCOMPARE(restored.defaultShadowType(), ShadowType::Blurred);
         QCOMPARE(restored.defaultShadowColor(), QColor(10, 20, 30, 200));
@@ -61,6 +67,23 @@ private slots:
         QCOMPARE(restored.defaultShadowColor(), QColor(0, 0, 0));
         QCOMPARE(restored.defaultShadowSize(), 2);
         QCOMPARE(restored.defaultShadowOpacity(), 0.7);
+        // No color keys at all → both default colors stay white
+        QCOMPARE(restored.defaultLabelColor(), QColor(Qt::white));
+        QCOMPARE(restored.defaultValueColor(), QColor(Qt::white));
+    }
+
+    void legacyDefaultTextColorSeedsBoth()
+    {
+        // .utp files predating the label/value split only carry
+        // "defaultTextColor" — it must seed both new defaults
+        QJsonObject json;
+        json[QStringLiteral("version")] = QStringLiteral("1.0");
+        json[QStringLiteral("templateName")] = QStringLiteral("Legacy");
+        json[QStringLiteral("defaultTextColor")] = QStringLiteral("#ff112233");
+
+        const OverlayTemplate restored = OverlayTemplate::fromJson(json);
+        QCOMPARE(restored.defaultLabelColor(), QColor(QStringLiteral("#ff112233")));
+        QCOMPARE(restored.defaultValueColor(), QColor(QStringLiteral("#ff112233")));
     }
 };
 


### PR DESCRIPTION
Each cell's label ("DEPTH") and data ("29.3 m") lines can now be colored
independently, both globally and per-cell:

- Replace the single textColor with labelColor/valueColor end-to-end
  (CellData, OverlayGenerator, OverlayTemplate, Config, CellModel, QML),
  each with its own hasCustom* flag, dual-mode setter (global vs selected
  cell), getCell*/setCell*/resetCell* invokables, undo tracking and
  frame-cache invalidation.
- Editor gains separate "Label color" / "Data color" rows with their own
  color dialogs and reset-to-global buttons; the magenta corner dot now
  flags a custom label or data color.
- C++ renderer draws the combined text twice with complementary clip
  bands so the two pens leave the multi-line layout pixel-identical; the
  QML preview keeps its single Text element via StyledText with a <font>
  tag on the label line, leaving geometry, shadows and hitboxes untouched.
- Full backward compatibility: legacy QSettings RGB keys, .utp
  defaultTextColor and per-cell textColor all seed both new colors on
  load; new files keep writing the legacy fields (mirroring the data
  color) so older app versions can still read them.
- Fix a latent preview bug: loadTemplate() now propagates default colors
  into cells without a per-cell override (like shadows already did), so
  the QML preview no longer shows white for non-custom cells in templates
  with a non-white default.
- Tests: round-trip label/value with distinct colors, legacy seeding and
  downgrade-compat assertions in cell_data_test and overlay_template_test.